### PR TITLE
VDL2: safe low-threshold triggering (16 frames off-air, from 13)

### DIFF
--- a/crates/xng-mode-vdl2/src/demod.rs
+++ b/crates/xng-mode-vdl2/src/demod.rs
@@ -39,7 +39,11 @@ pub const GRAY_INV: [(u8, u8, u8); 8] = [
     (1, 0, 0),
 ];
 
-const CORR_THRESHOLD: f32 = 0.88;
+const CORR_THRESHOLD: f32 = 0.6;
+/// Maximum weighted residual variance (rad²) of the coherent preamble
+/// fit for a candidate to count as a UW (true preambles on the off-air
+/// capture fit below ~0.11; random data above ~0.5).
+const FIT_COST_MAX: f32 = 0.25;
 const ENERGY_FACTOR: f32 = 6.0;
 const NOISE_ALPHA: f32 = 1e-4;
 const PHASE_GAIN: f32 = 0.1;
@@ -163,7 +167,7 @@ impl Vdl2Demod {
     /// only uses 15 transitions non-coherently.
     /// Returns (uw_pos, theta) or None when the buffer cannot cover the
     /// search window yet.
-    fn preamble_fit(&self, pos: f64) -> Option<(f64, f32)> {
+    fn preamble_fit(&self, pos: f64) -> Option<(f64, f32, f32)> {
         let mut pr = [0.0f32; 16];
         for k in 1..16 {
             pr[k] = pr[k - 1] + UW_DELTAS[k] as f32 * PI / 4.0;
@@ -224,7 +228,7 @@ impl Vdl2Demod {
                 best = Some((cost, cand, b));
             }
         }
-        best.map(|(_, p, th)| (p, th))
+        best.map(|(c, p, th)| (p, th, c))
     }
 
     /// Hunt for a UW; returns the refined first-UW-symbol position.
@@ -246,9 +250,14 @@ impl Vdl2Demod {
                     // Coherent refinement: joint timing/CFO fit over the
                     // whole preamble (the differential metric's peak is
                     // broad and its CFO estimate noisy — both degrade
-                    // every later symbol decision).
-                    if let Some(fit) = self.preamble_fit(pos) {
-                        return Some(fit);
+                    // every later symbol decision). The fit residual
+                    // arbitrates true UWs; with collection-time buffer
+                    // retention, an accepted false candidate costs only
+                    // wasted work, never a lost burst.
+                    if let Some((p, th, cost)) = self.preamble_fit(pos) {
+                        if cost < FIT_COST_MAX {
+                            return Some((p, th));
+                        }
                     }
                 }
             }
@@ -359,8 +368,14 @@ impl Vdl2Demod {
         }
 
         // Drop consumed samples (keep a tail behind the active position).
+        // While collecting, retain everything back to the UW that started
+        // the collection: if the header was a false decode with a bogus
+        // length, the RS failure rewinds the hunt to uw_start + 1, and
+        // any real burst inside the consumed span must still be in the
+        // buffer. Worst case (max TL ≈ 6240 symbols) this holds ~150 KB
+        // of samples at the 50 kHz channel rate.
         let active = match &self.state {
-            State::Collect(c) => c.next_pos,
+            State::Collect(c) => c.uw_start.min(c.next_pos),
             State::Hunt => self.cursor,
         };
         let keep_from = (active - self.start_abs - 4.0 * self.sps).max(0.0) as usize;

--- a/docs/notes/VDL2-DEMOD-V2.md
+++ b/docs/notes/VDL2-DEMOD-V2.md
@@ -95,3 +95,15 @@ shape, or fit ramp amplitude jointly), or gate on the fit cost of the
 SECOND half of the UW only (past the ramp). Each false acceptance is
 expensive — a bogus header length drains the buffer past real bursts —
 so the discriminator must be strong, not just statistical.
+
+## Trigger sensitivity v3 (resolved, 2026-06)
+
+The missing piece was never the discriminator — it was making false
+acceptances harmless. The buffer retention policy now keeps samples
+back to the collecting burst's UW start, so when a false header decode
+with a bogus length fails RS, the rewind to uw_start+1 still has every
+sample of any real burst inside the consumed span. With that, the
+trigger threshold drops 0.88 → 0.6 with the fit-cost gate (< 0.25 rad²)
+arbitrating, and weak bursts get attempted safely: **16 frames** on the
+capture (13 before; plateau holds down to thr 0.4). The remaining gap
+to dumpvdl2 is genuine SNR reach at 4.76 samples/symbol.


### PR DESCRIPTION
Resolves the trigger-sensitivity item that #25 documented as needing a stronger approach — and the answer wasn't a better discriminator.

## The reframe
#25's dead ends all tried to make the UW discriminator strong enough that false triggers never start collections. The actual blocker was that a false acceptance was *catastrophic*: a false header decode yields a bogus transmission length, the collection consumes samples far past real bursts, and the buffer had already dropped them by the time RS failed.

## The fix
**Buffer retention during collection**: keep samples back to the collecting burst's UW start (worst case ~150 KB at max TL). The existing RS-failure rewind to `uw_start + 1` then always finds any real burst inside the consumed span intact. False acceptances become wasted work instead of lost traffic.

With that property, the trigger threshold drops **0.88 → 0.6**, gated by the coherent fit residual (true preambles < 0.11 rad², random data > 0.5, gate at 0.25) — the separation #25 measured but couldn't safely exploit.

## Results
- **16 frames on the off-air capture, up from 13** (the plateau holds down to thr 0.4; 0.6 chosen as fewest false attempts for the same yield)
- Workspace green including the off-air fixture
- Remaining gap to dumpvdl2 is genuine SNR reach at 4.76 samples/symbol — a channel-rate/architecture question, not a triggering one

🤖 Generated with [Claude Code](https://claude.com/claude-code)