### PR TITLE
Iridium wave 2: native ring-alert/broadcast decode core

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ xng-mode-vdl2 = { path = "crates/xng-mode-vdl2" }
 xng-mode-aero = { path = "crates/xng-mode-aero" }
 xng-mode-stdc = { path = "crates/xng-mode-stdc" }
 xng-mode-hfdl = { path = "crates/xng-mode-hfdl" }
+xng-mode-iridium = { path = "crates/xng-mode-iridium" }
 prost = "0.13"
 tonic = "0.12"
 quinn = "0.11"
@@ -88,6 +89,7 @@ xng-mode-vdl2.workspace = true
 xng-mode-aero.workspace = true
 xng-mode-stdc.workspace = true
 xng-mode-hfdl.workspace = true
+xng-mode-iridium.workspace = true
 prost.workspace = true
 tonic.workspace = true
 quinn.workspace = true

--- a/crates/xng-mode-iridium/Cargo.toml
+++ b/crates/xng-mode-iridium/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "xng-mode-iridium"
+description = "Native Iridium decode core for xng (ring alert / broadcast frames, DQPSK bursts)"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+
+[dependencies]
+chrono.workspace = true
+num-complex.workspace = true
+rustfft.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+xng-dsp.workspace = true
+xng-types.workspace = true

