### PR TITLE
survey: official soak-test command with per-channel reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ xng listen --sdr driver=rtlsdr -r 2400000 -c 131.500M \
 | **Validation** | Varies | Every decode core is validated against **real off-air recordings** or the reference implementation's own test vectors, with the captures vendored into CI so conventions can never silently regress |
 | **Application layer** | libacars bolted on, or nothing | Built-in ARINC 622 (ADS-C positions, **CPDLC rendered as readable text** — `REQUEST CLIMB TO FL360`), media advisory, H1 sublabels — shared by every ACARS carrier (VHF, VDL2, HFDL, Aero, Iridium SBD) |
 | **Outputs** | Per-tool formats | Pretty console, JSON/JSONL, acarsdec-compatible UDP, Airframes feeding, Prometheus metrics, and the multiplexed gRPC/QUIC **asf-2.0** protocol — identical across all modes |
-| **Tooling** | None | Interactive TUI (spectrum, waterfall, message browser), auto-scanner that proposes ready-to-run configs, IQ-file inspection, built-in self-test |
+| **Tooling** | None | Interactive TUI (spectrum, waterfall, message browser), auto-scanner that proposes ready-to-run configs, site survey/soak reports with gain tuning, IQ-file inspection, built-in self-test |
 | **License** | Mostly GPL | MIT/Apache-2.0 dual license; cores are clean-room from public specs or ported from MIT/BSD projects with attribution |
 
 The provenance discipline is part of the engineering: every core has a
@@ -124,6 +124,11 @@ xng selftest                      # end-to-end pipeline sanity check
 xng scan --sdr driver=rtlsdr --gain 28 --modes acars,vdl2,ais --dwell 120 --out scan.json
 # → prints verdicts per channel and ready-to-paste `xng listen` command lines.
 #   For HFDL it even learns new frequencies from the over-the-air system table.
+
+# Then qualify the site properly: a 15-minute soak across the whole ACARS
+# plan, with an empirical gain sweep first, ending in a per-channel report
+# (frames, CRC rate, levels) plus reception advice:
+xng survey --sdr driver=rtlsdr --mode acars --tune-gain --out survey.json
 ```
 
 ## Examples
@@ -171,6 +176,28 @@ xng listen --sdr driver=rtlsdr --mode ais -r 2400000 -c 162.000M \
 
 # Mode S / ADS-B (consumes the whole capture)
 xng listen --sdr driver=rtlsdr --mode adsb -r 2000000 -c 1090.000M --channels 1090
+```
+
+### Site survey / soak test
+
+`xng survey` qualifies a site for one mode: it monitors every channel in
+the mode's plan (rotating capture windows when the plan exceeds the SDR
+bandwidth), prints interim tables as it goes, and ends with per-channel
+statistics — frames, CRC pass rate, frames/min, levels — plus reception
+advice and a ready-to-run `listen` command. Ctrl-C ends early but still
+reports.
+
+```bash
+# 15-minute ACARS soak over the full plan, gain picked empirically
+xng survey --sdr driver=rtlsdr --mode acars --tune-gain --out survey.json
+
+# Scan first, then soak only active channels — plus the mode's core
+# worldwide channels, which short scans routinely undersell
+xng survey --sdr driver=rtlsdr --gain 28 --mode vdl2 --scan --duration 1800
+
+# Specific channels, live message output, messages archived to JSONL
+xng survey --sdr driver=rtlsdr --gain 28 --mode acars --duration 3600 \
+    --channels 130.025,131.550,131.725 --show-messages --jsonl soak.jsonl
 ```
 
 ### Recordings

--- a/crates/xng-sdr/src/soapy.rs
+++ b/crates/xng-sdr/src/soapy.rs
@@ -67,6 +67,15 @@ impl SoapyIqSource {
     }
 }
 
