### PR TITLE
CPDLC: decode Altitude and Time element arguments

### DIFF
--- a/crates/xng-acars/src/cpdlc/mod.rs
+++ b/crates/xng-acars/src/cpdlc/mod.rs
@@ -37,6 +37,10 @@ pub struct CpdlcMessage {
     /// "REQUEST [altitude]", ...). Bracketed arguments are not decoded
     /// in v1.
     pub text: String,
+    /// Decoded element arguments in template order (when the element's
+    /// argument structure is one we decode; see `decode`).
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub args: Vec<String>,
     /// The message carries additional elements beyond the first.
     pub more_elements: bool,
 }
@@ -56,6 +60,60 @@ impl Bits<'_> {
         }
         Some(v)
     }
+}
+
+/// FANSAltitude CHOICE (3-bit index; widths/offsets and the value
+/// semantics — QNH/QFE in tens of feet, flight level metric in tens of
+/// meters — from libacars's generated constraints and text formatters).
+fn read_altitude(b: &mut Bits) -> Option<String> {
+    Some(match b.read(3)? {
+        0 => format!("{} ft", b.read(12)? * 10),        // QNH (0..2500) x10
+        1 => format!("{} m", b.read(14)?),              // QNH meters
+        2 => format!("{} ft QFE", b.read(12)? * 10),    // QFE (0..2100) x10
+        3 => format!("{} m QFE", b.read(13)?),          // QFE meters
+        4 => format!("{} ft", b.read(18)?),             // GNSS feet
+        5 => format!("{} m", b.read(16)?),              // GNSS meters
+        6 => format!("FL{}", 30 + b.read(10)?),         // flight level (30..600)
+        7 => format!("{} m", (100 + b.read(11)?) * 10), // metric FL (100..2000) x10
+        _ => unreachable!(),
+    })
+}
+
+/// FANSTime: hours (0..23, 5 bits) + minutes (0..59, 6 bits).
+fn read_time(b: &mut Bits) -> Option<String> {
+    let h = b.read(5)?;
+    let m = b.read(6)?;
+    if h > 23 || m > 59 {
+        return None;
+    }
+    Some(format!("{h:02}:{m:02}"))
+}
+
+/// Decode the element's arguments when its type (the tag's suffix after
+/// `dMnn`/`uMnn`) is one of the simple shapes we handle. Returns None
+/// for argument structures not decoded yet — the caller keeps the
+/// bracketed template untouched.
+fn read_args(tag: &str, b: &mut Bits) -> Option<Vec<String>> {
+    let ty = tag.trim_start_matches(|c: char| c.is_ascii_lowercase() || c.is_ascii_digit() || c == 'M');
+    match ty {
+        "NULL" => Some(Vec::new()),
+        "Altitude" => Some(vec![read_altitude(b)?]),
+        // SEQUENCE SIZE(2..2) OF Altitude: fixed size, no length bits.
+        "AltitudeAltitude" => Some(vec![read_altitude(b)?, read_altitude(b)?]),
+        "Time" => Some(vec![read_time(b)?]),
+        _ => None,
+    }
+}
+
+/// Substitute decoded arguments into the bracketed template slots.
+fn render(template: &str, args: &[String]) -> String {
+    let mut out = template.to_string();
+    for a in args {
+        let Some(start) = out.find('[') else { break };
+        let Some(end) = out[start..].find(']') else { break };
+        out.replace_range(start..start + end + 1, a);
+    }
+    out
 }
 
 /// Decode a FANS-1/A ATC message body (the octets after the ARINC 622
@@ -82,12 +140,15 @@ pub fn decode(body: &[u8], downlink: bool) -> Option<CpdlcMessage> {
         if downlink { &DOWNLINK_ELEMENTS } else { &UPLINK_ELEMENTS };
     let idx = b.read(8)? as usize;
     let (tag, label) = table.get(idx).copied()?;
+    let args = read_args(tag, &mut b).unwrap_or_default();
+    let text = if args.is_empty() { label.to_string() } else { render(label, &args) };
     Some(CpdlcMessage {
         msg_id,
         msg_ref,
         timestamp,
         element: tag.to_string(),
-        text: label.to_string(),
+        text,
+        args,
         more_elements: has_more,
     })
 }
@@ -151,6 +212,44 @@ mod tests {
         assert_eq!(m.element, "dM6Altitude");
         assert_eq!(m.text, "REQUEST [altitude]");
         assert!(m.more_elements);
+    }
+
+    #[test]
+    fn altitude_arguments_render() {
+        // dM9Altitude = "REQUEST CLIMB TO [altitude]"; arg = flight level
+        // CHOICE (index 6) + FL360 (offset 330 from lower bound 30).
+        let mut body = build(11, None, None, 9, false);
+        // Append the altitude arg bits: 3-bit choice 6, 10-bit offset 330.
+        let mut bits: Vec<u8> = Vec::new();
+        for k in (0..3).rev() {
+            bits.push(((6 >> k) & 1) as u8);
+        }
+        for k in (0..10).rev() {
+            bits.push(((330u32 >> k) & 1) as u8);
+        }
+        // The header for this build is 3+6+8 = 17 bits; continue packing
+        // from bit 17.
+        let mut all = body.clone();
+        all.resize(5, 0);
+        for (i, &v) in bits.iter().enumerate() {
+            let p = 17 + i;
+            all[p / 8] |= v << (7 - p % 8);
+        }
+        body = all;
+        let m = decode(&body, true).unwrap();
+        assert_eq!(m.element, "dM9Altitude");
+        assert_eq!(m.args, vec!["FL360"]);
+        assert_eq!(m.text, "REQUEST CLIMB TO FL360");
+    }
+
+    #[test]
+    fn undecoded_argument_keeps_template() {
+        // dM22Position = "REQUEST DIRECT TO [position]" — position args
+        // are not decoded; the bracketed template must survive.
+        let m = decode(&build(2, None, None, 22, false), true).unwrap();
+        assert_eq!(m.element, "dM22Position");
+        assert!(m.args.is_empty());
+        assert!(m.text.contains("[position]"), "{}", m.text);
     }
 
     #[test]


### PR DESCRIPTION
v2 of #18: the highest-value argument types now render real values.

## What
- **Altitude** — all 8 `FANSAltitude` CHOICE variants with libacars's value semantics: QNH/QFE in tens of feet, GNSS feet/meters direct, flight level offset from 30 (`FL360`), metric FL in tens of meters. Widths from the generated constraint tables (3-bit CHOICE + 12/14/12/13/18/16/10/11-bit values).
- **AltitudeAltitude** — fixed SIZE(2) sequences (block altitude clearances: `REQUEST BLOCK 9000 ft TO FL250`).
- **Time** — `AT [time]` elements render `AT 14:32`.
- Decoded values render into the label template **and** land in a structured `args` array for downstream consumers.

## Honest coverage
The element's argument shape is derived from its asn1c tag suffix (`dM9Altitude` → one Altitude). Anything not handled — positions, speeds, route clearances, free text — keeps its bracketed template (`REQUEST DIRECT TO [position]`), so what's decoded vs. not is always visible in the output. Tested: FL rendering from raw UPER bits, template preservation for undecoded types, plus the existing envelope end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)