--- a/crates/xng-mode-iridium/PROVENANCE.md
+++ b/crates/xng-mode-iridium/PROVENANCE.md
@@ -1,0 +1,49 @@
+# Provenance — xng-mode-iridium
+
+Layer 2 ported from **iridium-toolkit** (https://github.com/muccc/iridium-toolkit,
+BSD-2-Clause, muccc) — porting permitted with attribution, which this
+file and the crate documentation provide. Ported structures (from
+`bitsparser.py` / `bch.py`):
+
+- 24-bit access codes (the differential decode of the 12-symbol UW),
+  IMS messaging header, frame classification order (IMS header → IBC
+  via BCH(7,3) poly 29 + 2-way deinterleave → IRA via 3-way
+  deinterleave + triple ringalert BCH).
+- Symbol-pair deinterleavers (bits swapped within each pair, symbols
+  read from the end backwards): 2-way 64→2×32, 3-way 96→3×32.
+- BCH blocks: 32 bits = 31 BCH (21 data + 10 check, polys
+  ringalert 1207 / messaging 1897) + whole-block even parity; repair
+  by 1–2 bit flip search.
+- 64-bit FILL pattern removal (≤2 bitdiff per half).
+- IRA field layout (sat/beam/x/y/z/interval/timeslot/EPI/sub-band +
+  42-bit pages terminated by an all-ones page) and the geocentric
+  position conversion.
+
+PHY facts (no code) from **gr-iridium** and **iridium-sniffer**
+(https://github.com/alphafox02/iridium-sniffer, both GPL-3): 25 000
+sym/s DQPSK, 40 kHz channels, tone preamble (16/64 symbols) + UW,
+`dqpsk_map = [0,2,3,1]` with MSB-first bit emission, frame length
+limits, burst detector parameters. iridium-sniffer's ARCHITECTURE.md
+is the single best pipeline reference (and documents the IDA/SBD→ACARS
+chain for wave-2 follow-up).
+
+The demodulator itself is original: power-boxcar burst gate, tone-DFT
+coarse CFO, and the coherent UW fit (joint timing/phase/CFO weighted
+least squares over the 12 known UW symbols) developed for the VDL2 and
+HFDL demods in this codebase, plus a decision-directed phase trim
+(α=0.2 as in gr-iridium).
+
+## Validation
+
+- **Oracle-validated against iridium-toolkit**: a generated ring-alert
+  frame decodes bit-identically in `bitsparser.py` (the reference
+  implementation) and in this crate — sat/beam/xyz/position/interval/
+  flags/sub-band/TMSIs all agree. The exact vector is vendored in
+  tests/e2e.rs. (Interop note: gr-iridium `RAW:` lines carry each
+  symbol's two bits swapped; `RWA:` is the normalized form this crate
+  uses internally.)
+- RF loopback: tone+UW+payload burst with CFO and noise through the
+  full chain (burst gate, tone CFO, UW fit, DQPSK, deinterleave, BCH,
+  field parse).
+- Off-air validation pending an L-band capture of the ring-alert
+  channel (1626.270833 MHz; bursts every few seconds worldwide).

--- a/crates/xng-mode-iridium/examples/genframe.rs
+++ b/crates/xng-mode-iridium/examples/genframe.rs
@@ -1,0 +1,56 @@
+//! Emit a generated IRA bit stream + our decode as JSON (oracle harness).
+
+use xng_mode_iridium::{decode_bits, frame};
+
+fn push_field(bits: &mut Vec<u8>, v: u32, n: usize) {
+    for k in (0..n).rev() {
+        bits.push(((v >> k) & 1) as u8);
+    }
+}
+
+fn main() {
+    let mut d = Vec::new();
+    push_field(&mut d, 75, 7); // sat
+    push_field(&mut d, 21, 6); // beam
+    for v in [-1411i32, 263, 1602] {
+        let sign = if v < 0 { 1 } else { 0 };
+        let mag = if v < 0 { v + (1 << 11) } else { v } as u32;
+        push_field(&mut d, sign, 1);
+        push_field(&mut d, mag, 11);
+    }
+    push_field(&mut d, 33, 7);
+    push_field(&mut d, 0, 1);
+    push_field(&mut d, 1, 1);
+    push_field(&mut d, 22, 5);
+    for tmsi in [0xCAFED00Du32, 0x00C0FFEE] {
+        push_field(&mut d, tmsi, 32);
+        push_field(&mut d, 0, 2);
+        push_field(&mut d, 7, 5);
+        push_field(&mut d, 0, 3);
+    }
+    d.extend(std::iter::repeat(1).take(42));
+
+    let mut padded = d.clone();
+    while padded.len() % 21 != 0 {
+        padded.push(0);
+    }
+    let mut nblk = padded.len() / 21;
+    while (nblk - 3) % 2 != 0 {
+        padded.extend(std::iter::repeat(0).take(21));
+        nblk += 1;
+    }
+    let blocks: Vec<Vec<u8>> = padded
+        .chunks_exact(21)
+        .map(|x| frame::bch_encode(frame::RINGALERT_BCH_POLY, x))
+        .collect();
+    let mut bits: Vec<u8> = frame::ACCESS_DL.to_vec();
+    bits.extend(frame::interleave3(&blocks[0], &blocks[1], &blocks[2]));
+    for pair in blocks[3..].chunks_exact(2) {
+        bits.extend(frame::interleave2(&pair[0], &pair[1]));
+    }
+
+    let bitstr: String = bits.iter().map(|&b| char::from(b'0' + b)).collect();
+    let ours = decode_bits(&bits).expect("decodes");
+    println!("{bitstr}");
+    println!("{}", serde_json::to_string(&ours.details).unwrap());
+}

--- a/crates/xng-mode-iridium/src/demod.rs
+++ b/crates/xng-mode-iridium/src/demod.rs
@@ -1,0 +1,300 @@
+//! Iridium DQPSK burst demodulator (single 25 kHz channel at 10
+//! samples/symbol). Pipeline facts from gr-iridium/iridium-sniffer (GPL,
+//! facts only): tone preamble → 12-symbol UW (DL/UL) → payload, 25 000
+//! sym/s, RRC matched filter, differential decode with
+//! `dqpsk_map = [0,2,3,1]`, two MSB-first bits per mapped symbol.
+//!
+//! Acquisition reuses the coherent preamble fit proven on VDL2/HFDL:
+//! after a power trigger and tone-based coarse CFO, the 12 known UW
+//! symbols (absolute QPSK phases) are fit jointly for timing, carrier
+//! phase, and residual CFO over a fine grid.
+
+use crate::frame::{ACCESS_DL, ACCESS_UL};
+use num_complex::Complex;
+use std::f32::consts::PI;
+
+pub const SYMBOL_RATE: f64 = 25_000.0;
+const SPS: f64 = 10.0;
+/// UW absolute QPSK symbol phases (units of π/2).
+const UW_DL: [u8; 12] = [0, 2, 2, 2, 2, 0, 0, 0, 2, 0, 0, 2];
+const UW_UL: [u8; 12] = [2, 2, 0, 0, 0, 2, 0, 0, 2, 0, 2, 2];
+/// Differential symbol → mapped symbol (gr-iridium).
+const DQPSK_MAP: [u8; 4] = [0, 2, 3, 1];
+/// Maximum burst length in symbols (90 ms at 25 ksym/s).
+const MAX_BURST_SYMS: usize = 2_250;
+/// Preamble tone length to search across (long preamble = 64 symbols).
+const PRE_SYMS: f64 = 64.0;
+
+pub struct IridiumDemod {
+    sps: f64,
+    buf: Vec<Complex<f32>>,
+    start_abs: f64,
+    cursor: f64,
+    noise: f32,
+    /// 16-sample boxcar of power for the burst gate (single noise
+    /// samples have an exponential tail; bursts are sustained).
+    pwr_win: [f32; 16],
+    pwr_pos: usize,
+    pwr_sum: f32,
+    level: f32,
+}
+
+impl IridiumDemod {
+    pub fn new(channel_rate: f64) -> Self {
+        let sps = channel_rate / SYMBOL_RATE;
+        Self {
+            sps,
+            buf: Vec::new(),
+            start_abs: 0.0,
+            cursor: 0.0,
+            // Initialized high: falls to the true floor within ~1000
+            // samples (the asymmetric EMA falls fast, rises slowly).
+            noise: 1.0,
+            pwr_win: [0.0; 16],
+            pwr_pos: 0,
+            pwr_sum: 0.0,
+            level: 0.0,
+        }
+    }
+
+    fn sample(&self, abs_pos: f64) -> Option<Complex<f32>> {
+        let rel = abs_pos - self.start_abs;
+        if rel < 0.0 {
+            return None;
+        }
+        let i = rel.floor() as usize;
+        if i + 1 >= self.buf.len() {
+            return None;
+        }
+        let frac = (rel - i as f64) as f32;
+        Some(self.buf[i] * (1.0 - frac) + self.buf[i + 1] * frac)
+    }
+
+    /// Coarse CFO from the preamble tone: FFT peak over the tone window.
+    fn tone_cfo(&self, pos: f64, syms: f64) -> Option<f64> {
+        let n = (syms * self.sps) as usize;
+        let rel = (pos - self.start_abs) as usize;
+        if rel + n > self.buf.len() {
+            return None;
+        }
+        let mut best = (0.0f32, 0.0f64);
+        // Coarse DFT scan ±12 kHz in 50 Hz steps (tone is strong).
+        let mut f = -12_000.0;
+        while f <= 12_000.0 {
+            let mut acc = Complex::new(0.0f32, 0.0);
+            let step = -2.0 * std::f64::consts::PI * f / (SYMBOL_RATE * self.sps / 1.0);
+            for (k, s) in self.buf[rel..rel + n].iter().enumerate() {
+                acc += s * Complex::from_polar(1.0, (step * k as f64) as f32);
+            }
+            let m = acc.norm();
+            if m > best.0 {
+                best = (m, f);
+            }
+            f += 50.0;
+        }
+        Some(best.1)
+    }
+
+    /// Coherent UW fit (timing/phase/CFO jointly) for one UW variant.
+    /// Returns (cost, uw_pos, theta_per_symbol, carrier_phase).
+    fn uw_fit(&self, pos: f64, uw: &[u8; 12], theta0: f32) -> Option<(f32, f64, f32, f32)> {
+        let mut best: Option<(f32, f64, f32, f32)> = None;
+        let mut t = -self.sps;
+        while t <= self.sps {
+            let cand = pos + t;
+            t += 0.25;
+            if cand < self.start_abs {
+                continue;
+            }
+            let mut r = [0.0f32; 12];
+            let mut w = [0.0f32; 12];
+            let mut prev = 0.0f32;
+            for k in 0..12 {
+                let s = self.sample(cand + k as f64 * self.sps)?;
+                let expect = uw[k] as f32 * PI / 2.0;
+                let mut ph = (s * Complex::from_polar(1.0, -expect - theta0 * k as f32)).arg();
+                while ph - prev > PI {
+                    ph -= 2.0 * PI;
+                }
+                while ph - prev < -PI {
+                    ph += 2.0 * PI;
+                }
+                prev = ph;
+                r[k] = ph;
+                w[k] = s.norm_sqr();
+            }
+            let sw: f32 = w.iter().sum();
+            if sw < 1e-12 {
+                continue;
+            }
+            let kbar = w.iter().enumerate().map(|(k, &wk)| wk * k as f32).sum::<f32>() / sw;
+            let rbar = w.iter().zip(&r).map(|(&wk, &rk)| wk * rk).sum::<f32>() / sw;
+            let mut num = 0.0;
+            let mut den = 0.0;
+            for k in 0..12 {
+                let dk = k as f32 - kbar;
+                num += w[k] * dk * (r[k] - rbar);
+                den += w[k] * dk * dk;
+            }
+            if den < 1e-12 {
+                continue;
+            }
+            let b = num / den;
+            let a = rbar - b * kbar;
+            let mut cost = 0.0;
+            for (k, (&wk, &rk)) in w.iter().zip(&r).enumerate() {
+                let e = rk - a - b * k as f32;
+                cost += wk * e * e;
+            }
+            cost /= sw;
+            if best.map(|(c, _, _, _)| cost < c).unwrap_or(true) {
+                best = Some((cost, cand, theta0 + b, a));
+            }
+        }
+        best
+    }
+
+    /// Feed channel samples; returns demodulated burst bit streams
+    /// (each beginning at the access code).
+    pub fn process(&mut self, input: &[Complex<f32>]) -> Vec<Vec<u8>> {
+        self.buf.extend_from_slice(input);
+        for x in input {
+            self.level += 1e-4 * (x.norm_sqr() - self.level);
+        }
+        let mut out = Vec::new();
+        let span = (PRE_SYMS + 14.0 + MAX_BURST_SYMS as f64) * self.sps;
+        loop {
+            let end_abs = self.start_abs + self.buf.len() as f64 - span;
+            if self.cursor >= end_abs {
+                break;
+            }
+            let pos = self.cursor;
+            self.cursor += 1.0;
+            let rel = (pos - self.start_abs) as usize;
+            let p = self.buf[rel].norm_sqr();
+            // Asymmetric noise floor (burst sweep must not lift it).
+            if p < self.noise {
+                self.noise += 0.01 * (p - self.noise);
+            } else {
+                self.noise += 1e-5 * (p - self.noise);
+            }
+            self.pwr_sum += p - self.pwr_win[self.pwr_pos];
+            self.pwr_win[self.pwr_pos] = p;
+            self.pwr_pos = (self.pwr_pos + 1) % 16;
+            if self.pwr_sum < self.noise * 8.0 * 16.0 {
+                continue;
+            }
+            // The boxcar trigger fires ~16 samples into the burst; the
+            // tone preamble starts at roughly pos − 16. Measure CFO on a
+            // window that is certainly inside the tone, then hunt the UW
+            // over the possible preamble lengths (16 short, 64 long).
+            let bstart = pos - 16.0;
+            let Some(cfo) = self.tone_cfo(bstart + 2.0 * self.sps, 10.0) else { break };
+            let theta0 = (2.0 * std::f64::consts::PI * cfo / SYMBOL_RATE) as f32;
+            let burst_gate = self.noise * 8.0;
+            let mut found: Option<(f32, f64, f32, f32, &'static [u8; 24])> = None;
+            let mut hunt = 6.0 * self.sps;
+            while hunt < (PRE_SYMS + 26.0) * self.sps {
+                let cand = bstart + hunt;
+                hunt += 2.0 * self.sps;
+                // The whole 12-symbol window must carry burst power.
+                let mut energetic = true;
+                for k in 0..12 {
+                    match self.sample(cand + k as f64 * self.sps) {
+                        Some(s) if s.norm_sqr() > burst_gate => {}
+                        Some(_) => {
+                            energetic = false;
+                            break;
+                        }
+                        None => {
+                            energetic = false;
+                            break;
+                        }
+                    }
+                }
+                if !energetic {
+                    continue;
+                }
+                for (uw, access) in [(&UW_DL, ACCESS_DL), (&UW_UL, ACCESS_UL)] {
+                    if let Some((cost, p2, th, ph)) = self.uw_fit(cand, uw, theta0) {
+                        if cost < 0.05 && found.map(|(c, ..)| cost < c).unwrap_or(true) {
+                            found = Some((cost, p2, th, ph, access));
+                        }
+                    }
+                }
+                if found.is_some() && hunt > 10.0 * self.sps {
+                    break;
+                }
+            }
+            let Some((_, uw_pos, theta, phase, access)) = found else {
+                // No UW: skip past this energy region.
+                self.cursor = pos + 32.0 * self.sps;
+                continue;
+            };
+
+            // Demodulate symbols until the burst power drops or max len.
+            let mut symbols: Vec<u8> = Vec::new();
+            let mut k = 0usize;
+            let mut carr = phase;
+            loop {
+                let sp = uw_pos + k as f64 * self.sps;
+                let Some(s) = self.sample(sp) else { break };
+                if k >= 12 {
+                    // End of burst: power gone for this symbol.
+                    if s.norm_sqr() < self.noise * 4.0 {
+                        break;
+                    }
+                }
+                let derot = s * Complex::from_polar(1.0, -(theta * k as f32) - carr);
+                // Hard QPSK decision in units of π/2.
+                let ang = derot.arg();
+                // Signed rounding so the residual wraps correctly at ±π
+                // (q·π/2 after mod-4 would put −π against +π → −2π).
+                let idx_f = (ang / (PI / 2.0)).round();
+                let q = (idx_f as i32).rem_euclid(4) as u8;
+                // Decision-directed phase trim (PLL α≈0.2 per gr-iridium).
+                let residual = ang - idx_f * (PI / 2.0);
+                carr += 0.2 * residual;
+                symbols.push(q);
+                k += 1;
+                if k >= 12 + MAX_BURST_SYMS {
+                    break;
+                }
+            }
+            if symbols.len() < 12 + 32 {
+                self.cursor = uw_pos + symbols.len().max(1) as f64 * self.sps;
+                continue;
+            }
+
+            // Differential decode (the first UW symbol acts as reference;
+            // toolkit bit streams start at the access code, i.e. the UW
+            // itself differentially decoded from old_sym = 0).
+            let mut bits = Vec::with_capacity(symbols.len() * 2);
+            let mut old = 0u8;
+            for &s in &symbols {
+                let d = (s + 4 - old) % 4;
+                old = s;
+                let m = DQPSK_MAP[d as usize];
+                bits.push(m >> 1);
+                bits.push(m & 1);
+            }
+            // Sanity: access code must match what the UW fit promised.
+            if bits.len() >= 24 && bits[..24] == access[..] {
+                out.push(bits);
+            }
+            self.cursor = uw_pos + symbols.len() as f64 * self.sps;
+        }
+
+        // Drop consumed samples.
+        let keep_from = (self.cursor - self.start_abs - 4.0 * self.sps).max(0.0) as usize;
+        if keep_from > 0 && keep_from <= self.buf.len() {
+            self.buf.drain(..keep_from);
+            self.start_abs += keep_from as f64;
+        }
+        out
+    }
+
+    pub fn level_dbfs(&self) -> f32 {
+        10.0 * self.level.max(1e-12).log10()
+    }
+}

--- a/crates/xng-mode-iridium/src/frame.rs
+++ b/crates/xng-mode-iridium/src/frame.rs
@@ -1,0 +1,322 @@
+//! Iridium layer 2 (ported from BSD-2-licensed iridium-toolkit — see PROVENANCE.md): access codes, symbol-pair deinterleaving,
+//! BCH(31,21) blocks with even parity, FILL removal, and frame
+//! classification (IRA ring alert, IBC broadcast, IMS messaging header).
+
+/// 24-bit access codes (differential decode of the 12-symbol UW).
+pub const ACCESS_DL: &[u8; 24] = &[
+    0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 1, 1, 1, 1, 0, 0, 1, 1,
+];
+pub const ACCESS_UL: &[u8; 24] = &[
+    1, 1, 0, 0, 1, 1, 0, 0, 0, 0, 1, 1, 1, 1, 0, 0, 1, 1, 1, 1, 1, 1, 0, 0,
+];
+
+/// IMS (messaging) 32-bit header.
+pub const HEADER_MESSAGING: &[u8; 32] = &[
+    0, 0, 1, 1, 0, 0, 1, 1, 1, 1, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1,
+    1, 1, 1, 1, 0, 0, 1, 1,
+];
+
+/// BCH generator polynomials (toolkit integer convention).
+pub const RINGALERT_BCH_POLY: u32 = 1207;
+pub const MESSAGING_BCH_POLY: u32 = 1897;
+pub const HDR_POLY: u32 = 29;
+
+/// The 64-bit FILL pattern that pads RA/MS frames (two 32-bit halves).
+pub const FILL_A: u32 = 0b1010_0010_0111_0011_1011_1111_0110_1101;
+pub const FILL_B: u32 = 0b0101_0100_0100_0101_1100_0010_1110_0110;
+
+/// GF(2) polynomial remainder of a bit slice by `poly`.
+pub fn ndivide(poly: u32, bits: &[u8]) -> u32 {
+    let mut num: u64 = 0;
+    for &b in bits {
+        num = (num << 1) | b as u64;
+    }
+    let pbits = 32 - poly.leading_zeros();
+    let nbits = bits.len() as u32;
+    if nbits < pbits {
+        return num as u32;
+    }
+    let mut shift = nbits - pbits;
+    loop {
+        if num >> (shift + pbits - 1) & 1 == 1 {
+            num ^= (poly as u64) << shift;
+        }
+        if shift == 0 {
+            break;
+        }
+        shift -= 1;
+    }
+    num as u32
+}
+
+/// Repair a 31-bit BCH block (≤2 bit flips searched); returns the number
+/// of corrected bits, or None when uncorrectable. `block` is fixed up in
+/// place.
+pub fn bch_repair(poly: u32, block: &mut [u8]) -> Option<u32> {
+    if ndivide(poly, block) == 0 {
+        return Some(0);
+    }
+    for i in 0..block.len() {
+        block[i] ^= 1;
+        if ndivide(poly, block) == 0 {
+            return Some(1);
+        }
+        for j in i + 1..block.len() {
+            block[j] ^= 1;
+            if ndivide(poly, block) == 0 {
+                return Some(2);
+            }
+            block[j] ^= 1;
+        }
+        block[i] ^= 1;
+    }
+    None
+}
+
+/// 2-way symbol-pair deinterleave: 64 bits → two 32-bit blocks.
+/// Operates on QPSK symbol pairs with the two bits of each pair swapped,
+/// reading symbols from the end backwards (toolkit `de_interleave`).
+pub fn de_interleave2(group: &[u8]) -> (Vec<u8>, Vec<u8>) {
+    let symbols: Vec<[u8; 2]> = group
+        .chunks_exact(2)
+        .map(|p| [p[1], p[0]])
+        .collect();
+    let n = symbols.len();
+    let mut even = Vec::with_capacity(n);
+    let mut odd = Vec::with_capacity(n);
+    let mut x = n as isize - 2;
+    while x >= 0 {
+        even.extend_from_slice(&symbols[x as usize]);
+        x -= 2;
+    }
+    let mut x = n as isize - 1;
+    while x >= 0 {
+        odd.extend_from_slice(&symbols[x as usize]);
+        x -= 2;
+    }
+    (odd, even)
+}
+
+/// 3-way symbol-pair deinterleave: 96 bits → three 32-bit blocks
+/// (toolkit `de_interleave3`).
+pub fn de_interleave3(group: &[u8]) -> (Vec<u8>, Vec<u8>, Vec<u8>) {
+    let symbols: Vec<[u8; 2]> = group
+        .chunks_exact(2)
+        .map(|p| [p[1], p[0]])
+        .collect();
+    let n = symbols.len() as isize;
+    let collect = |start: isize| -> Vec<u8> {
+        let mut out = Vec::new();
+        let mut x = start;
+        while x >= 0 {
+            out.extend_from_slice(&symbols[x as usize]);
+            x -= 3;
+        }
+        out
+    };
+    (collect(n - 1), collect(n - 2), collect(n - 3))
+}
+
+fn bits_to_u32(bits: &[u8]) -> u32 {
+    bits.iter().fold(0u32, |v, &b| (v << 1) | b as u32)
+}
+
+/// Decode a sequence of 32-bit interleaver-output blocks through
+/// BCH(31,21) + even parity; returns (data bits, corrected blocks) and
+/// stops at the first uncorrectable block (toolkit `IridiumECCMessage`).
+pub fn ecc_blocks(blocks: &[Vec<u8>], poly: u32) -> (Vec<u8>, u32) {
+    let mut data = Vec::new();
+    let mut fixed = 0u32;
+    for block in blocks {
+        if block.len() != 32 {
+            break;
+        }
+        let mut b31: Vec<u8> = block[..31].to_vec();
+        let Some(errs) = bch_repair(poly, &mut b31) else {
+            break;
+        };
+        // Whole-block even parity (over the repaired 31 bits + parity).
+        let ones: u32 =
+            b31.iter().map(|&v| v as u32).sum::<u32>() + block[31] as u32;
+        if ones % 2 == 1 && errs > 0 {
+            break;
+        }
+        if errs > 0 {
+            fixed += 1;
+        }
+        data.extend_from_slice(&b31[..21]);
+    }
+    (data, fixed)
+}
+
+/// Remove trailing FILL pattern pairs from the interleaved block list.
+pub fn strip_fill(blocks: &mut Vec<Vec<u8>>) -> u32 {
+    let mut fill = 0;
+    while blocks.len() >= 2 {
+        let a = bits_to_u32(&blocks[blocks.len() - 2]);
+        let b = bits_to_u32(&blocks[blocks.len() - 1]);
+        if (a ^ FILL_A).count_ones() <= 2 && (b ^ FILL_B).count_ones() <= 2 {
+            blocks.pop();
+            blocks.pop();
+            fill += 1;
+        } else {
+            break;
+        }
+    }
+    fill
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FrameKind {
+    /// Ring alert (simplex downlink).
+    Ra,
+    /// Broadcast (IBC).
+    Bc,
+    /// Messaging header seen (payload not parsed in v1).
+    Ms,
+    Unknown,
+}
+
+/// Classify the post-access bit stream (downlink heuristics from the
+/// toolkit, without frequency classing).
+pub fn classify(data: &[u8]) -> FrameKind {
+    if data.len() >= 32 && data[..32] == HEADER_MESSAGING[..] {
+        return FrameKind::Ms;
+    }
+    if data.len() > 6 + 64 && ndivide(HDR_POLY, &data[..6]) == 0 {
+        let (b1, b2) = de_interleave2(&data[6..6 + 64]);
+        if ndivide(RINGALERT_BCH_POLY, &b1[..31]) == 0
+            && ndivide(RINGALERT_BCH_POLY, &b2[..31]) == 0
+        {
+            return FrameKind::Bc;
+        }
+    }
+    if data.len() >= 96 {
+        let (b1, b2, b3) = de_interleave3(&data[..96]);
+        if ndivide(RINGALERT_BCH_POLY, &b1[..31]) == 0
+            && ndivide(RINGALERT_BCH_POLY, &b2[..31]) == 0
+            && ndivide(RINGALERT_BCH_POLY, &b3[..31]) == 0
+        {
+            return FrameKind::Ra;
+        }
+    }
+    FrameKind::Unknown
+}
+
+/// Deinterleave an RA frame's bit stream: leading 3-way triple, then
+/// 2-way per following 64-bit chunk.
+pub fn ra_blocks(data: &[u8]) -> Vec<Vec<u8>> {
+    let mut blocks = Vec::new();
+    let (b1, b2, b3) = de_interleave3(&data[..96]);
+    blocks.push(b1);
+    blocks.push(b2);
+    blocks.push(b3);
+    for chunk in data[96..].chunks_exact(64) {
+        let (o, e) = de_interleave2(chunk);
+        blocks.push(o);
+        blocks.push(e);
+    }
+    blocks
+}
+
+// ── transmit side (loopback/testing) ────────────────────────────────────
+
+/// BCH-encode 21 data bits into a 32-bit block (21 data + 10 check +
+/// even parity).
+pub fn bch_encode(poly: u32, data21: &[u8]) -> Vec<u8> {
+    debug_assert_eq!(data21.len(), 21);
+    let mut padded: Vec<u8> = data21.to_vec();
+    padded.extend(std::iter::repeat(0).take(10));
+    let rem = ndivide(poly, &padded);
+    let mut block: Vec<u8> = data21.to_vec();
+    for k in (0..10).rev() {
+        block.push(((rem >> k) & 1) as u8);
+    }
+    let ones: u32 = block.iter().map(|&b| b as u32).sum();
+    block.push((ones % 2) as u8);
+    block
+}
+
+/// Inverse of `de_interleave2`: two 32-bit blocks → 64 transmitted bits.
+pub fn interleave2(odd: &[u8], even: &[u8]) -> Vec<u8> {
+    let n = (odd.len() + even.len()) / 2; // symbol count
+    let mut symbols: Vec<[u8; 2]> = vec![[0, 0]; n];
+    let mut o = odd.chunks_exact(2);
+    let mut x = n as isize - 1;
+    while x >= 0 {
+        let p = o.next().unwrap();
+        symbols[x as usize] = [p[0], p[1]];
+        x -= 2;
+    }
+    let mut e = even.chunks_exact(2);
+    let mut x = n as isize - 2;
+    while x >= 0 {
+        let p = e.next().unwrap();
+        symbols[x as usize] = [p[0], p[1]];
+        x -= 2;
+    }
+    symbols.into_iter().flat_map(|[a, b]| [b, a]).collect()
+}
+
+/// Inverse of `de_interleave3`: three 32-bit blocks → 96 transmitted bits.
+pub fn interleave3(b1: &[u8], b2: &[u8], b3: &[u8]) -> Vec<u8> {
+    let n = (b1.len() + b2.len() + b3.len()) / 2;
+    let mut symbols: Vec<[u8; 2]> = vec![[0, 0]; n];
+    for (start, blk) in [(1usize, b1), (2, b2), (3, b3)] {
+        let mut it = blk.chunks_exact(2);
+        let mut x = n as isize - start as isize;
+        while x >= 0 {
+            let p = it.next().unwrap();
+            symbols[x as usize] = [p[0], p[1]];
+            x -= 3;
+        }
+    }
+    symbols.into_iter().flat_map(|[a, b]| [b, a]).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rand_bits(n: usize, mut s: u64) -> Vec<u8> {
+        (0..n)
+            .map(|_| {
+                s = s.wrapping_mul(6364136223846793005).wrapping_add(1);
+                ((s >> 33) & 1) as u8
+            })
+            .collect()
+    }
+
+    #[test]
+    fn interleave_roundtrips() {
+        let odd = rand_bits(32, 1);
+        let even = rand_bits(32, 2);
+        let tx = interleave2(&odd, &even);
+        let (o, e) = de_interleave2(&tx);
+        assert_eq!(o, odd);
+        assert_eq!(e, even);
+
+        let b1 = rand_bits(32, 3);
+        let b2 = rand_bits(32, 4);
+        let b3 = rand_bits(32, 5);
+        let tx = interleave3(&b1, &b2, &b3);
+        let (r1, r2, r3) = de_interleave3(&tx);
+        assert_eq!(r1, b1);
+        assert_eq!(r2, b2);
+        assert_eq!(r3, b3);
+    }
+
+    #[test]
+    fn bch_roundtrip_and_repair() {
+        let data = rand_bits(21, 7);
+        let block = bch_encode(RINGALERT_BCH_POLY, &data);
+        assert_eq!(block.len(), 32);
+        assert_eq!(ndivide(RINGALERT_BCH_POLY, &block[..31]), 0);
+        // Two-bit error repairs.
+        let mut b31: Vec<u8> = block[..31].to_vec();
+        b31[3] ^= 1;
+        b31[17] ^= 1;
+        assert_eq!(bch_repair(RINGALERT_BCH_POLY, &mut b31), Some(2));
+        assert_eq!(&b31[..21], &data[..]);
+    }
+}

--- a/crates/xng-mode-iridium/src/ira.rs
+++ b/crates/xng-mode-iridium/src/ira.rs
@@ -1,0 +1,102 @@
+//! IRA (ring alert) and minimal IBC payload parsing (ported from
+//! iridium-toolkit bitsparser.py, BSD-2 — see PROVENANCE.md).
+
+use serde::Serialize;
+use serde_json::json;
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct IridiumFrame {
+    pub kind: &'static str,
+    pub details: serde_json::Value,
+    #[serde(skip_serializing)]
+    pub raw_bits: Vec<u8>,
+}
+
+fn field(bits: &[u8], range: std::ops::Range<usize>) -> u32 {
+    bits[range].iter().fold(0u32, |v, &b| (v << 1) | b as u32)
+}
+
+/// Sign-magnitude-ish position component: sign bit then 11 bits.
+fn pos_component(bits: &[u8], start: usize) -> i32 {
+    let mag = field(bits, start + 1..start + 12) as i32;
+    mag - (bits[start] as i32) * (1 << 11)
+}
+
+/// Parse the concatenated 21-bit BCH data blocks of a ring alert.
+pub fn parse_ra(data: &[u8], fixed: u32, raw_bits: &[u8]) -> Option<IridiumFrame> {
+    if data.len() < 63 {
+        return None;
+    }
+    let sat = field(data, 0..7);
+    let beam = field(data, 7..13);
+    let x = pos_component(data, 13);
+    let y = pos_component(data, 25);
+    let z = pos_component(data, 37);
+    let ra_int = field(data, 49..56);
+    let ts = data[56];
+    let eip = data[57];
+    let sb = field(data, 58..63);
+
+    let (xf, yf, zf) = (x as f64, y as f64, z as f64);
+    let lat = zf.atan2((xf * xf + yf * yf).sqrt()).to_degrees();
+    let lon = yf.atan2(xf).to_degrees();
+    let radius_km = (xf * xf + yf * yf + zf * zf).sqrt() * 4.0;
+    let alt_km = radius_km - 6378.0 + 23.0;
+
+    // Pages: 42 bits each; an all-ones page terminates the list.
+    let mut pages = Vec::new();
+    let mut complete = false;
+    for page in data[63..].chunks(42) {
+        if page.len() < 42 {
+            break;
+        }
+        if page.iter().all(|&b| b == 1) {
+            complete = true;
+            break;
+        }
+        pages.push(json!({
+            "tmsi": format!("{:08x}", field(page, 0..32)),
+            "msc_id": field(page, 34..39),
+        }));
+    }
+
+    Some(IridiumFrame {
+        kind: "ring-alert",
+        details: json!({
+            "sat": sat,
+            "beam": beam,
+            "lat": lat,
+            "lon": lon,
+            "alt_km": alt_km,
+            "ra_interval": ra_int,
+            "timeslot": ts,
+            "epi": eip,
+            "bc_sub_band": sb,
+            "pages": pages,
+            "pages_complete": complete,
+            "bch_corrected": fixed,
+        }),
+        raw_bits: raw_bits.to_vec(),
+    })
+}
+
+/// Minimal IBC summary (type from the BCH(7,3) header; payload data bits
+/// reported but not field-parsed in v1).
+pub fn parse_bc(bc_type: u32, data: &[u8], fixed: u32, raw_bits: &[u8]) -> IridiumFrame {
+    let hex: String = data
+        .chunks(8)
+        .map(|c| {
+            let v = c.iter().fold(0u8, |a, &b| (a << 1) | b);
+            format!("{:02x}", v << (8 - c.len()))
+        })
+        .collect();
+    IridiumFrame {
+        kind: "broadcast",
+        details: json!({
+            "bc_type": bc_type,
+            "data_hex": hex,
+            "bch_corrected": fixed,
+        }),
+        raw_bits: raw_bits.to_vec(),
+    }
+}

--- a/crates/xng-mode-iridium/src/lib.rs
+++ b/crates/xng-mode-iridium/src/lib.rs
@@ -1,0 +1,117 @@
+//! Native Iridium decode core (v1: single-channel burst decoder aimed at
+//! the fixed ring-alert channel; see PROVENANCE.md and
+//! docs/notes/IRIDIUM.md).
+
+pub mod demod;
+pub mod frame;
+pub mod ira;
+pub mod modulate;
+
+use chrono::Utc;
+use num_complex::Complex;
+use xng_dsp::Ddc;
+use xng_types::{DecodeQuality, Message, MessageBody, Mode, Provenance, SignalQuality};
+
+/// Channel rate (10 samples/symbol at 25 000 sym/s, as gr-iridium).
+pub const CHANNEL_RATE: f64 = 250_000.0;
+/// One-sided passband (one 40 kHz Iridium channel).
+pub const CHANNEL_PASSBAND_HZ: f64 = 25_000.0;
+/// The simplex ring-alert channel.
+pub const RING_ALERT_HZ: u64 = 1_626_270_833;
+
+pub struct IridiumChannelDecoder {
+    ddc: Option<Ddc>,
+    demod: demod::IridiumDemod,
+    channel_buf: Vec<Complex<f32>>,
+}
+
+impl IridiumChannelDecoder {
+    pub fn new(input_rate: f64, freq_offset_hz: f64) -> Result<Self, String> {
+        let ddc = if (input_rate - CHANNEL_RATE).abs() < 1e-6 && freq_offset_hz.abs() < 1e-6 {
+            None
+        } else {
+            Some(Ddc::new(input_rate, CHANNEL_RATE, freq_offset_hz, CHANNEL_PASSBAND_HZ)?)
+        };
+        Ok(Self {
+            ddc,
+            demod: demod::IridiumDemod::new(CHANNEL_RATE),
+            channel_buf: Vec::new(),
+        })
+    }
+
+    pub fn process(&mut self, input: &[Complex<f32>]) -> Vec<ira::IridiumFrame> {
+        let channel: &[Complex<f32>] = match &mut self.ddc {
+            Some(ddc) => {
+                self.channel_buf.clear();
+                ddc.process(input, &mut self.channel_buf);
+                &self.channel_buf
+            }
+            None => input,
+        };
+        let mut out = Vec::new();
+        for bits in self.demod.process(channel) {
+            if let Some(f) = decode_bits(&bits) {
+                out.push(f);
+            }
+        }
+        out
+    }
+
+    pub fn level_dbfs(&self) -> f32 {
+        self.demod.level_dbfs()
+    }
+}
+
+/// Decode a demodulated burst bit stream (starting at the access code).
+pub fn decode_bits(bits: &[u8]) -> Option<ira::IridiumFrame> {
+    let data = if bits.len() > 24 && bits[..24] == frame::ACCESS_DL[..] {
+        &bits[24..]
+    } else if bits.len() > 24 && bits[..24] == frame::ACCESS_UL[..] {
+        &bits[24..]
+    } else {
+        return None;
+    };
+    match frame::classify(data) {
+        frame::FrameKind::Ra => {
+            let mut blocks = frame::ra_blocks(data);
+            frame::strip_fill(&mut blocks);
+            let (payload, fixed) = frame::ecc_blocks(&blocks, frame::RINGALERT_BCH_POLY);
+            ira::parse_ra(&payload, fixed, bits)
+        }
+        frame::FrameKind::Bc => {
+            // BCH(7,3) header: first 3 bits are the broadcast type.
+            let bc_type = data[..3].iter().fold(0u32, |v, &b| (v << 1) | b as u32);
+            let mut blocks = Vec::new();
+            for chunk in data[6..].chunks_exact(64) {
+                let (o, e) = frame::de_interleave2(chunk);
+                blocks.push(o);
+                blocks.push(e);
+            }
+            let (payload, fixed) = frame::ecc_blocks(&blocks, frame::RINGALERT_BCH_POLY);
+            if payload.is_empty() {
+                return None;
+            }
+            Some(ira::parse_bc(bc_type, &payload, fixed, bits))
+        }
+        _ => None,
+    }
+}
+
+/// Convert a decoded frame into the normalized message model.
+pub fn to_message(
+    f: &ira::IridiumFrame,
+    frequency_hz: u64,
+    level_dbfs: f32,
+    source: Provenance,
+) -> Message {
+    Message {
+        mode: Mode::Iridium,
+        timestamp: Utc::now(),
+        frequency_hz,
+        signal: SignalQuality { rssi_db: Some(level_dbfs), ..Default::default() },
+        decode: DecodeQuality { crc_ok: true, fec_corrected: None, errors: None },
+        body: MessageBody::Iridium { kind: f.kind.to_string(), details: f.details.clone() },
+        raw: None,
+        source,
+    }
+}

--- a/crates/xng-mode-iridium/src/modulate.rs
+++ b/crates/xng-mode-iridium/src/modulate.rs
@@ -1,0 +1,80 @@
+//! Iridium burst modulator (loopback/testing): tone preamble + UW +
+//! payload symbols at 25 ksym/s, RRC-shaped DQPSK.
+
+use num_complex::Complex;
+
+/// Root-raised-cosine taps (unit energy).
+pub fn rrc_taps(sps: f64, num_taps: usize, beta: f64) -> Vec<f32> {
+    let mid = (num_taps - 1) as f64 / 2.0;
+    let mut taps: Vec<f64> = (0..num_taps)
+        .map(|n| {
+            let t = (n as f64 - mid) / sps;
+            if t.abs() < 1e-9 {
+                1.0 - beta + 4.0 * beta / std::f64::consts::PI
+            } else if (t.abs() - 1.0 / (4.0 * beta)).abs() < 1e-9 {
+                (beta / std::f64::consts::SQRT_2)
+                    * ((1.0 + 2.0 / std::f64::consts::PI)
+                        * (std::f64::consts::PI / (4.0 * beta)).sin()
+                        + (1.0 - 2.0 / std::f64::consts::PI)
+                            * (std::f64::consts::PI / (4.0 * beta)).cos())
+            } else {
+                let pt = std::f64::consts::PI * t;
+                ((pt * (1.0 - beta)).sin() + 4.0 * beta * t * (pt * (1.0 + beta)).cos())
+                    / (pt * (1.0 - (4.0 * beta * t).powi(2)))
+            }
+        })
+        .collect();
+    let energy: f64 = taps.iter().map(|h| h * h).sum::<f64>().sqrt();
+    taps.iter_mut().for_each(|h| *h /= energy);
+    taps.into_iter().map(|h| h as f32).collect()
+}
+
+/// Inverse of the demod's differential decode: bits (starting at the
+/// access code) → absolute QPSK symbols, old_sym starting at 0.
+pub fn bits_to_symbols(bits: &[u8]) -> Vec<u8> {
+    const INV_MAP: [u8; 4] = [0, 3, 1, 2]; // inverse of [0,2,3,1]
+    let mut out = Vec::with_capacity(bits.len() / 2);
+    let mut old = 0u8;
+    for pair in bits.chunks_exact(2) {
+        let m = (pair[0] << 1) | pair[1];
+        let d = INV_MAP[m as usize];
+        old = (old + d) % 4;
+        out.push(old);
+    }
+    out
+}
+
+/// Modulate a burst: `pre_syms` of tone, then the symbol stream,
+/// RRC-shaped at `sample_rate` with `freq_offset_hz`.
+pub fn modulate(
+    bits: &[u8],
+    pre_syms: usize,
+    sample_rate: f64,
+    freq_offset_hz: f64,
+    amplitude: f32,
+) -> Vec<Complex<f32>> {
+    let sps = sample_rate / super::demod::SYMBOL_RATE;
+    let symbols = bits_to_symbols(bits);
+    let total_syms = pre_syms + symbols.len() + 4;
+    let total = (total_syms as f64 * sps) as usize;
+    let mut i_imp = vec![Complex::new(0.0f32, 0.0); total];
+    for k in 0..pre_syms {
+        let at = (k as f64 * sps) as usize;
+        i_imp[at] = Complex::new(1.0, 0.0);
+    }
+    for (k, &q) in symbols.iter().enumerate() {
+        let at = ((pre_syms + k) as f64 * sps) as usize;
+        i_imp[at] = Complex::from_polar(1.0, q as f32 * std::f32::consts::FRAC_PI_2);
+    }
+    let mut shaped = Vec::new();
+    let mut fir = xng_dsp::Fir::new(rrc_taps(sps, 81, 0.4));
+    fir.process(&i_imp, &mut shaped);
+    shaped
+        .iter()
+        .enumerate()
+        .map(|(n, s)| {
+            let ph = std::f64::consts::TAU * freq_offset_hz * n as f64 / sample_rate;
+            s * Complex::from_polar(amplitude, ph as f32)
+        })
+        .collect()
+}

--- a/crates/xng-mode-iridium/tests/e2e.rs
+++ b/crates/xng-mode-iridium/tests/e2e.rs
@@ -1,0 +1,143 @@
+//! Iridium ring-alert loopback: build an IRA frame bit-exactly per the
+//! iridium-toolkit layout, modulate as a DQPSK burst, and decode through
+//! the full chain (burst hunt, tone CFO, coherent UW fit, DQPSK,
+//! deinterleave, BCH, field parse).
+
+use num_complex::Complex;
+use xng_mode_iridium::{decode_bits, frame, modulate, IridiumChannelDecoder, CHANNEL_RATE};
+
+fn push_field(bits: &mut Vec<u8>, v: u32, n: usize) {
+    for k in (0..n).rev() {
+        bits.push(((v >> k) & 1) as u8);
+    }
+}
+
+/// Build the payload data bits of a ring alert (63-bit header + pages).
+fn ira_payload(sat: u32, beam: u32, x: i32, y: i32, z: i32, tmsis: &[u32]) -> Vec<u8> {
+    let mut d = Vec::new();
+    push_field(&mut d, sat, 7);
+    push_field(&mut d, beam, 6);
+    for v in [x, y, z] {
+        let sign = if v < 0 { 1 } else { 0 };
+        let mag = if v < 0 { v + (1 << 11) } else { v } as u32;
+        push_field(&mut d, sign, 1);
+        push_field(&mut d, mag, 11);
+    }
+    push_field(&mut d, 17, 7); // ra_interval
+    push_field(&mut d, 1, 1); // timeslot
+    push_field(&mut d, 0, 1); // epi
+    push_field(&mut d, 9, 5); // bc sub-band
+    for &tmsi in tmsis {
+        push_field(&mut d, tmsi, 32);
+        push_field(&mut d, 0, 2);
+        push_field(&mut d, 14, 5); // msc
+        push_field(&mut d, 0, 3);
+    }
+    d.extend(std::iter::repeat(1).take(42)); // END page
+    d
+}
+
+/// Encode payload data bits into the transmitted bit stream:
+/// 21-bit blocks → BCH(31,21)+parity → interleave (3-way then 2-way) →
+/// access code prefix.
+fn ira_bits(payload: &[u8]) -> Vec<u8> {
+    let mut padded = payload.to_vec();
+    while padded.len() % 21 != 0 {
+        padded.push(0);
+    }
+    // Need an even number of blocks beyond the first three for the 2-way
+    // interleave; pad with zero blocks.
+    let mut nblk = padded.len() / 21;
+    while (nblk - 3) % 2 != 0 {
+        padded.extend(std::iter::repeat(0).take(21));
+        nblk += 1;
+    }
+    let blocks: Vec<Vec<u8>> = padded
+        .chunks_exact(21)
+        .map(|d| frame::bch_encode(frame::RINGALERT_BCH_POLY, d))
+        .collect();
+    let mut bits: Vec<u8> = frame::ACCESS_DL.to_vec();
+    bits.extend(frame::interleave3(&blocks[0], &blocks[1], &blocks[2]));
+    for pair in blocks[3..].chunks_exact(2) {
+        bits.extend(frame::interleave2(&pair[0], &pair[1]));
+    }
+    bits
+}
+
+#[test]
+fn ira_bits_decode() {
+    let payload = ira_payload(42, 13, -1200, 800, 1500, &[0xDEADBEEF]);
+    let bits = ira_bits(&payload);
+    let f = decode_bits(&bits).expect("frame decodes");
+    assert_eq!(f.kind, "ring-alert");
+    assert_eq!(f.details["sat"], 42);
+    assert_eq!(f.details["beam"], 13);
+    assert_eq!(f.details["ra_interval"], 17);
+    assert_eq!(f.details["bc_sub_band"], 9);
+    assert_eq!(f.details["pages"][0]["tmsi"], "deadbeef");
+    assert_eq!(f.details["pages"][0]["msc_id"], 14);
+    assert_eq!(f.details["pages_complete"], true);
+    // Geometry: alt = 4*r km.
+    let lat = f.details["lat"].as_f64().unwrap();
+    assert!((lat - (1500.0f64).atan2((1200.0f64*1200.0+800.0*800.0).sqrt()).to_degrees()).abs() < 0.01);
+}
+
+#[test]
+fn ira_rf_loopback() {
+    let payload = ira_payload(99, 7, 500, -900, 1300, &[0x12345678, 0x0BADCAFE]);
+    let bits = ira_bits(&payload);
+    let mut iq = modulate::modulate(&bits, 64, CHANNEL_RATE, 1_500.0, 0.5);
+    // Quiet padding before/after.
+    let mut sig = vec![Complex::new(0.0f32, 0.0); 4000];
+    sig.extend(iq.drain(..));
+    sig.extend(std::iter::repeat(Complex::new(0.0f32, 0.0)).take((CHANNEL_RATE * 0.12) as usize));
+    let mut noise = 0x1234_5678_9abc_def0u64;
+    for s in &mut sig {
+        noise ^= noise << 13;
+        noise ^= noise >> 7;
+        noise ^= noise << 17;
+        let n1 = (noise as f32 / u64::MAX as f32) - 0.5;
+        noise ^= noise << 13;
+        noise ^= noise >> 7;
+        noise ^= noise << 17;
+        let n2 = (noise as f32 / u64::MAX as f32) - 0.5;
+        *s += Complex::new(n1 * 0.02, n2 * 0.02);
+    }
+
+    let mut dec = IridiumChannelDecoder::new(CHANNEL_RATE, 0.0).unwrap();
+    let mut frames = Vec::new();
+    for chunk in sig.chunks(65_536) {
+        frames.extend(dec.process(chunk));
+    }
+    let f = frames.first().expect("burst decodes");
+    assert_eq!(f.kind, "ring-alert");
+    assert_eq!(f.details["sat"], 99);
+    assert_eq!(f.details["beam"], 7);
+    assert_eq!(f.details["pages"][0]["tmsi"], "12345678");
+    assert_eq!(f.details["pages"][1]["tmsi"], "0badcafe");
+}
+
+#[test]
+fn oracle_validated_vector() {
+    // This exact bit stream was decoded by iridium-toolkit's bitsparser
+    // (the reference implementation) as:
+    //   IRA: sat:075 beam:21 xyz=(-1411,+0263,+1602) pos=(+48.14/+169.44)
+    //        alt=2248 RAI:33 ?01 bc_sb:22
+    //        P02: PAGE(tmsi:cafed00d msc_id:07) PAGE(tmsi:00c0ffee msc_id:07) {OK}
+    let bitstr = "001100000011000011110011111010100110001000001000100110000011110111011000101110101011000001010001001001100010001010011101000110011011111011000010001011111001001101110111100100010000001100000010010110110010000100111111100000000000111110001100110011001111111111111111111111111111111111111111111111111111111111111111";
+    let bits: Vec<u8> = bitstr.bytes().map(|b| b - b'0').collect();
+    let f = decode_bits(&bits).expect("decodes");
+    assert_eq!(f.kind, "ring-alert");
+    assert_eq!(f.details["sat"], 75);
+    assert_eq!(f.details["beam"], 21);
+    assert_eq!(f.details["ra_interval"], 33);
+    assert_eq!(f.details["timeslot"], 0);
+    assert_eq!(f.details["epi"], 1);
+    assert_eq!(f.details["bc_sub_band"], 22);
+    assert!((f.details["lat"].as_f64().unwrap() - 48.14).abs() < 0.01);
+    assert!((f.details["lon"].as_f64().unwrap() - 169.44).abs() < 0.01);
+    assert!((f.details["alt_km"].as_f64().unwrap() - 2248.7).abs() < 0.5);
+    assert_eq!(f.details["pages"][0]["tmsi"], "cafed00d");
+    assert_eq!(f.details["pages"][1]["tmsi"], "00c0ffee");
+    assert_eq!(f.details["pages"][0]["msc_id"], 7);
+}

--- a/crates/xng-proto/src/lib.rs
+++ b/crates/xng-proto/src/lib.rs
@@ -78,6 +78,12 @@ impl From<&Message> for asf2::DecodedMessage {
                     altitude_ft: *altitude_ft,
                 }))
             }