+impl Drop for SoapyIqSource {
+    fn drop(&mut self) {
+        // Deactivate before the stream closes: skipping this leaves some
+        // drivers (rtlsdr) wedged for the next open — observed as
+        // stream-read timeouts when sequential dwells reuse one dongle.
+        let _ = self.stream.deactivate(None);
+    }
+}
+
 impl IqSource for SoapyIqSource {
     fn sample_rate(&self) -> f64 {
         self.sample_rate

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -4,3 +4,4 @@ pub mod ingest;
 pub mod iq_info;
 pub mod scan;
 pub mod selftest;
+pub mod survey;

--- a/src/commands/scan.rs
+++ b/src/commands/scan.rs
@@ -13,7 +13,7 @@ use xng_types::{Mode, StationIdentity};
 
 /// Built-in frequency plans (kHz). Curated, worldwide-common channels;
 /// the HFDL list follows the public system table.
-fn plan(mode: Mode) -> (f64, Vec<u64>) {
+pub(crate) fn plan(mode: Mode) -> (f64, Vec<u64>) {
     let k = |v: &[u32]| v.iter().map(|&f| f as u64 * 1_000).collect::<Vec<u64>>();
     match mode {
         Mode::AcarsPoa => (
@@ -50,8 +50,40 @@ fn plan(mode: Mode) -> (f64, Vec<u64>) {
     }
 }
 
+/// Channels worth watching even when a short scan finds them quiet:
+/// the worldwide/primary frequencies where traffic eventually shows up.
+/// (A 90 s dwell routinely undersells a site — observed first-hand: the
+/// channels busiest over 30 minutes had been scored quiet.)
+pub(crate) fn core_channels(mode: Mode) -> Vec<u64> {
+    let k = |v: &[u32]| v.iter().map(|&f| f as u64 * 1_000).collect::<Vec<u64>>();
+    match mode {
+        // Worldwide primary + the common US/EU secondaries.
+        Mode::AcarsPoa => k(&[131_550, 130_025, 131_725, 131_125]),
+        // The worldwide Common Signaling Channel + busiest secondary.
+        Mode::Vdl2 => k(&[136_975, 136_650]),
+        Mode::Ais => k(&[161_975, 162_025]),
+        Mode::Adsb => k(&[1_090_000]),
+        // Primary ring-alert channel.
+        Mode::Iridium => k(&[1_626_271]),
+        _ => Vec::new(),
+    }
+}
+
+/// Per-channel passband the DDC must preserve, by mode.
+pub(crate) fn passband(mode: Mode) -> f64 {
+    match mode {
+        Mode::Ais => xng_mode_ais::CHANNEL_PASSBAND_HZ,
+        Mode::Vdl2 => xng_mode_vdl2::CHANNEL_PASSBAND_HZ,
+        Mode::Hfdl => xng_mode_hfdl::CHANNEL_PASSBAND_HZ,
+        Mode::StdC => xng_mode_stdc::CHANNEL_PASSBAND_HZ,
+        Mode::Iridium => xng_mode_iridium::CHANNEL_PASSBAND_HZ,
+        Mode::Adsb => 0.0,
+        _ => xng_mode_acars::CHANNEL_PASSBAND_HZ,
+    }
+}
+
 /// Cluster channels into capture-width groups.
-fn group_channels(channels: &[u64], sample_rate: f64, passband: f64) -> Vec<(u64, Vec<u64>)> {
+pub(crate) fn group_channels(channels: &[u64], sample_rate: f64, passband: f64) -> Vec<(u64, Vec<u64>)> {
     let usable = sample_rate * 0.8 - 2.0 * passband;
     let mut sorted = channels.to_vec();
     sorted.sort_unstable();
@@ -126,16 +158,7 @@ pub fn run(
             tracing::warn!("no built-in frequency plan for mode {mode}; skipping");
             continue;
         }
-        let passband = match mode {
-            Mode::Ais => xng_mode_ais::CHANNEL_PASSBAND_HZ,
-            Mode::Vdl2 => xng_mode_vdl2::CHANNEL_PASSBAND_HZ,
-            Mode::Hfdl => xng_mode_hfdl::CHANNEL_PASSBAND_HZ,
-            Mode::StdC => xng_mode_stdc::CHANNEL_PASSBAND_HZ,
-            Mode::Iridium => xng_mode_iridium::CHANNEL_PASSBAND_HZ,
-            Mode::Adsb => 0.0,
-            _ => xng_mode_acars::CHANNEL_PASSBAND_HZ,
-        };
-        let groups = group_channels(&channels, rate, passband);
+        let groups = group_channels(&channels, rate, passband(mode));
         groups_total += groups.len();
         plans.push((mode, rate, groups));
     }
@@ -270,7 +293,7 @@ pub fn run(
     Ok(())
 }
 
-fn scan_group(
+pub(crate) fn scan_group(
     sdr: &str,
     gain: Option<f64>,
     mode: Mode,

--- a/src/commands/survey.rs
+++ b/src/commands/survey.rs
@@ -1,0 +1,687 @@
+//! `xng survey` — official soak test for one mode: monitor and decode every
+//! channel that fits the SDR's bandwidth for a sustained period, then report
+//! per-channel statistics (frames, CRC, levels, rates) plus gain/SDR advice.
+//!
+//! Where `xng scan` answers "what's receivable here?" with a short dwell per
+//! group, `survey` answers "how well does this site/configuration actually
+//! perform?" — long dwells, full-plan coverage (rotating capture windows when
+//! the plan exceeds the bandwidth), interim progress tables, and an optional
+//! gain sweep that picks the best setting empirically.
+
+use crate::bus::MessageBus;
+use crate::commands::scan;
+use crate::outputs::console::{ConsoleFormat, format_message};
+use crate::runtime::{self, SessionConfig};
+use serde::Serialize;
+use std::io::Write;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::{Duration, Instant};
+use xng_types::{Mode, StationIdentity};
+
+pub struct SurveyOpts {
+    pub sdr: String,
+    pub gain: Option<f64>,
+    pub mode: Mode,
+    pub sample_rate: Option<f64>,
+    /// Explicit channels (Hz); full built-in plan when empty.
+    pub channels: Vec<u64>,
+    pub duration_secs: u64,
+    pub interim_secs: u64,
+    /// Run a scan pre-pass and survey only active/core channels.
+    pub scan_first: bool,
+    pub scan_dwell_secs: u64,
+    /// Sweep gain settings empirically before the survey proper.
+    pub tune_gain: bool,
+    pub tune_dwell_secs: u64,
+    /// Per-visit dwell when rotating between capture windows.
+    pub rotate_dwell_secs: u64,
+    pub show_messages: bool,
+    pub jsonl: Option<std::path::PathBuf>,
+    pub out_json: Option<std::path::PathBuf>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct SurveyChannel {
+    frequency_hz: u64,
+    listen_secs: f64,
+    frames: u64,
+    crc_ok: u64,
+    crc_bad: u64,
+    ok_pct: f64,
+    frames_per_min: f64,
+    level_dbfs: f32,
+    verdict: &'static str,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct SweepRow {
+    gain_db: f64,
+    frames: u64,
+    crc_ok: u64,
+    mean_level_dbfs: f32,
+}
+
+#[derive(Serialize)]
+struct SurveyReport {
+    mode: String,
+    duration_secs: f64,
+    sample_rate: f64,
+    gain: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    sweep: Vec<SweepRow>,
+    channels: Vec<SurveyChannel>,
+    advice: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    proposal: Option<String>,
+}
+
+/// Accumulated per-channel state across rotation visits.
+#[derive(Default, Clone)]
+struct ChanAcc {
+    frames: u64,
+    crc_ok: u64,
+    listen_secs: f64,
+    level_dbfs: f32,
+}
+
+pub fn run(opts: SurveyOpts) -> anyhow::Result<()> {
+    let mode = opts.mode;
+    let (plan_rate, plan_channels) = scan::plan(mode);
+    let rate = opts.sample_rate.unwrap_or(plan_rate);
+    let passband = scan::passband(mode);
+
+    // Ctrl-C ends the survey early but still produces the report.
+    let abort = Arc::new(AtomicBool::new(false));
+    {
+        let abort = abort.clone();
+        std::thread::spawn(move || {
+            let rt = tokio::runtime::Builder::new_current_thread().enable_io().build();
+            if let Ok(rt) = rt {
+                let _ = rt.block_on(tokio::signal::ctrl_c());
+                eprintln!("\ninterrupted — finishing up and reporting");
+                abort.store(true, Ordering::Relaxed);
+            }
+        });
+    }
+
+    // ── Channel set ────────────────────────────────────────────────────
+    let channels: Vec<u64> = if !opts.channels.is_empty() {
+        opts.channels.clone()
+    } else if opts.scan_first {
+        scan_prepass(&opts, mode, rate, &plan_channels, passband, &abort)?
+    } else {
+        plan_channels.clone()
+    };
+    anyhow::ensure!(
+        !channels.is_empty(),
+        "no channels to survey: mode {mode} has no built-in plan; pass --channels"
+    );
+    let groups = scan::group_channels(&channels, rate, passband);
+    println!(
+        "surveying {} channel(s) in {} capture window(s), {}s total",
+        channels.len(),
+        groups.len(),
+        opts.duration_secs
+    );
+
+    // ── Gain ───────────────────────────────────────────────────────────
+    let mut sweep_rows = Vec::new();
+    let (gain, gain_desc) = if opts.tune_gain && !abort.load(Ordering::Relaxed) {
+        let (g, rows) = sweep_gain(&opts, mode, rate, &groups, &abort)?;
+        sweep_rows = rows;
+        (Some(g), format!("{g} dB (swept)"))
+    } else {
+        match opts.gain {
+            Some(g) => (Some(g), format!("{g} dB (fixed)")),
+            None => (None, "hardware AGC".to_string()),
+        }
+    };
+
+    // ── Survey loop: rotate capture windows until the time is spent ────
+    let bus = MessageBus::new();
+    let mut rx = bus.subscribe();
+    let mut jsonl = match &opts.jsonl {
+        Some(p) => Some(std::io::BufWriter::new(
+            std::fs::OpenOptions::new().create(true).append(true).open(p)?,
+        )),
+        None => None,
+    };
+
+    let mut acc: std::collections::BTreeMap<u64, ChanAcc> = Default::default();
+    let started = Instant::now();
+    let deadline = started + Duration::from_secs(opts.duration_secs);
+    let mut next_interim = started + Duration::from_secs(opts.interim_secs);
+    let mut gi = 0usize;
+    while Instant::now() < deadline && !abort.load(Ordering::Relaxed) {
+        let (center, group) = &groups[gi % groups.len()];
+        gi += 1;
+        let remaining = deadline.saturating_duration_since(Instant::now()).as_secs();
+        // A single window has nothing to rotate to: dwell straight through
+        // to the next interim boundary instead of churning the device.
+        let visit = if groups.len() == 1 {
+            remaining.min(opts.interim_secs)
+        } else {
+            remaining.min(opts.rotate_dwell_secs)
+        };
+        if visit == 0 {
+            break;
+        }
+        // Settle between reopen cycles (multi-window rotation reuses the
+        // same device back-to-back).
+        if gi > 1 {
+            std::thread::sleep(Duration::from_millis(500));
+        }
+        let t0 = Instant::now();
+        match dwell(&opts.sdr, gain, mode, rate, *center, group, visit, &abort, &bus) {
+            Ok(stats) => {
+                let secs = t0.elapsed().as_secs_f64();
+                for (freq, frames, ok, level) in stats {
+                    let a = acc.entry(freq).or_default();
+                    a.frames += frames;
+                    a.crc_ok += ok;
+                    a.listen_secs += secs;
+                    a.level_dbfs = level;
+                }
+            }
+            Err(e) => {
+                println!("window @ {:.3} MHz skipped: {e}", *center as f64 / 1e6);
+                std::thread::sleep(Duration::from_secs(2));
+            }
+        }
+        drain_messages(&mut rx, opts.show_messages, jsonl.as_mut());
+        if Instant::now() >= next_interim && Instant::now() < deadline {
+            let elapsed = started.elapsed().as_secs();
+            println!("\n── interim @ {elapsed}s ──");
+            print_table(&summarize(&acc));
+            next_interim += Duration::from_secs(opts.interim_secs);
+        }
+    }
+    if let Some(w) = jsonl.as_mut() {
+        let _ = w.flush();
+    }
+
+    // ── Report ─────────────────────────────────────────────────────────
+    let results = summarize(&acc);
+    let actual = started.elapsed().as_secs_f64();
+    println!("\n══ survey report: {mode}, {:.0}s, gain {gain_desc} ══", actual);
+    if !sweep_rows.is_empty() {
+        println!("gain sweep:");
+        for r in &sweep_rows {
+            println!(
+                "  {:>5.1} dB: {:>4} frames, {:>4} ok, mean level {:>6.1} dBFS",
+                r.gain_db, r.frames, r.crc_ok, r.mean_level_dbfs
+            );
+        }
+    }
+    print_table(&results);
+
+    let advice = advise(opts.gain.is_none() && !opts.tune_gain, &results);
+    if !advice.is_empty() {
+        println!("\nsuggestions:");
+        for a in &advice {
+            println!("  • {a}");
+        }
+    }
+
+    let proposal = proposal_command(&opts.sdr, mode, rate, gain, &results);
+    if let Some(p) = &proposal {
+        println!("\nproposed configuration:\n  {p}");
+    }
+
+    if let Some(path) = &opts.out_json {
+        let report = SurveyReport {
+            mode: mode.as_str().to_string(),
+            duration_secs: actual,
+            sample_rate: rate,
+            gain: gain_desc,
+            sweep: sweep_rows,
+            channels: results,
+            advice,
+            proposal,
+        };
+        std::fs::write(path, serde_json::to_string_pretty(&report)?)?;
+        println!("\nreport written to {}", path.display());
+    }
+    Ok(())
+}
+
+/// Scan pre-pass: short dwell over the full plan, then survey the channels
+/// that showed life **plus** the mode's core tier — the worldwide/primary
+/// frequencies a short dwell routinely undersells.
+fn scan_prepass(
+    opts: &SurveyOpts,
+    mode: Mode,
+    rate: f64,
+    plan_channels: &[u64],
+    passband: f64,
+    abort: &Arc<AtomicBool>,
+) -> anyhow::Result<Vec<u64>> {
+    let groups = scan::group_channels(plan_channels, rate, passband);
+    println!(
+        "scan pre-pass: {} group(s), {}s dwell each",
+        groups.len(),
+        opts.scan_dwell_secs
+    );
+    let mut results = Vec::new();
+    for (center, group) in &groups {
+        if abort.load(Ordering::Relaxed) {
+            break;
+        }
+        println!("→ {:.3} MHz", *center as f64 / 1e6);
+        match scan::scan_group(&opts.sdr, opts.gain, mode, rate, *center, group, opts.scan_dwell_secs)
+        {
+            Ok((mut r, _)) => results.append(&mut r),
+            Err(e) => println!("  group skipped: {e}"),
+        }
+    }
+    let mut levels: Vec<f32> = results.iter().map(|r| r.level_dbfs).collect();
+    levels.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    let median = levels.get(levels.len() / 2).copied().unwrap_or(-120.0);
+
+    let mut keep: std::collections::BTreeSet<u64> = results
+        .iter()
+        .filter(|r| r.frames > 0 || r.level_dbfs > median + 6.0)
+        .map(|r| r.frequency_hz)
+        .collect();
+    let active = keep.len();
+    let core: Vec<u64> = scan::core_channels(mode)
+        .into_iter()
+        .filter(|f| plan_channels.contains(f) && keep.insert(*f))
+        .collect();
+    if !core.is_empty() {
+        let list: Vec<String> = core.iter().map(|&f| format!("{:.3}", f as f64 / 1e6)).collect();
+        println!("including {} quiet-but-core channel(s) anyway: {}", core.len(), list.join(", "));
+    }
+    println!("pre-pass kept {} channel(s) ({active} with signal + {} core)", keep.len(), core.len());
+    Ok(keep.into_iter().collect())
+}
+
+/// Step a generic dB ladder on the busiest window, score each setting, and
+/// pick the winner: most CRC-verified frames, then most frames, then the
+/// healthiest mean level (closest to −35 dBFS — strong but far from
+/// clipping).
+fn sweep_gain(
+    opts: &SurveyOpts,
+    mode: Mode,
+    rate: f64,
+    groups: &[(u64, Vec<u64>)],
+    abort: &Arc<AtomicBool>,
+) -> anyhow::Result<(f64, Vec<SweepRow>)> {
+    const LADDER: [f64; 5] = [12.0, 21.0, 30.0, 39.0, 48.0];
+    let (center, group) =
+        groups.iter().max_by_key(|(_, g)| g.len()).expect("at least one group");
+    println!(
+        "gain sweep on {:.3} MHz window: {:?} dB, {}s each",
+        *center as f64 / 1e6,
+        LADDER,
+        opts.tune_dwell_secs
+    );
+    let bus = MessageBus::new();
+    let mut rx = bus.subscribe();
+    let mut rows = Vec::new();
+    for &g in &LADDER {
+        if abort.load(Ordering::Relaxed) {
+            break;
+        }
+        // Let the device settle between rapid reopen cycles.
+        std::thread::sleep(Duration::from_millis(500));
+        match dwell(&opts.sdr, Some(g), mode, rate, *center, group, opts.tune_dwell_secs, abort, &bus)
+        {
+            Ok(stats) => {
+                let frames: u64 = stats.iter().map(|s| s.1).sum();
+                let ok: u64 = stats.iter().map(|s| s.2).sum();
+                let mean = stats.iter().map(|s| s.3).sum::<f32>() / stats.len().max(1) as f32;
+                println!("  {g:>5.1} dB: {frames} frames, {ok} ok, mean {mean:.1} dBFS");
+                rows.push(SweepRow { gain_db: g, frames, crc_ok: ok, mean_level_dbfs: mean });
+            }
+            Err(e) => println!("  {g:>5.1} dB: failed ({e})"),
+        }
+        drain_messages(&mut rx, false, None);
+    }
+    anyhow::ensure!(!rows.is_empty(), "gain sweep collected no data");
+    let best = pick_gain(&rows);
+    println!("→ using {best} dB");
+    Ok((best, rows))
+}
+
+/// Decode counts only outrank level health once there's enough traffic to
+/// be statistics rather than luck — bursty modes can hand any gain setting
+/// a frame or two in a short dwell (observed live: a 15 s dwell crowned
+/// 12 dB on two lucky frames, leaving every channel at −66 dBFS). Below
+/// the threshold, prefer the mean level closest to −35 dBFS: strong ADC
+/// loading with ample clipping headroom.
+fn pick_gain(rows: &[SweepRow]) -> f64 {
+    const MIN_FRAMES_FOR_DECODE_SCORING: u64 = 5;
+    rows.iter()
+        .max_by(|a, b| {
+            let key = |r: &SweepRow| {
+                let trusted = r.frames >= MIN_FRAMES_FOR_DECODE_SCORING;
+                (
+                    if trusted { r.crc_ok } else { 0 },
+                    if trusted { r.frames } else { 0 },
+                    -((r.mean_level_dbfs + 35.0).abs() * 10.0) as i64,
+                )
+            };
+            key(a).cmp(&key(b))
+        })
+        .map(|r| r.gain_db)
+        .expect("non-empty rows")
+}
+
+/// One capture-window visit: open, decode for `secs` (or until abort), and
+/// return per-channel (freq, frames, crc_ok, level_dbfs).
+#[allow(clippy::too_many_arguments)]
+fn dwell(
+    sdr: &str,
+    gain: Option<f64>,
+    mode: Mode,
+    rate: f64,
+    center: u64,
+    channels: &[u64],
+    secs: u64,
+    abort: &Arc<AtomicBool>,
+    bus: &MessageBus,
+) -> anyhow::Result<Vec<(u64, u64, u64, f32)>> {
+    let (mut source, _) = crate::open_sdr(sdr, rate, center, gain)?;
+    let cfg = SessionConfig {
+        mode,
+        center_hz: center,
+        channels_hz: channels.to_vec(),
+        station_ident: "XNG-SURVEY".into(),
+        sdr: None,
+        outputs: runtime::OutputConfig {
+            console: ConsoleFormat::Pretty,
+            jsonl: None,
+            udp: vec![],
+            asf2_grpc: None,
+            asf2_quic: None,
+            asf2_quic_trust: crate::outputs::asf2_quic::TrustMode::SystemRoots,
+            metrics: None,
+        },
+    };
+    let decoders = runtime::build_decoders(rate, center, &cfg)?;
+    let live = runtime::LiveState::new();
+    let stop = Arc::new(AtomicBool::new(false));
+    let deadline = Instant::now() + Duration::from_secs(secs);
+    let stop_thread = {
+        let stop = stop.clone();
+        let abort = abort.clone();
+        std::thread::spawn(move || {
+            while Instant::now() < deadline && !abort.load(Ordering::Relaxed) {
+                std::thread::sleep(Duration::from_millis(100));
+            }
+            stop.store(true, Ordering::Relaxed);
+        })
+    };
+    let stats = runtime::decode_loop(
+        &mut *source,
+        decoders,
+        StationIdentity::new("XNG-SURVEY"),
+        None,
+        bus.clone(),
+        stop,
+        Some((live.clone(), center, rate)),
+    )?;
+    let _ = stop_thread.join();
+    let levels = live.stats.lock().unwrap().clone();
+    Ok(stats
+        .iter()
+        .enumerate()
+        .map(|(i, &(freq, frames, ok))| {
+            (freq, frames, ok, levels.get(i).map(|l| l.3).unwrap_or(-120.0))
+        })
+        .collect())
+}
+
+fn drain_messages(
+    rx: &mut tokio::sync::broadcast::Receiver<Arc<xng_types::Message>>,
+    show: bool,
+    mut jsonl: Option<&mut std::io::BufWriter<std::fs::File>>,
+) {
+    use tokio::sync::broadcast::error::TryRecvError;
+    loop {
+        match rx.try_recv() {
+            Ok(msg) => {
+                if show {
+                    println!("{}", format_message(&msg, ConsoleFormat::Pretty));
+                }
+                if let Some(w) = jsonl.as_deref_mut() {
+                    if let Ok(line) = serde_json::to_string(&*msg) {
+                        let _ = writeln!(w, "{line}");
+                    }
+                }
+            }
+            Err(TryRecvError::Lagged(_)) => continue,
+            Err(_) => break,
+        }
+    }
+}
+
+fn summarize(acc: &std::collections::BTreeMap<u64, ChanAcc>) -> Vec<SurveyChannel> {
+    let mut levels: Vec<f32> = acc.values().map(|a| a.level_dbfs).collect();
+    levels.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    let median = levels.get(levels.len() / 2).copied().unwrap_or(-120.0);
+    acc.iter()
+        .map(|(&freq, a)| {
+            let bad = a.frames - a.crc_ok;
+            let mins = (a.listen_secs / 60.0).max(1e-9);
+            SurveyChannel {
+                frequency_hz: freq,
+                listen_secs: a.listen_secs,
+                frames: a.frames,
+                crc_ok: a.crc_ok,
+                crc_bad: bad,
+                ok_pct: if a.frames > 0 {
+                    a.crc_ok as f64 / a.frames as f64 * 100.0
+                } else {
+                    0.0
+                },
+                frames_per_min: a.frames as f64 / mins,
+                level_dbfs: a.level_dbfs,
+                verdict: if a.crc_ok > 0 {
+                    "ACTIVE"
+                } else if a.frames > 0 {
+                    "partial"
+                } else if a.level_dbfs > median + 6.0 {
+                    "signal?"
+                } else {
+                    "quiet"
+                },
+            }
+        })
+        .collect()
+}
+
+fn print_table(results: &[SurveyChannel]) {
+    println!(
+        "{:<10} {:>8} {:>7} {:>6} {:>6} {:>6} {:>7} {:>8}  verdict",
+        "freq MHz", "listen s", "frames", "ok", "bad", "ok%", "fr/min", "dBFS"
+    );
+    for r in results {
+        println!(
+            "{:<10.3} {:>8.0} {:>7} {:>6} {:>6} {:>6.0} {:>7.2} {:>8.1}  {}",
+            r.frequency_hz as f64 / 1e6,
+            r.listen_secs,
+            r.frames,
+            r.crc_ok,
+            r.crc_bad,
+            r.ok_pct,
+            r.frames_per_min,
+            r.level_dbfs,
+            r.verdict
+        );
+    }
+    let frames: u64 = results.iter().map(|r| r.frames).sum();
+    let ok: u64 = results.iter().map(|r| r.crc_ok).sum();
+    println!(
+        "{:<10} {:>8} {:>7} {:>6} {:>6} {:>6.0}",
+        "total",
+        "",
+        frames,
+        ok,
+        frames - ok,
+        if frames > 0 { ok as f64 / frames as f64 * 100.0 } else { 0.0 }
+    );
+}
+
+/// Reception advice from the final statistics. Pure so it's testable.
+fn advise(used_agc: bool, results: &[SurveyChannel]) -> Vec<String> {
+    let mut advice = Vec::new();
+    if results.is_empty() {
+        return advice;
+    }
+    let max_level = results.iter().map(|r| r.level_dbfs).fold(f32::MIN, f32::max);
+    let frames: u64 = results.iter().map(|r| r.frames).sum();
+    let ok: u64 = results.iter().map(|r| r.crc_ok).sum();
+
+    if max_level < -55.0 {
+        advice.push(format!(
+            "every channel sits below \u{2212}55 dBFS (max {max_level:.1}): weak signals \u{2014} \
+             increase gain, or improve the antenna / add an LNA"
+        ));
+    }
+    if max_level > -12.0 {
+        advice.push(format!(
+            "strongest channel is at {max_level:.1} dBFS, close to full scale: if CRC failures \
+             are high, reduce gain to avoid intermodulation"
+        ));
+    }
+    for r in results {
+        if r.frames >= 5 && r.crc_ok == 0 && r.level_dbfs > -50.0 {
+            advice.push(format!(
+                "{:.3} MHz triggers the demodulator ({} frames) but nothing passes CRC at a \
+                 healthy level: likely interference or a non-{} signal on that frequency",
+                r.frequency_hz as f64 / 1e6,
+                r.frames,
+                "matching"
+            ));
+        }
+    }
+    if frames >= 20 && ok as f64 / frames as f64 * 100.0 < 50.0 {
+        advice.push(format!(
+            "overall CRC pass rate is {:.0}% \u{2014} marginal SNR; small gain changes \
+             (\u{00b1}3\u{2013}6 dB) or antenna placement usually dominate here",
+            ok as f64 / frames as f64 * 100.0
+        ));
+    }
+    if used_agc {
+        advice.push(
+            "gain was hardware AGC: run again with --tune-gain to pick a fixed gain empirically"
+                .to_string(),
+        );
+    }
+    advice
+}
+
+fn proposal_command(
+    sdr: &str,
+    mode: Mode,
+    rate: f64,
+    gain: Option<f64>,
+    results: &[SurveyChannel],
+) -> Option<String> {
+    let active: Vec<u64> = results
+        .iter()
+        .filter(|r| r.verdict == "ACTIVE")
+        .map(|r| r.frequency_hz)
+        .collect();
+    if active.is_empty() {
+        return None;
+    }
+    let center = (active.iter().min().unwrap() + active.iter().max().unwrap()) / 2;
+    let center = if active.contains(&center) { center + 25_000 } else { center };
+    let chans: Vec<String> = active.iter().map(|&f| format!("{:.3}", f as f64 / 1e6)).collect();
+    let gain_arg = gain.map(|g| format!(" --gain {g}")).unwrap_or_default();
+    Some(format!(
+        "xng listen --sdr '{sdr}'{gain_arg} --mode {mode} -r {} -c {:.3}M --channels {}",
+        rate as u64,
+        center as f64 / 1e6,
+        chans.join(",")
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn chan(freq: u64, frames: u64, ok: u64, level: f32) -> SurveyChannel {
+        SurveyChannel {
+            frequency_hz: freq,
+            listen_secs: 600.0,
+            frames,
+            crc_ok: ok,
+            crc_bad: frames - ok,
+            ok_pct: if frames > 0 { ok as f64 / frames as f64 * 100.0 } else { 0.0 },
+            frames_per_min: frames as f64 / 10.0,
+            level_dbfs: level,
+            verdict: if ok > 0 { "ACTIVE" } else { "quiet" },
+        }
+    }
+
+    #[test]
+    fn weak_site_advice() {
+        let advice = advise(false, &[chan(131_550_000, 2, 1, -62.0), chan(130_025_000, 0, 0, -70.0)]);
+        assert!(advice.iter().any(|a| a.contains("weak signals")), "{advice:?}");
+    }
+
+    #[test]
+    fn clipping_advice() {
+        let advice = advise(false, &[chan(131_550_000, 50, 10, -6.0)]);
+        assert!(advice.iter().any(|a| a.contains("full scale")), "{advice:?}");
+    }
+
+    #[test]
+    fn interference_and_agc_advice() {
+        let advice = advise(true, &[chan(131_550_000, 9, 0, -40.0)]);
+        assert!(advice.iter().any(|a| a.contains("nothing passes CRC")), "{advice:?}");
+        assert!(advice.iter().any(|a| a.contains("--tune-gain")), "{advice:?}");
+    }
+
+    #[test]
+    fn healthy_site_gets_no_scolding() {
+        let advice = advise(false, &[chan(131_550_000, 40, 36, -38.0)]);
+        assert!(advice.is_empty(), "{advice:?}");
+    }
+
+    #[test]
+    fn sweep_prefers_decodes_then_level() {
+        let rows = vec![
+            SweepRow { gain_db: 12.0, frames: 3, crc_ok: 1, mean_level_dbfs: -60.0 },
+            SweepRow { gain_db: 30.0, frames: 8, crc_ok: 6, mean_level_dbfs: -40.0 },
+            SweepRow { gain_db: 48.0, frames: 9, crc_ok: 6, mean_level_dbfs: -8.0 },
+        ];
+        // 30 and 48 dB tie on decodes; 48 has more frames so it wins the
+        // second criterion before level is consulted.
+        assert_eq!(pick_gain(&rows), 48.0);
+        let rows2 = vec![
+            SweepRow { gain_db: 30.0, frames: 8, crc_ok: 6, mean_level_dbfs: -40.0 },
+            SweepRow { gain_db: 48.0, frames: 8, crc_ok: 6, mean_level_dbfs: -8.0 },
+        ];
+        // Full tie on decodes and frames: the healthier level decides.
+        assert_eq!(pick_gain(&rows2), 30.0);
+    }
+
+    #[test]
+    fn sweep_ignores_lucky_frames_on_sparse_traffic() {
+        // The live-observed failure: 2 lucky decodes at low gain must not
+        // outrank healthy ADC loading when traffic is too sparse to score.
+        let rows = vec![
+            SweepRow { gain_db: 12.0, frames: 3, crc_ok: 2, mean_level_dbfs: -66.0 },
+            SweepRow { gain_db: 21.0, frames: 1, crc_ok: 1, mean_level_dbfs: -59.0 },
+            SweepRow { gain_db: 48.0, frames: 1, crc_ok: 1, mean_level_dbfs: -35.0 },
+        ];
+        assert_eq!(pick_gain(&rows), 48.0);
+    }
+
+    #[test]
+    fn proposal_only_from_active_channels() {
+        let results =
+            vec![chan(131_550_000, 40, 36, -38.0), chan(130_025_000, 0, 0, -60.0)];
+        let p = proposal_command("driver=rtlsdr", Mode::AcarsPoa, 2_400_000.0, Some(28.0), &results)
+            .unwrap();
+        assert!(p.contains("--channels 131.550"), "{p}");
+        assert!(!p.contains("130.025"), "{p}");
+        assert!(p.contains("--gain 28"), "{p}");
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -185,6 +185,58 @@ enum Command {
         #[arg(last = true)]
         command: Vec<String>,
     },
+    /// Soak-test one mode: monitor all channels that fit the SDR bandwidth
+    /// for a sustained period, then report per-channel statistics and
+    /// reception advice
+    Survey {
+        /// SDR device args (as for listen)
+        #[arg(long, default_value = "")]
+        sdr: String,
+        /// Tuner gain in dB (hardware AGC when omitted; see --tune-gain)
+        #[arg(short, long)]
+        gain: Option<f64>,
+        /// Mode to survey: acars, vdl2, hfdl, aero, std-c, ais, adsb, iridium
+        #[arg(short, long, default_value = "acars")]
+        mode: String,
+        /// Capture sample rate in Hz (the mode's plan default when omitted)
+        #[arg(short = 'r', long)]
+        sample_rate: Option<f64>,
+        /// Survey only these channels (MHz/k/M suffixes accepted);
+        /// the full built-in plan when omitted
+        #[arg(long, value_delimiter = ',')]
+        channels: Vec<String>,
+        /// Total survey duration in seconds
+        #[arg(long, default_value_t = 900)]
+        duration: u64,
+        /// Print an interim statistics table every N seconds
+        #[arg(long, default_value_t = 300)]
+        interim: u64,
+        /// Run a scan pre-pass and keep active channels (plus the mode's
+        /// core worldwide channels, which short scans routinely undersell)
+        #[arg(long)]
+        scan: bool,
+        /// Dwell per capture window during the scan pre-pass, seconds
+        #[arg(long, default_value_t = 90)]
+        scan_dwell: u64,
+        /// Sweep gain settings empirically first and use the best
+        #[arg(long)]
+        tune_gain: bool,
+        /// Dwell per gain step during --tune-gain, seconds
+        #[arg(long, default_value_t = 20)]
+        tune_dwell: u64,
+        /// Dwell per visit when rotating between capture windows, seconds
+        #[arg(long, default_value_t = 60)]
+        rotate_dwell: u64,
+        /// Print decoded messages live during the survey
+        #[arg(long)]
+        show_messages: bool,
+        /// Also write decoded messages to this JSONL file
+        #[arg(long)]
+        jsonl: Option<PathBuf>,
+        /// Write the full survey report as JSON
+        #[arg(long)]
+        out: Option<PathBuf>,
+    },
     /// Auto-scan known frequency plans and propose a configuration
     Scan {
         /// SoapySDR device args
@@ -310,6 +362,46 @@ fn main() -> anyhow::Result<()> {
                 format.parse().map_err(|e: String| anyhow::anyhow!(e))?;
             let (outputs, station_ident) = output.build()?;
             commands::extern_cmd::run(fmt, &command, station_ident, outputs)
+        }
+        Command::Survey {
+            sdr,
+            gain,
+            mode,
+            sample_rate,
+            channels,
+            duration,
+            interim,
+            scan,
+            scan_dwell,
+            tune_gain,
+            tune_dwell,
+            rotate_dwell,
+            show_messages,
+            jsonl,
+            out,
+        } => {
+            let mode: xng_types::Mode = mode.parse().map_err(|e: String| anyhow::anyhow!(e))?;
+            let channels = channels
+                .iter()
+                .map(|c| freq::parse_hz(c))
+                .collect::<anyhow::Result<Vec<u64>>>()?;
+            commands::survey::run(commands::survey::SurveyOpts {
+                sdr,
+                gain,
+                mode,
+                sample_rate,
+                channels,
+                duration_secs: duration,
+                interim_secs: interim,
+                scan_first: scan,
+                scan_dwell_secs: scan_dwell,
+                tune_gain,
+                tune_dwell_secs: tune_dwell,
+                rotate_dwell_secs: rotate_dwell,
+                show_messages,
+                jsonl,
+                out_json: out,
+            })
         }
         Command::Scan { sdr, gain, modes, dwell, out } => {
             let modes: Vec<xng_types::Mode> = modes

--- a/src/sdr_args.rs
+++ b/src/sdr_args.rs
@@ -49,6 +49,7 @@ impl SdrArgs {
 
 /// Airspy serials are 64-bit values conventionally printed as 16 hex digits
 /// (as by `airspy_info` and `xng devices`).
+#[cfg_attr(not(any(feature = "airspy", feature = "airspyhf")), allow(dead_code))]
 pub fn parse_airspy_serial(s: &str) -> anyhow::Result<u64> {
     let t = s.trim().trim_start_matches("0x").trim_start_matches("0X");
     u64::from_str_radix(t, 16)


### PR DESCRIPTION
Turns the manual soak-test workflow from the live validation session into a first-class command.

```bash
# 15-minute ACARS soak over the full plan, gain picked empirically
xng survey --sdr driver=rtlsdr --mode acars --tune-gain --out survey.json
```

```
══ survey report: acars, 150s, gain 28 dB (fixed) ══
freq MHz   listen s  frames     ok    bad    ok%  fr/min     dBFS  verdict
130.025         150      12     11      1     92    4.80    -49.8  ACTIVE
131.725         150       5      5      0    100    2.00    -51.1  ACTIVE
total                    17     16      1     94
proposed configuration:
  xng listen --sdr 'driver=rtlsdr' --gain 28 --mode acars -r 2400000 -c 130.875M --channels 130.025,131.725
```

## What
- **Coverage**: full plan by default, rotating capture windows when the plan exceeds the SDR bandwidth; `--channels` for explicit lists; `--scan` pre-pass (configurable dwell) keeps active channels **plus the mode's new core tier** — worldwide-primary frequencies short scans routinely undersell (the 30-min soak's busiest channels had been scored quiet by a 90 s scan).
- **Reporting**: interim tables every `--interim` seconds, final per-channel table (frames/ok/bad/ok%/fr-per-min/dBFS/verdict), reception advice, proposed `listen` command, `--out` JSON report. Ctrl-C ends early but still reports. `--show-messages`/`--jsonl` for live output and archiving.
- **`--tune-gain`**: empirical dB-ladder sweep before the survey. Decode counts only outrank ADC-loading health above a minimum frame count — live testing showed 15 s of bursty ACARS crowning 12 dB on two lucky frames; sparse traffic now falls back to mean level closest to −35 dBFS.
- **Driver fix from live testing**: `SoapyIqSource` never deactivated its stream on drop, wedging sequential dwells on one rtlsdr dongle into stream-read timeouts. Streams now deactivate before close; survey adds settle pauses between reopen cycles.
- scan.rs internals (plan/grouping/passband/dwell) shared with survey rather than duplicated.

## Validation
Unit tests for advice rules, sweep scoring (including the lucky-frames regression), and proposal generation; live-tested on an RTL-SDR through all three paths (explicit channels, `--tune-gain`, `--scan` pre-pass) with real off-air ACARS decoding in every report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `xng survey` command for sustained channel monitoring with optional gain tuning, interim statistics, and formatted reports (tabular, JSON, JSONL archives).
  * Enhanced tooling capabilities documentation.

* **Bug Fixes**
  * Improved SDR stream shutdown to prevent device lockups on subsequent device opens.

* **Documentation**
  * Updated README with Quick Start section and survey command examples for soak testing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->