### PR TITLE
HFDL system-table reassembly (0xD0 HFNPDU)

### DIFF
--- a/crates/xng-mode-hfdl/src/lib.rs
+++ b/crates/xng-mode-hfdl/src/lib.rs
@@ -4,6 +4,7 @@ pub mod demod;
 pub mod fec;
 pub mod modulate;
 pub mod pdu;
+pub mod systable;
 
 use chrono::Utc;
 use num_complex::Complex;

--- a/crates/xng-mode-hfdl/src/pdu.rs
+++ b/crates/xng-mode-hfdl/src/pdu.rs
@@ -26,11 +26,13 @@ pub struct HfdlEvent {
     pub raw: Vec<u8>,
 }
 
-pub struct PduParser;
+pub struct PduParser {
+    systable: crate::systable::SystableAssembler,
+}
 
 impl PduParser {
     pub fn new() -> Self {
-        Self
+        Self { systable: crate::systable::SystableAssembler::new() }
     }
 
     /// Parse one decoded burst payload (one SPDU or MPDU + padding).
@@ -198,17 +200,24 @@ impl PduParser {
                     raw: h.to_vec(),
                 });
             }
-            0xD0 => out.push(HfdlEvent {
-                kind: "systable-partial".into(),
-                details: json!({
-                    "seq": h[2] & 0x0F,
-                    "total": (h[2] >> 4) + 1,
-                    "version": (h.get(3).copied().unwrap_or(0) as u16 >> 4)
-                        | ((h.get(4).copied().unwrap_or(0) as u16) << 4),
-                }),
-                acars: None,
-                raw: h.to_vec(),
-            }),
+            0xD0 if h.len() >= 5 => {
+                let (seq, total) = (h[2] & 0x0F, (h[2] >> 4) + 1);
+                let version = (h[3] as u16 >> 4) | ((h[4] as u16) << 4);
+                out.push(HfdlEvent {
+                    kind: "systable-partial".into(),
+                    details: json!({ "seq": seq, "total": total, "version": version }),
+                    acars: None,
+                    raw: h.to_vec(),
+                });
+                if let Some(table) = self.systable.store(version, seq, total, &h[5..]) {
+                    out.push(HfdlEvent {
+                        kind: "systable-complete".into(),
+                        details: serde_json::to_value(&table).unwrap_or_default(),
+                        acars: None,
+                        raw: Vec::new(),
+                    });
+                }
+            }
             t => out.push(HfdlEvent {
                 kind: "hfnpdu".into(),
                 details: json!({ "type": t, "who": who }),
@@ -243,6 +252,13 @@ pub fn build_spdu(gs_id: u8, frame_index: u16, systable_version: u16) -> Vec<u8>
     p[53] = (systable_version & 0xFF) as u8;
     p[54] = ((systable_version >> 8) & 0x0F) as u8 | 0x10; // freq bit 0
     with_fcs(p)
+}
+
+/// Unnumbered-data LPDU carrying an arbitrary HFNPDU.
+pub fn build_lpdu_hfnpdu(hfnpdu: &[u8]) -> Vec<u8> {
+    let mut l = vec![0x0D];
+    l.extend_from_slice(hfnpdu);
+    with_fcs(l)
 }
 
 /// LPDU carrying an enveloped ACARS HFNPDU.
@@ -304,6 +320,33 @@ mod tests {
         assert!(b.crc_ok);
         assert_eq!(b.core.label, "B6");
         assert_eq!(b.core.app.as_ref().unwrap()["app"], "adsc");
+    }
+
+    #[test]
+    fn systable_reassembles_across_mpdus() {
+        let stations = vec![crate::systable::GroundStation {
+            gs_id: 4,
+            utc_sync: true,
+            lat: 40.88,
+            lon: -72.64,
+            spdu_version: 2,
+            frequencies: vec![
+                crate::systable::GsFrequency { freq_hz: 21_931_000, master_frame_slot: 2 },
+                crate::systable::GsFrequency { freq_hz: 11_387_000, master_frame_slot: 5 },
+            ],
+        }];
+        let body = crate::systable::build_gs_record(&stations[0]);
+        let pdus = crate::systable::build_systable_hfnpdus(77, &body, 2);
+        let mut parser = PduParser::new();
+        let ev1 = parser.parse(&build_mpdu_downlink(4, 0xC7, &[build_lpdu_hfnpdu(&pdus[0])]), 300);
+        assert_eq!(ev1.len(), 1);
+        assert_eq!(ev1[0].kind, "systable-partial");
+        let ev2 = parser.parse(&build_mpdu_downlink(4, 0xC7, &[build_lpdu_hfnpdu(&pdus[1])]), 300);
+        assert_eq!(ev2.len(), 2);
+        assert_eq!(ev2[1].kind, "systable-complete");
+        assert_eq!(ev2[1].details["version"], 77);
+        assert_eq!(ev2[1].details["stations"][0]["gs_id"], 4);
+        assert_eq!(ev2[1].details["stations"][0]["frequencies"][0]["freq_hz"], 21_931_000);
     }
 
     #[test]

--- a/crates/xng-mode-hfdl/src/systable.rs
+++ b/crates/xng-mode-hfdl/src/systable.rs
@@ -1,0 +1,294 @@
+//! HFDL system-table reassembly: 0xD0 HFNPDU partials carry slices of the
+//! ground-station table (id, position, frequencies, master frame slots).
+//! Facts from ICAO Annex 10 Vol III Ch. 11 and dumphfdl's systable handling
+//! (GPL — read for the wire layout only); see docs/notes/HFDL.md.
+//!
+//! Each partial repeats a 5-octet header (type, 0xD0, total/seq, 12-bit
+//! version split across octets 3-4); the remainder is one slice of the
+//! table. Slices keyed by (version, total) accumulate until every sequence
+//! number is present, then concatenate in order and parse as consecutive
+//! ground-station records.
+
+use serde::Serialize;
+
+/// Frequencies per station are bounded by the 20-bit frequency bitmaps
+/// used in SPDUs and frequency-data HFNPDUs.
+const MAX_FREQS: usize = 20;
+const GS_RECORD_MIN: usize = 8; // 7-octet fixed part + at least one frequency/slot octet
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct GsFrequency {
+    pub freq_hz: u32,
+    pub master_frame_slot: u8,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct GroundStation {
+    pub gs_id: u8,
+    pub utc_sync: bool,
+    pub lat: f64,
+    pub lon: f64,
+    pub spdu_version: u8,
+    pub frequencies: Vec<GsFrequency>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct SystemTable {
+    pub version: u16,
+    pub stations: Vec<GroundStation>,
+}
+
+/// 20-bit two's-complement coordinate, degrees ×180/2^19.
+fn coordinate(v: u32) -> f64 {
+    let r = ((v << 12) as i32) >> 12;
+    r as f64 * 180.0 / (1 << 19) as f64
+}
+
+/// 3 octets of BCD, nibbles low→high, in units of 100 Hz.
+fn bcd_frequency(b: &[u8]) -> u32 {
+    let nib = |x: u8| (x & 0x0F) as u32;
+    100 * nib(b[0])
+        + 1_000 * nib(b[0] >> 4)
+        + 10_000 * nib(b[1])
+        + 100_000 * nib(b[1] >> 4)
+        + 1_000_000 * nib(b[2])
+        + 10_000_000 * nib(b[2] >> 4)
+}
+
+/// 12-bit wrapping version comparison: newer if it leads by < half the space.
+pub fn version_is_newer(new: u16, old: u16) -> bool {
+    let d = (new.wrapping_sub(old)) & 0x0FFF;
+    d != 0 && d < 2048
+}
+
+/// Parse a reassembled table body (concatenated partial payloads) into
+/// ground-station records. Returns None if any record is malformed.
+pub fn parse_stations(mut buf: &[u8]) -> Option<Vec<GroundStation>> {
+    let mut stations = Vec::new();
+    while buf.len() >= GS_RECORD_MIN {
+        let freq_cnt = ((buf[6] >> 3) & 0x1F) as usize;
+        if freq_cnt > MAX_FREQS {
+            return None;
+        }
+        let rec_len = 7 + freq_cnt * 4;
+        if buf.len() < rec_len {
+            return None;
+        }
+        let lat = coordinate(buf[1] as u32 | (buf[2] as u32) << 8 | ((buf[3] as u32 & 0x0F) << 16));
+        let lon = coordinate((buf[3] as u32) >> 4 | (buf[4] as u32) << 4 | (buf[5] as u32) << 12);
+        let frequencies = (0..freq_cnt)
+            .map(|f| {
+                let p = 7 + f * 4;
+                GsFrequency {
+                    freq_hz: bcd_frequency(&buf[p..p + 3]),
+                    master_frame_slot: buf[p + 3] & 0x0F,
+                }
+            })
+            .collect();
+        stations.push(GroundStation {
+            gs_id: buf[0] & 0x7F,
+            utc_sync: buf[0] & 0x80 != 0,
+            lat,
+            lon,
+            spdu_version: buf[6] & 0x07,
+            frequencies,
+        });
+        buf = &buf[rec_len..];
+    }
+    // Trailing octets shorter than a record are padding; a table with no
+    // stations at all is a parse failure, not an empty network.
+    if stations.is_empty() {
+        None
+    } else {
+        Some(stations)
+    }
+}
+
+/// Accumulates 0xD0 partial payloads until a complete set reassembles.
+#[derive(Debug, Default)]
+pub struct SystableAssembler {
+    version: u16,
+    parts: Vec<Option<Vec<u8>>>,
+}
+
+impl SystableAssembler {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Store one partial's payload (the octets after the 5-byte header).
+    /// Returns the decoded table when this part completes the set.
+    pub fn store(
+        &mut self,
+        version: u16,
+        seq: u8,
+        total: u8,
+        payload: &[u8],
+    ) -> Option<SystemTable> {
+        let (seq, total) = (seq as usize, total as usize);
+        if total == 0 || seq >= total || payload.is_empty() {
+            return None;
+        }
+        // A different version or set size obsoletes anything collected.
+        if self.version != version || self.parts.len() != total {
+            self.parts = vec![None; total];
+            self.version = version;
+        }
+        // Same slot with different content: trust the newest copy.
+        if self.parts[seq].as_deref() != Some(payload) {
+            self.parts[seq] = Some(payload.to_vec());
+        }
+        if self.parts.iter().any(|p| p.is_none()) {
+            return None;
+        }
+        let body: Vec<u8> = self.parts.drain(..).flatten().flatten().collect();
+        parse_stations(&body).map(|stations| SystemTable { version, stations })
+    }
+}
+
+// ── builders (testing/modulation) ───────────────────────────────────────
+
+/// Encode one ground-station record.
+pub fn build_gs_record(gs: &GroundStation) -> Vec<u8> {
+    let coord = |deg: f64| -> u32 {
+        ((deg * (1 << 19) as f64 / 180.0).round() as i32 as u32) & 0xFFFFF
+    };
+    let (lat, lon) = (coord(gs.lat), coord(gs.lon));
+    let mut v = vec![
+        gs.gs_id & 0x7F | if gs.utc_sync { 0x80 } else { 0 },
+        (lat & 0xFF) as u8,
+        ((lat >> 8) & 0xFF) as u8,
+        ((lat >> 16) & 0x0F) as u8 | (((lon & 0x0F) as u8) << 4),
+        ((lon >> 4) & 0xFF) as u8,
+        ((lon >> 12) & 0xFF) as u8,
+        (gs.spdu_version & 0x07) | ((gs.frequencies.len() as u8 & 0x1F) << 3),
+    ];
+    for f in &gs.frequencies {
+        let units = f.freq_hz / 100;
+        let mut b = [0u8; 3];
+        for (i, d) in (0..6).map(|i| (units / 10u32.pow(i)) % 10).enumerate() {
+            b[i / 2] |= (d as u8) << ((i % 2) * 4);
+        }
+        v.extend_from_slice(&b);
+        v.push(f.master_frame_slot & 0x0F);
+    }
+    v
+}
+
+/// Split a table body into `total` 0xD0 HFNPDUs (header + slice each).
+pub fn build_systable_hfnpdus(version: u16, body: &[u8], total: u8) -> Vec<Vec<u8>> {
+    let total = total.max(1) as usize;
+    let chunk = body.len().div_ceil(total);
+    (0..total)
+        .map(|i| {
+            let mut h = vec![
+                0xFF,
+                0xD0,
+                (((total - 1) as u8) << 4) | i as u8,
+                ((version & 0x0F) as u8) << 4,
+                (version >> 4) as u8,
+            ];
+            h.extend_from_slice(&body[i * chunk..body.len().min((i + 1) * chunk)]);
+            h
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_stations() -> Vec<GroundStation> {
+        vec![
+            GroundStation {
+                gs_id: 1,
+                utc_sync: true,
+                lat: 37.0179,
+                lon: -122.9059,
+                spdu_version: 2,
+                frequencies: vec![
+                    GsFrequency { freq_hz: 21_934_000, master_frame_slot: 0 },
+                    GsFrequency { freq_hz: 17_919_000, master_frame_slot: 3 },
+                    GsFrequency { freq_hz: 13_276_000, master_frame_slot: 7 },
+                ],
+            },
+            GroundStation {
+                gs_id: 13,
+                utc_sync: true,
+                lat: -37.6691,
+                lon: 144.8410,
+                spdu_version: 2,
+                frequencies: vec![
+                    GsFrequency { freq_hz: 21_949_000, master_frame_slot: 1 },
+                ],
+            },
+        ]
+    }
+
+    #[test]
+    fn gs_record_roundtrip() {
+        let stations = sample_stations();
+        let body: Vec<u8> = stations.iter().flat_map(|g| build_gs_record(g)).collect();
+        let parsed = parse_stations(&body).expect("parses");
+        assert_eq!(parsed.len(), 2);
+        assert_eq!(parsed[0].gs_id, 1);
+        assert_eq!(parsed[0].frequencies[0].freq_hz, 21_934_000);
+        assert_eq!(parsed[0].frequencies[2].master_frame_slot, 7);
+        assert!((parsed[0].lat - 37.0179).abs() < 0.001);
+        assert!((parsed[0].lon + 122.9059).abs() < 0.001);
+        assert_eq!(parsed[1].gs_id, 13);
+        assert!((parsed[1].lat + 37.6691).abs() < 0.001);
+    }
+
+    #[test]
+    fn bcd_frequency_decodes() {
+        // 13,276,700 Hz = 132767 ×100Hz units; digits 7,6,7,2,3,1 low→high.
+        assert_eq!(bcd_frequency(&[0x67, 0x27, 0x13]), 13_276_700);
+        assert_eq!(bcd_frequency(&[0x00, 0x00, 0x00]), 0);
+    }
+
+    #[test]
+    fn reassembly_out_of_order() {
+        let body: Vec<u8> =
+            sample_stations().iter().flat_map(|g| build_gs_record(g)).collect();
+        let pdus = build_systable_hfnpdus(52, &body, 3);
+        let mut asm = SystableAssembler::new();
+        assert!(asm.store(52, 2, 3, &pdus[2][5..]).is_none());
+        assert!(asm.store(52, 0, 3, &pdus[0][5..]).is_none());
+        let table = asm.store(52, 1, 3, &pdus[1][5..]).expect("complete");
+        assert_eq!(table.version, 52);
+        assert_eq!(table.stations.len(), 2);
+        assert_eq!(table.stations[1].frequencies[0].freq_hz, 21_949_000);
+    }
+
+    #[test]
+    fn version_change_discards_partial_set() {
+        let body: Vec<u8> =
+            sample_stations().iter().flat_map(|g| build_gs_record(g)).collect();
+        let old = build_systable_hfnpdus(51, &body, 2);
+        let new = build_systable_hfnpdus(52, &body, 2);
+        let mut asm = SystableAssembler::new();
+        assert!(asm.store(51, 0, 2, &old[0][5..]).is_none());
+        // Version bump: the stored part 0 must not combine with new part 1.
+        assert!(asm.store(52, 1, 2, &new[1][5..]).is_none());
+        assert!(asm.store(52, 0, 2, &new[0][5..]).is_some());
+    }
+
+    #[test]
+    fn malformed_body_rejected() {
+        // freq_cnt = 31 exceeds the 20-frequency bound.
+        let mut body = build_gs_record(&sample_stations()[0]);
+        body[6] |= 0x1F << 3;
+        assert!(parse_stations(&body).is_none());
+        assert!(parse_stations(&[]).is_none());
+    }
+
+    #[test]
+    fn version_wraparound() {
+        assert!(version_is_newer(1, 4095));
+        assert!(version_is_newer(53, 52));
+        assert!(!version_is_newer(52, 52));
+        assert!(!version_is_newer(52, 53));
+        assert!(!version_is_newer(4095, 1));
+    }
+}

--- a/docs/REFERENCES.md
+++ b/docs/REFERENCES.md
@@ -34,7 +34,8 @@ attribution. GPL projects are listed as fact references only.
 | acars crate (xoolive) | MIT | Inspected for API/coverage comparison; test fixtures noted as borrowable | https://crates.io/crates/acars |
 | ship162 (xoolive) | MIT | Noted as AIS reference (our core ended up independent) | https://github.com/xoolive/ship162 |
 | rs1090/jet1090 (xoolive) | MIT | Architectural comparison; candidate dep for deep Mode S decode | https://github.com/xoolive/jet1090 |
-| dumpvdl2, dumphfdl (szpajder) | GPL-3 | **Facts only** (not read for xng so far; clean-room held for VDL2) | https://github.com/szpajder/dumpvdl2 |
+| dumpvdl2 (szpajder) | GPL-3 | **Facts only** (not read for xng so far; clean-room held for VDL2) | https://github.com/szpajder/dumpvdl2 |
+| dumphfdl (szpajder) | GPL-3 | **Facts only**: src/systable.c + src/hfnpdu.c read for the system-table wire layout (0xD0 partial header, GS record fields, BCD frequency encoding, reassembly semantics); all xng code re-derived | https://github.com/szpajder/dumphfdl |
 | acarsdec (TLeconte / f00b4r0) | LGPL/GPL-2 | Facts only (display conventions) | https://github.com/TLeconte/acarsdec |
 | AIS-catcher (jvde-github) | GPL-3 | Facts only (landscape research) | https://github.com/jvde-github/AIS-catcher |
 | gr-iridium (muccc) | GPL-3 | Facts only (wave 2 planning) | https://github.com/muccc/gr-iridium |


### PR DESCRIPTION
Reassembles HFDL system-table partials into the complete ground-station table.

## What
- New `xng-mode-hfdl::systable`: `SystableAssembler` accumulates 0xD0 HFNPDU payloads keyed by (12-bit version, set size), discarding stale sets on version/size change and replacing differing duplicates, matching the semantics aircraft rely on.
- Complete sets parse into `GroundStation` records: GS id, UTC sync, 20-bit lat/lon, SPDU version, and per-frequency BCD-coded assignments (100 Hz units) with master frame slots.
- `PduParser` now emits a `systable-complete` event (full table as JSON) in addition to the existing `systable-partial` events, so downstream consumers — notably the scanner / Airwaves OS auto-configuration — can learn the live HFDL network without shipping a static systable.conf.
- 12-bit wrapping version comparison (`version_is_newer`) for table freshness.
- Builders for GS records and partial sets; 7 new tests including an end-to-end reassembly across two MPDUs through the full PDU path.

## Sourcing
Wire layout from ICAO Annex 10 Vol III Ch. 11 plus dumphfdl `systable.c`/`hfnpdu.c` read for facts only (GPL — all code re-derived); docs/REFERENCES.md updated accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for HFDL system table reassembly across multiple partial messages
  * System table parsing now extracts ground station frequency records and network configuration data

* **Documentation**
  * Updated reference documentation entries

<!-- end of auto-generated comment: release notes by coderabbit.ai -->