+            MessageBody::Iridium { kind, details } => {
+                Some(asf2::decoded_message::Body::Iridium(asf2::IridiumBody {
+                    kind: kind.clone(),
+                    details_json: details.to_string(),
+                }))
+            }
             MessageBody::Hfdl { kind, details } => {
                 Some(asf2::decoded_message::Body::Hfdl(asf2::HfdlBody {
                     kind: kind.clone(),

--- a/crates/xng-types/src/message.rs
+++ b/crates/xng-types/src/message.rs
@@ -93,6 +93,11 @@ pub enum MessageBody {
         #[serde(skip_serializing_if = "Option::is_none")]
         altitude_ft: Option<i32>,
     },
+    /// Iridium frame (ring alert, broadcast, ...).
+    Iridium {
+        kind: String,
+        details: serde_json::Value,
+    },
     /// HFDL non-ACARS event (squitter, logon, performance data, ...).
     Hfdl {
         kind: String,

--- a/docs/REFERENCES.md
+++ b/docs/REFERENCES.md
@@ -30,7 +30,8 @@ attribution. GPL projects are listed as fact references only.
 |---|---|---|---|
 | libacars (szpajder) | MIT | **Ported** (attributed): ARINC 622 envelope, ADS-C decoder, media advisory, sublabel/MFI rules; CPDLC FANS-1/A element tables + UPER layout from the asn1c-generated FANSAC* constraint tables and asn1-format-cpdlc-text.c labels; 4 real ADS-C test vectors from examples/adsc_get_position.c | https://github.com/szpajder/libacars |
 | JAERO (jontio) | MIT | **Ported** (attributed): P-channel framing, interleaver, scrambler, SU/ISU/SSU layer, ACARS carriage; 10.5k OQPSK demod ported from oqpskdemodulator.cpp + coarsefreqestimate.cpp (square-law timing, tanh cross-product carrier loop, squared-signal two-tone coarse CFO); 600/1200 MSK demod intentionally diverges (see xng-mode-aero/PROVENANCE.md). Off-air samples **used for validation** (600bps: 11 ACARS decoded; 10.5k: 144 ACARS decoded; 12 s vendored as CI fixture with attribution) | https://github.com/jontio/JAERO |
-| iridium-toolkit (muccc) | BSD-2 | Planned port source for Iridium frame parsing (wave 2) | https://github.com/muccc/iridium-toolkit |
+| iridium-toolkit (muccc) | BSD-2 | **Ported** (attributed): access codes, symbol-pair deinterleavers, BCH(31,21) blocks + parity, FILL removal, frame classification, IRA field layout; bitsparser.py used as a decode oracle (generated frames must parse bit-identically) | https://github.com/muccc/iridium-toolkit |
+| iridium-sniffer (alphafox02) | GPL-3 | **Facts only**: ARCHITECTURE.md + iridium.h read for the full pipeline parameters (burst detect, downmix, demod, UW patterns, dqpsk_map, IDA/SBD→ACARS chain for wave 2) | https://github.com/alphafox02/iridium-sniffer |
 | acars crate (xoolive) | MIT | Inspected for API/coverage comparison; test fixtures noted as borrowable | https://crates.io/crates/acars |
 | ship162 (xoolive) | MIT | Noted as AIS reference (our core ended up independent) | https://github.com/xoolive/ship162 |
 | rs1090/jet1090 (xoolive) | MIT | Architectural comparison; candidate dep for deep Mode S decode | https://github.com/xoolive/jet1090 |
@@ -41,7 +42,7 @@ attribution. GPL projects are listed as fact references only.
 | sigidwiki Inmarsat-C TDM sample | CC BY-SA | Off-air STD-C TDM/EGC IQ capture (AOR-E) used for STD-C validation; 14 s vendored as CI fixture with attribution | https://www.sigidwiki.com/wiki/Inmarsat-C_TDM |
 | acarsdec (TLeconte / f00b4r0) | LGPL/GPL-2 | Facts only (display conventions) | https://github.com/TLeconte/acarsdec |
 | AIS-catcher (jvde-github) | GPL-3 | Facts only (landscape research) | https://github.com/jvde-github/AIS-catcher |
-| gr-iridium (muccc) | GPL-3 | Facts only (wave 2 planning) | https://github.com/muccc/gr-iridium |
+| gr-iridium (muccc) | GPL-3 | Facts only: PHY parameters (25 ksym/s DQPSK, channel/burst structure, PLL α, UW symbol patterns) | https://github.com/muccc/gr-iridium |
 | SatDump | GPL-3 | Facts only (landscape research) | https://github.com/SatDump/SatDump |
 | Scytale-C | GPL-3 | STD-C facts reference (see docs/notes/STDC.md) | https://bitbucket.org/scytalec/scytalec |
 | inmarsatc (cropinghigh) | GPL-3 | STD-C facts reference (Scytale-C port; constants cross-verified) | https://github.com/cropinghigh/inmarsatc |

--- a/docs/notes/IRIDIUM.md
+++ b/docs/notes/IRIDIUM.md
@@ -1,0 +1,91 @@
+# Iridium — implementation notes
+
+Recorded 2026-06 for xng-mode-iridium. Sources: iridium-toolkit
+(muccc, BSD-2 — code portable with attribution; bitsparser.py/bch.py
+are the layer-2 reference), gr-iridium and iridium-sniffer
+(alphafox02; GPL-3 — **facts only**; iridium-sniffer's ARCHITECTURE.md
+documents the whole pipeline with parameters and is the best single
+PHY reference).
+
+## PHY
+
+- L-band 1616–1626.5 MHz. Duplex channels below ~1625.979 MHz
+  (toolkit `f_duplex` incl. doppler guard), simplex above ~1626.104
+  (`f_simplex`). Ring-alert channel 1626.270833 MHz; quaternary
+  messaging channels nearby.
+- DQPSK, **25 000 symbols/s**, bursts. Channel width 40 kHz
+  (gr-iridium burst detector width); RRC matched filter.
+- Burst anatomy: preamble tone (16 symbols normal, 64 long/simplex) →
+  12-symbol UW → payload. Max burst 90 ms; normal frames 131–191
+  payload symbols, simplex 80–444.
+- UW absolute QPSK symbols: DL `[0,2,2,2,2,0,0,0,2,0,0,2]`,
+  UL `[2,2,0,0,0,2,0,0,2,0,2,2]` (gr-iridium); the toolkit's 24-bit
+  "access codes" are the *differential decode* of these:
+  DL `001100000011000011110011`, UL `110011000011110011111100`.
+- Demod (gr-iridium/sniffer): decimate to 1 sps → 1st-order PLL
+  (α=0.2) → hard QPSK → UW verify (DL+UL, Hamming ≤ 2) → differential
+  decode `map[(s−prev) mod 4]` with `dqpsk_map = [0,2,3,1]` → 2 bits
+  per mapped symbol MSB-first (0→00, 1→01, 2→10, 3→11; verified: UW
+  symbols reproduce the access-code bits exactly).
+- gr-iridium front end (for the wave-2 wideband mode): 8192-pt
+  sliding FFT at 10 MHz, adaptive noise floor over 512 frames, 16 dB
+  threshold, per-burst downmix to 250 kHz / 10 sps.
+
+## Layer 2 (iridium-toolkit bitsparser.py, BSD — ported)
+
+Bit stream starts with the 24-bit access code; `data` = rest.
+
+Classification (downlink, in order): IMS if `data[0..32]` ==
+`00110011111100110011001111110011`; ITL if 96-bit header `11` + 94
+zeros; IBC if BCH(7,3) poly 29 over `data[0..6]` == 0 and the 2-way
+deinterleave of the next 64 bits passes ringalert BCH; LCW (duplex)
+via the 46-bit LCW permutation + BCH 29/465/41; **IRA** if the 3-way
+deinterleave of `data[0..96]` yields 3×32-bit blocks each passing
+ringalert BCH.
+
+- BCH polys (as integers, toolkit convention): ringalert/IBC **1207**,
+  messaging **1897**, IBC header **29**, LCW parts 29/465/41. Blocks
+  are 32 bits = 31 BCH bits (21 data + 10 check) + 1 even-parity bit.
+  Repair: try 1–2 bit flips until the syndrome clears; whole-block
+  even parity must hold.
+- Deinterleave operates on QPSK symbol pairs **with the two bits of
+  each pair swapped**, reading symbols from the end backwards:
+  2-way (64 bits → 2×32) alternating odd/even, 3-way (96 → 3×32).
+  After the leading IRA triple, the remainder deinterleaves 2-way per
+  64-bit chunk.
+- FILL pattern (64 bits, removed before ECC, ≤2 bitdiff per half):
+  `10100010011100111011111101101101 01010100010001011100001011100110`.
+
+### IRA (ring alert) payload — concatenated 21-bit BCH data blocks
+
+| Bits | Field |
+|---|---|
+| 0–6 | satellite id |
+| 7–12 | beam id |
+| 13–24 | pos_x (sign bit + 11) |
+| 25–36 | pos_y |
+| 37–48 | pos_z |
+| 49–55 | RA interval (90 ms units) |
+| 56 | broadcast timeslot |
+| 57 | EPI? |
+| 58–62 | BCH downlink sub-band |
+| 63… | pages, 42 bits each: tmsi(32) zero(2) msc_id(5) zero(3); all-1s page = END |
+
+lat = atan2(z, √(x²+y²)) (geocentric), lon = atan2(y, x),
+alt = 4·√(x²+y²+z²) km (radius; subtract ~6378−23 for height).
+
+## v1 scope in xng
+
+Single-channel decoder (DDC to 250 kHz / 10 sps) aimed at the fixed
+ring-alert channel: burst detect → tone CFO → RRC → coherent UW fit
+(timing/phase/CFO jointly, as in the VDL2/HFDL demods) → 1-sps
+decisions → DQPSK → bits → access check → IRA/IBC parse. Wideband
+burst hunting across the full band (gr-iridium style channelizer) is
+the wave-2 follow-up, as is IDA/SBD→ACARS (iridium-sniffer documents
+the chain: LCW FT==2/6/7, descramble 124-bit blocks, BCH(31,20),
+CRC-CCITT, multi-burst reassembly, SBD→ACARS via ARINC 622).
+
+Validation: iridium-toolkit's parser run offline as an oracle on
+generated frames (bit-identical field decode), vectors vendored into
+unit tests; live RA channel needs only an L-band antenna (bursts every
+few seconds worldwide).

--- a/proto/asf2.proto
+++ b/proto/asf2.proto
@@ -83,6 +83,11 @@ message HfdlBody {
   string details_json = 2;
 }
 
+message IridiumBody {
+  string kind = 1;
+  string details_json = 2;
+}
+
 message StdcBody {
   string name = 1;
   optional string text = 2;
@@ -114,6 +119,7 @@ message DecodedMessage {
     bool undecoded = 13;
     StdcBody stdc = 14;
     HfdlBody hfdl = 15;
+    IridiumBody iridium = 16;
   }
 }
 

--- a/src/commands/scan.rs
+++ b/src/commands/scan.rs
@@ -28,6 +28,8 @@ fn plan(mode: Mode) -> (f64, Vec<u64>) {
         Mode::Ais => (2_400_000.0, k(&[161_975, 162_025])),
         Mode::Adsb => (2_000_000.0, k(&[1_090_000])),
         Mode::StdC => (2_400_000.0, k(&[1_537_100, 1_537_700, 1_541_450])),
+        // Simplex ring-alert + primary messaging channels.
+        Mode::Iridium => (2_400_000.0, k(&[1_626_271, 1_626_437, 1_626_104])),
         Mode::Hfdl => (
             768_000.0,
             k(&[2_941, 2_944, 2_992, 2_998, 3_007, 3_016, 3_455, 3_497, 4_654,
@@ -129,6 +131,7 @@ pub fn run(
             Mode::Vdl2 => xng_mode_vdl2::CHANNEL_PASSBAND_HZ,
             Mode::Hfdl => xng_mode_hfdl::CHANNEL_PASSBAND_HZ,
             Mode::StdC => xng_mode_stdc::CHANNEL_PASSBAND_HZ,
+            Mode::Iridium => xng_mode_iridium::CHANNEL_PASSBAND_HZ,
             Mode::Adsb => 0.0,
             _ => xng_mode_acars::CHANNEL_PASSBAND_HZ,
         };

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,7 @@ struct Cli {
 
 #[derive(Args)]
 struct TuneOpts {
-    /// Decode mode: acars, vdl2, hfdl, aero, aero-c, std-c, ais, or adsb
+    /// Decode mode: acars, vdl2, hfdl, aero, aero-c, std-c, ais, adsb, or iridium
     #[arg(short, long, default_value = "acars")]
     mode: String,
     /// Capture sample rate in Hz (must be an integer multiple of the

--- a/src/outputs/console.rs
+++ b/src/outputs/console.rs
@@ -74,6 +74,24 @@ pub fn format_message(msg: &Message, fmt: ConsoleFormat) -> String {
                     }
                     s
                 }
+                MessageBody::Iridium { kind, details } => {
+                    let mut s = format!("IRIDIUM {kind}");
+                    for key in ["sat", "beam"] {
+                        if let Some(v) = details.get(key) {
+                            s.push_str(&format!(" {key}={v}"));
+                        }
+                    }
+                    if let (Some(lat), Some(lon)) = (
+                        details.get("lat").and_then(|v| v.as_f64()),
+                        details.get("lon").and_then(|v| v.as_f64()),
+                    ) {
+                        s.push_str(&format!(" pos={lat:.2},{lon:.2}"));
+                    }
+                    if let Some(p) = details.get("pages").and_then(|v| v.as_array()) {
+                        s.push_str(&format!(" pages={}", p.len()));
+                    }
+                    s
+                }
                 MessageBody::Hfdl { kind, details } => {
                     let mut s = format!("HFDL {kind}");
                     for key in ["gs_id", "flight", "icao", "frame_index"] {

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -14,6 +14,7 @@ use xng_mode_adsb::AdsbDecoder;
 use xng_mode_aero::{AeroBurstDecoder, AeroChannelDecoder};
 use xng_mode_ais::AisChannelDecoder;
 use xng_mode_hfdl::HfdlChannelDecoder;
+use xng_mode_iridium::IridiumChannelDecoder;
 use xng_mode_stdc::StdcChannelDecoder;
 use xng_mode_vdl2::Vdl2ChannelDecoder;
 use xng_sdr::{IqSource, SdrError};
@@ -82,6 +83,7 @@ pub(crate) enum ModeChannel {
     AeroBurst(AeroBurstDecoder),
     StdC(StdcChannelDecoder),
     Hfdl(HfdlChannelDecoder),
+    Iridium(IridiumChannelDecoder),
 }
 
 impl ModeChannel {
@@ -94,6 +96,7 @@ impl ModeChannel {
             Mode::AeroC => Ok(Self::AeroBurst(AeroBurstDecoder::new(sample_rate, offset)?)),
             Mode::StdC => Ok(Self::StdC(StdcChannelDecoder::new(sample_rate, offset)?)),
             Mode::Hfdl => Ok(Self::Hfdl(HfdlChannelDecoder::new(sample_rate, offset)?)),
+            Mode::Iridium => Ok(Self::Iridium(IridiumChannelDecoder::new(sample_rate, offset)?)),
             Mode::Adsb => {
                 if offset.abs() > 1e-6 {
                     return Err("Mode S uses the whole capture: tune -c to 1090.000M and pass --channels 1090".into());
@@ -111,6 +114,7 @@ impl ModeChannel {
             Mode::AeroL | Mode::AeroC => xng_mode_aero::CHANNEL_PASSBAND_HZ,
             Mode::StdC => xng_mode_stdc::CHANNEL_PASSBAND_HZ,
             Mode::Hfdl => xng_mode_hfdl::CHANNEL_PASSBAND_HZ,
+            Mode::Iridium => xng_mode_iridium::CHANNEL_PASSBAND_HZ,
             Mode::Adsb => 0.0, // wideband: offset must be 0, no DDC
             _ => xng_mode_acars::CHANNEL_PASSBAND_HZ,
         }
@@ -124,6 +128,7 @@ impl ModeChannel {
             Self::Aero(_) | Self::AeroBurst(_) => xng_mode_aero::CHANNEL_RATE,
             Self::StdC(_) => xng_mode_stdc::CHANNEL_RATE,
             Self::Hfdl(_) => xng_mode_hfdl::CHANNEL_RATE,
+            Self::Iridium(_) => xng_mode_iridium::CHANNEL_RATE,
             Self::Adsb(_) => 2_000_000.0,
         }
     }
@@ -138,6 +143,7 @@ impl ModeChannel {
             Self::AeroBurst(d) => d.level_dbfs(),
             Self::StdC(d) => d.level_dbfs(),
             Self::Hfdl(d) => d.level_dbfs(),
+            Self::Iridium(d) => d.level_dbfs(),
         }
     }
 
@@ -219,6 +225,16 @@ impl ModeChannel {
                     .map(|p| xng_mode_stdc::to_message(p, freq, level, prov.clone()))
                     .collect();
                 (msgs, seen, ok)
+            }
+            Self::Iridium(dec) => {
+                let frames = dec.process(iq);
+                let seen = frames.len() as u64;
+                let level = dec.level_dbfs();
+                let msgs = frames
+                    .iter()
+                    .map(|f| xng_mode_iridium::to_message(f, freq, level, prov.clone()))
+                    .collect();
+                (msgs, seen, seen)
             }
             Self::Hfdl(dec) => {
                 let events = dec.process(iq);


### PR DESCRIPTION
Wave 2 begins. New `xng-mode-iridium` crate decoding Iridium ring-alert (IRA) and broadcast frames on the fixed simplex channels — satellite id, beam, live ECEF→lat/lon/alt positions, and paging TMSIs — wired end-to-end: runtime, console (`IRIDIUM ring-alert sat=75 beam=21 pos=48.14,169.44 pages=2`), asf-2.0 protocol (new `IridiumBody`), and the scanner plan.

## Sources (per the repo's sourcing policy)
- **iridium-toolkit (BSD-2, ported with attribution)**: access codes, the symbol-pair deinterleavers, BCH(31,21)+parity blocks (polys 1207/1897), FILL removal, classification, IRA field layout.
- **gr-iridium / iridium-sniffer (GPL-3, facts only)**: PHY parameters — 25 ksym/s DQPSK, tone preamble + 12-symbol UW, `dqpsk_map=[0,2,3,1]`, burst limits. iridium-sniffer's ARCHITECTURE.md (thanks for the pointer — it's the best single pipeline reference) also documents the IDA/SBD→ACARS chain for the wideband follow-up.
- The demodulator itself is original: power-boxcar burst gate, tone-DFT coarse CFO, and the **coherent UW fit** (joint timing/phase/CFO least squares) that this session developed for VDL2/HFDL, now proving itself on a third modulation.

## Validation — oracle-grade
A generated ring-alert frame decodes **bit-identically** in iridium-toolkit's `bitsparser.py` (run offline as the reference oracle) and in this crate: `IRA: sat:075 beam:21 xyz=(-1411,+0263,+1602) pos=(+48.14/+169.44) alt=2248 RAI:33 ?01 bc_sb:22 P02: PAGE(tmsi:cafed00d…) {OK}` — every field agrees. The vector is vendored in tests, alongside an RF loopback through the full chain (CFO + noise). Interop note: gr-iridium `RAW:` lines carry each symbol's bits swapped; `RWA:` is the normalized form.

## Scope and next
v1 targets the fixed simplex channels (ring alert 1626.270833 MHz — bursts every few seconds worldwide, decodable with one DDC channel). The wave-2 follow-ups documented in docs/notes/IRIDIUM.md: wideband burst hunting across the full band (gr-iridium-style channelizer), IDA/SBD→ACARS, and an off-air L-band capture validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added native Iridium satellite message decoding support, including ring alerts and broadcasts
  * Enabled Iridium mode in scan command with pre-configured frequency plan
  * Messages now display satellite/beam information and decoded position coordinates (ring alerts)
  * Signal strength metrics integrated into Iridium message output

* **Documentation**
  * Added implementation notes and source attribution for Iridium decoding capabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->