### PR TITLE
VDL2: fix RS-failure decode livelock

### DIFF
--- a/crates/xng-mode-vdl2/PROVENANCE.md
+++ b/crates/xng-mode-vdl2/PROVENANCE.md
@@ -54,3 +54,24 @@ all also present in dumpvdl2's output. dumpvdl2 decodes 41 frames from
 the same file; the gap is acquisition sensitivity (proper symbol-timing
 recovery is the planned follow-up). A 6 s slice is vendored as a CI
 fixture (tests/data/, attributed) guarded by tests/offair.rs.
+
+## Sensitivity investigation round 2 (2026-06)
+
+Fixed a decode livelock: a burst whose RS decode failed was re-hunted
+from one sample past its UW, deterministically re-refined to the same
+position, and retried — ~1700 times per burst, escaping only when the
+(symmetric) noise-floor EMA rose above the burst. The retry storms also
+consumed the timeline so later bursts were never hunted. The demod now
+remembers the last RS-failed UW position and skips past it on
+re-detection. Result: every burst in the sigidwiki capture that passes
+the header now also passes RS (14 bursts, 0 RS row failures), and the
+wasted work is gone.
+
+Remaining gap to dumpvdl2 on the same capture: four ground-station XID
+bursts decode RS-"clean" but fail the AVLC FCS — running dumpvdl2's
+exact destuffing algorithm over our post-RS bits fails identically, so
+the corruption is upstream: our symbol decisions carry enough errors
+that RS (at capacity, fixed=3 on k=6 rows) miscorrects into a nearby
+codeword. Phase-gain and sampling-offset sweeps are already at their
+optima; closing this needs a matched filter + symbol-timing tracking in
+the demod (planned).

--- a/crates/xng-mode-vdl2/src/demod.rs
+++ b/crates/xng-mode-vdl2/src/demod.rs
@@ -66,6 +66,11 @@ enum State {
 }
 
 pub struct Vdl2Demod {
+    /// Refined UW position of the last collection that failed RS: a
+    /// re-hunt that refines back to the same position is skipped past
+    /// instead of retried (the decode is deterministic — retrying the
+    /// identical burst livelocks until the noise floor rises).
+    last_rs_fail: f64,
     sps: f64,
     /// Channel samples; index 0 is absolute sample `start_abs`.
     buf: Vec<Complex<f32>>,
@@ -92,6 +97,7 @@ impl Vdl2Demod {
             cursor: 0.0,
             noise: 1e-6,
             state: State::Hunt,
+            last_rs_fail: f64::NEG_INFINITY,
             level: 0.0,
         }
     }
@@ -228,6 +234,11 @@ impl Vdl2Demod {
         loop {
             match std::mem::replace(&mut self.state, State::Hunt) {
                 State::Hunt => match self.hunt() {
+                    Some(uw_pos) if (uw_pos - self.last_rs_fail).abs() < 1.0 => {
+                        // Deterministic re-detection of a burst that
+                        // already failed RS: skip past its UW entirely.
+                        self.cursor = uw_pos + 17.0 * self.sps;
+                    }
                     Some(uw_pos) => {
                         let (_, theta) = self.uw_correlate(uw_pos).unwrap();
                         let last_uw = uw_pos + 15.0 * self.sps;
@@ -264,6 +275,7 @@ impl Vdl2Demod {
                                 self.cursor = c.next_pos; // skip past the burst
                             }
                             None => {
+                                self.last_rs_fail = c.uw_start;
                                 // A false UW lock (e.g. on a burst edge) can
                                 // pass the header FEC with a bogus length and
                                 // swallow the real burst; resume right after


### PR DESCRIPTION
Investigated the 11/41 sensitivity gap against dumpvdl2 on the off-air capture; found and fixed a livelock, and precisely characterized what remains.

## The livelock
A burst failing RS was re-hunted from `uw_start + 1` — but the hunt deterministically re-refines to the identical quarter-sample position and retries the identical decode. **~1700 retries per failing burst**, escaping only when the noise-floor EMA (symmetric, slowly rising during the burst) eventually blocks the energy gate. The storms also consumed the timeline, starving later bursts. Fix: remember the last RS-failed UW position and skip past it on re-detection.

## Result
Every burst that passes the header now passes RS — 14 bursts, zero RS row failures, and the off-air fixture test is unchanged. (Frame count is 10 vs the storm's occasional lucky 11: one XID sometimes decoded on a lucky retry offset; determinism plus ~100× less wasted work is the right trade.)

## What remains, precisely characterized
Four ground-station XID bursts decode RS-"clean" but fail AVLC FCS. Differential test: running **dumpvdl2's exact destuffing algorithm** (ported line-for-line) over our post-RS bits fails identically — so the corruption is upstream in our symbol decisions, and RS at capacity (fixed=3 on k=6 rows) is miscorrecting into nearby codewords. Phase-gain and sampling-offset sweeps both sit at their optima already. Closing this needs a matched filter + symbol-timing tracking in the demod — documented in PROVENANCE.md as the follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)