### PR TITLE
VDL2: coherent preamble sync (demod v2 step 1)

### DIFF
--- a/crates/xng-mode-vdl2/PROVENANCE.md
+++ b/crates/xng-mode-vdl2/PROVENANCE.md
@@ -75,3 +75,17 @@ that RS (at capacity, fixed=3 on k=6 rows) miscorrects into a nearby
 codeword. Phase-gain and sampling-offset sweeps are already at their
 optima; closing this needs a matched filter + symbol-timing tracking in
 the demod (planned).
+
+## Coherent preamble sync (2026-06, demod v2 step 1)
+
+The UW hunt's quarter-sample differential refinement is replaced by a
+coherent joint fit (dumpvdl2's sync in least-squares form): over a fine
+timing grid, the unwrapped per-symbol phase trajectory of all 16 UW
+symbols is compared against the known cumulative UW phase ramp and fit
+to residual ≈ a + b·k, weighted by sample energy. The minimum-cost grid
+point yields timing and the per-symbol CFO (b) jointly — far less noisy
+than the differential correlation argument, which uses 15 transitions
+non-coherently. Off-air result: 13 frames (from 10), including the
+ground-station XID bursts whose symbol errors previously drove RS into
+miscorrection. Remaining gap to dumpvdl2 is hunt trigger sensitivity on
+the weakest bursts.

--- a/crates/xng-mode-vdl2/src/demod.rs
+++ b/crates/xng-mode-vdl2/src/demod.rs
@@ -152,10 +152,86 @@ impl Vdl2Demod {
         Some((corr.norm() / norm, corr.arg()))
     }
 
+    /// Coherent preamble fit (dumpvdl2's approach, in least-squares
+    /// form): over a fine timing grid around `pos`, compare the
+    /// unwrapped per-symbol phase trajectory of the 16 UW symbols
+    /// against the known cumulative UW phase ramp, and fit
+    /// residual ≈ a + b·k weighted by sample energy. The minimum-cost
+    /// grid point jointly yields timing, carrier phase (a, absorbed by
+    /// the differential decisions) and per-symbol CFO (b) — far less
+    /// noisy than the argument of the differential correlation, which
+    /// only uses 15 transitions non-coherently.
+    /// Returns (uw_pos, theta) or None when the buffer cannot cover the
+    /// search window yet.
+    fn preamble_fit(&self, pos: f64) -> Option<(f64, f32)> {
+        let mut pr = [0.0f32; 16];
+        for k in 1..16 {
+            pr[k] = pr[k - 1] + UW_DELTAS[k] as f32 * PI / 4.0;
+        }
+        let mut best: Option<(f32, f64, f32)> = None; // (cost, pos, theta)
+        let mut t = -3.0f64;
+        while t <= 3.0 {
+            let cand = pos + t;
+            t += 0.25;
+            if cand < self.start_abs {
+                continue;
+            }
+            let mut r = [0.0f32; 16];
+            let mut w = [0.0f32; 16];
+            for k in 0..16 {
+                let s = self.sample(cand + k as f64 * self.sps)?;
+                r[k] = s.arg() - pr[k];
+                w[k] = s.norm_sqr();
+            }
+            // Sequential unwrap of the residual trajectory.
+            for k in 1..16 {
+                let mut d = r[k] - r[k - 1];
+                while d > PI {
+                    r[k] -= 2.0 * PI;
+                    d = r[k] - r[k - 1];
+                }
+                while d < -PI {
+                    r[k] += 2.0 * PI;
+                    d = r[k] - r[k - 1];
+                }
+            }
+            // Weighted least squares r_k ≈ a + b·k.
+            let sw: f32 = w.iter().sum();
+            if sw < 1e-12 {
+                continue;
+            }
+            let kbar = w.iter().enumerate().map(|(k, &wk)| wk * k as f32).sum::<f32>() / sw;
+            let rbar = w.iter().zip(&r).map(|(&wk, &rk)| wk * rk).sum::<f32>() / sw;
+            let mut num = 0.0f32;
+            let mut den = 0.0f32;
+            for k in 0..16 {
+                let dk = k as f32 - kbar;
+                num += w[k] * dk * (r[k] - rbar);
+                den += w[k] * dk * dk;
+            }
+            if den < 1e-12 {
+                continue;
+            }
+            let b = num / den;
+            let a = rbar - b * kbar;
+            let mut cost = 0.0f32;
+            for k in 0..16 {
+                let e = r[k] - a - b * k as f32;
+                cost += w[k] * e * e;
+            }
+            cost /= sw;
+            if best.map(|(c, _, _)| cost < c).unwrap_or(true) {
+                best = Some((cost, cand, b));
+            }
+        }
+        best.map(|(_, p, th)| (p, th))
+    }
+
     /// Hunt for a UW; returns the refined first-UW-symbol position.
-    fn hunt(&mut self) -> Option<f64> {
-        let span = 18.0 * self.sps;
-        let end_abs = self.start_abs + self.buf.len() as f64 - span - 2.0;
+    fn hunt(&mut self) -> Option<(f64, f32)> {
+        // Span covers the preamble-fit search window (pos+3 + 15 symbols).
+        let span = 19.0 * self.sps;
+        let end_abs = self.start_abs + self.buf.len() as f64 - span - 4.0;
         while self.cursor < end_abs {
             let pos = self.cursor;
             self.cursor += 1.0;
@@ -167,21 +243,13 @@ impl Vdl2Demod {
             }
             if let Some((metric, _)) = self.uw_correlate(pos) {
                 if metric > CORR_THRESHOLD {
-                    // Quarter-sample refinement: at 4.76 samples/symbol a
-                    // 1-2 sample timing error degrades every later symbol
-                    // decision (header FEC and RS then fail) — the same
-                    // broad-differential-peak effect seen on HFDL off-air.
-                    let mut best = (metric, pos);
-                    let mut k = -4.0f64;
-                    while k <= 4.0 {
-                        if let Some((m, _)) = self.uw_correlate(pos + k) {
-                            if m > best.0 {
-                                best = (m, pos + k);
-                            }
-                        }
-                        k += 0.25;
+                    // Coherent refinement: joint timing/CFO fit over the
+                    // whole preamble (the differential metric's peak is
+                    // broad and its CFO estimate noisy — both degrade
+                    // every later symbol decision).
+                    if let Some(fit) = self.preamble_fit(pos) {
+                        return Some(fit);
                     }
-                    return Some(best.1);
                 }
             }
         }
@@ -234,13 +302,12 @@ impl Vdl2Demod {
         loop {
             match std::mem::replace(&mut self.state, State::Hunt) {
                 State::Hunt => match self.hunt() {
-                    Some(uw_pos) if (uw_pos - self.last_rs_fail).abs() < 1.0 => {
+                    Some((uw_pos, _)) if (uw_pos - self.last_rs_fail).abs() < 1.5 => {
                         // Deterministic re-detection of a burst that
                         // already failed RS: skip past its UW entirely.
                         self.cursor = uw_pos + 17.0 * self.sps;
                     }
-                    Some(uw_pos) => {
-                        let (_, theta) = self.uw_correlate(uw_pos).unwrap();
+                    Some((uw_pos, theta)) => {
                         let last_uw = uw_pos + 15.0 * self.sps;
                         let prev = self.sample(last_uw).unwrap();
                         self.state = State::Collect(Box::new(Collecting {

--- a/docs/notes/VDL2-DEMOD-V2.md
+++ b/docs/notes/VDL2-DEMOD-V2.md
@@ -1,0 +1,62 @@
+# VDL2 demod v2 — design notes for the sensitivity upgrade
+
+Status 2026-06: the native demod decodes 14/18-ish bursts on the
+sigidwiki off-air capture (10 AVLC frames; dumpvdl2 gets 41 frames from
+the same file, counting multi-frame bursts per frame). Every burst that
+passes the header passes RS; the remaining losses are four
+ground-station XID bursts whose symbol decisions carry enough errors
+that RS at capacity (3 corrections on k=6 rows) miscorrects into a
+nearby codeword — dumpvdl2's exact destuffing algorithm fails
+identically on our post-RS bits, so the gap is entirely in the
+demodulator front end. Phase-gain (0.05–0.1 plateau) and sampling-offset
+(0 optimal) sweeps are exhausted.
+
+## What dumpvdl2 actually does differently (facts from src/demod.c)
+
+It does NOT use a matched filter. Its symbol decisions are single-sample
+`atan2` phases, like ours. The edges are architectural:
+
+1. **10 samples/symbol** (105 kHz channel rate vs our 50 kHz / 4.76 sps).
+   Finer timing grid and more samples to average over the preamble.
+2. **Preamble phase-pattern sync**: a buffer of per-sample phases spans
+   the whole 16-symbol preamble; sync compares the phase *trajectory*
+   against the known UW phase ramp (`pr_phase[]` = cumulative expected
+   phases) and picks the sample where the error vector is most constant.
+   The constant value of that error vector simultaneously yields the
+   carrier phase. This uses all 16 symbols coherently — our differential
+   correlation uses 15 transitions non-coherently.
+3. **Explicit per-sample CFO (`dphi`)**: estimated from the preamble
+   (slope of the error vector), applied as `phi - prev_phi - dphi` in
+   every symbol decision, carried across bursts (`prev_dphi`) and
+   reported as a ppm error. Our `theta` is per-symbol rotation from the
+   differential correlation argument — same idea, noisier estimate, and
+   our decision-directed `PHASE_GAIN` residual tracking is the only
+   in-burst adaptation.
+
+## v2 plan
+
+- Raise `CHANNEL_RATE` to 105_000 (Ddc from wideband input; the
+  sigidwiki capture resamples to 105 kHz losslessly for the test path).
+- Replace the differential UW hunt's refinement with the phase-pattern
+  sync over the full preamble: coarse trigger can stay differential
+  (CFO-immune), then fit phase trajectory for (sync point, carrier
+  phase, dphi) jointly.
+- Per-symbol decisions as today, but derotated by the fitted dphi;
+  keep the decision-directed residual tracking on top.
+- Regression assets: `examples/offair.rs` against the conjugated
+  sigidwiki capture (expect ≥14 bursts / 10 frames before, target the
+  four XID bursts: tl_bits 372, 489, 572, 573 — XID heads
+  `F6/F2 FE FE FE 94 AC 48 …` must pass AVLC FCS after the upgrade);
+  the vendored 6 s fixture; the full synthetic suite.
+
+Capture regeneration:
+
+```
+curl -L https://www.sigidwiki.com/images/d/df/VDL-M2_IQ.zip -o vdl2.zip && unzip vdl2.zip
+ffmpeg -i "VDL2 IQ.wav" -f f32le -ac 2 -ar 105000 vdl2_105k.f32
+# NOTE: capture has inverted I/Q — negate Q before decoding.
+```
+
+The same investigation applies to HFDL's weak-burst gap (31/37 vs
+dumphfdl): its A1 hunt is also differential-then-refine; a coherent
+preamble fit would sharpen acquisition there too.

--- a/docs/notes/VDL2-DEMOD-V2.md
+++ b/docs/notes/VDL2-DEMOD-V2.md
@@ -60,3 +60,13 @@ ffmpeg -i "VDL2 IQ.wav" -f f32le -ac 2 -ar 105000 vdl2_105k.f32
 The same investigation applies to HFDL's weak-burst gap (31/37 vs
 dumphfdl): its A1 hunt is also differential-then-refine; a coherent
 preamble fit would sharpen acquisition there too.
+
+## Progress (same day)
+
+The coherent preamble fit is implemented (weighted least-squares over
+the 16-symbol phase trajectory, ±3 samples in 0.25 steps) at the
+existing 50 kHz channel rate — the rate bump turned out unnecessary for
+this step. Result on the capture: **13 frames (from 10)**, including
+the GS XID bursts (`XID len=75` from 2D4918) that previously RS-
+miscorrected. The remaining gap to dumpvdl2 (41) is burst *detection* —
+hunt trigger sensitivity on the weakest bursts — not decode quality.


### PR DESCRIPTION
Executes step 1 of the demod v2 blueprint — and it recovers the XID bursts without the channel-rate change.

## What
The UW hunt's quarter-sample differential refinement is replaced by a **coherent joint fit** — dumpvdl2's preamble sync recast as weighted least squares. Over a fine timing grid (±3 samples, 0.25 steps), the unwrapped per-symbol phase trajectory of all 16 UW symbols is compared against the known cumulative UW phase ramp and fit to `residual ≈ a + b·k`, weighted by sample energy. The minimum-cost grid point yields timing and per-symbol CFO **jointly** — the differential correlation it replaces used 15 transitions non-coherently and fed every later symbol decision a noisier carrier estimate.

## Results (off-air sigidwiki capture)
- **13 frames, up from 10** — including the ground-station XID bursts (`XID len=75` from 2D4918) that #21 precisely characterized as RS-miscorrecting from accumulated symbol errors. Exactly the failure the blueprint targeted.
- Full synthetic suite + off-air fixture unchanged-green.
- The 105 kHz channel-rate bump contemplated in the notes proved unnecessary for this step.

## Remaining
The gap to dumpvdl2 (41 frames) is now burst *detection* — hunt trigger sensitivity on the weakest bursts — not decode quality. Recorded in docs/notes/VDL2-DEMOD-V2.md (included here; supersedes #22).

🤖 Generated with [Claude Code](https://claude.com/claude-code)