### PR TITLE
Release plumbing: version 0.9.0 + tagged-release pipeline

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,8 +3,7 @@ name: Docker Image
 on:
   push:
     branches:
-      - 'main'
-      - 'develop'
+      - 'master'
     tags:
       - v*
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,123 @@
+name: Release
+
+# Tag a version (e.g. v0.9.0) to build binaries for every supported
+# platform/architecture and publish a GitHub release with the assets.
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            deb: true
+          - os: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+            deb: true
+          - os: macos-14
+            target: aarch64-apple-darwin
+          - os: macos-13
+            target: x86_64-apple-darwin
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt update
+          sudo apt install -y libsoapysdr-dev libairspy-dev libairspyhf-dev protobuf-compiler
+      - name: Install dependencies (macOS)
+        if: runner.os == 'macOS'
+        run: brew install soapysdr airspy airspyhf protobuf
+      - name: Build
+        run: cargo build --release --features airspy,airspyhf
+      - name: Package tarball
+        run: |
+          PKG=xng-${GITHUB_REF_NAME}-${{ matrix.target }}
+          mkdir -p dist/${PKG}
+          cp target/release/xng README.md LICENSE-MIT LICENSE-APACHE dist/${PKG}/
+          tar -C dist -czf dist/${PKG}.tar.gz ${PKG}
+          rm -r dist/${PKG}
+      - name: Build Debian package
+        if: matrix.deb
+        run: |
+          ./build_deb_package.sh
+          cp build/*.deb dist/
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist-${{ matrix.target }}
+          path: dist/*
+
+  release:
+    name: Publish release
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+      - name: Checksums
+        run: cd dist && sha256sum * > SHA256SUMS
+      - name: Release notes
+        run: |
+          cat > notes.md <<'EOF'
+          **xng** is a single native decoder for the radio side of aviation
+          and maritime data: ACARS, VDL Mode 2, HFDL, Inmarsat Aero (L/C),
+          Inmarsat STD-C/EGC, Iridium (ring alerts, broadcasts, ACARS over
+          SBD with wideband burst hunting), AIS, and Mode S/ADS-B — one CLI,
+          every output (console, JSON/JSONL, acarsdec-compatible UDP,
+          Airframes feeding, Prometheus, asf-2.0 gRPC/QUIC), and a built-in
+          application layer (ADS-C, CPDLC rendered as text, media advisory).
+
+          Every decode core is validated against real off-air recordings or
+          reference-implementation test vectors, vendored into CI. The VHF
+          ACARS chain is validated end-to-end into production Airframes from
+          a live station.
+
+          ## Assets
+
+          | Asset | Platform |
+          |---|---|
+          | `xng-*-x86_64-unknown-linux-gnu.tar.gz` | Linux x86_64 |
+          | `xng-*-aarch64-unknown-linux-gnu.tar.gz` | Linux arm64 (Pi 4/5 64-bit) |
+          | `xng-*-aarch64-apple-darwin.tar.gz` | macOS Apple Silicon |
+          | `xng-*-x86_64-apple-darwin.tar.gz` | macOS Intel |
+          | `xng_*.deb` | Debian/Ubuntu packages (x86_64 + arm64) |
+
+          Binaries are built with SoapySDR plus the native Airspy backends;
+          they need `libsoapysdr` (and `libairspy`/`libairspyhf` for native
+          Airspy) at runtime — the .deb declares these. Multi-arch Docker
+          images (amd64/arm64/armv7) are published to
+          `ghcr.io/airframesio/xng` for the same tag.
+
+          Quick start:
+
+          ```bash
+          xng devices
+          xng scan --sdr driver=rtlsdr --gain 28 --modes acars,vdl2,ais
+          xng survey --sdr driver=rtlsdr --mode acars --tune-gain
+          xng listen --sdr driver=rtlsdr --mode acars -r 2400000 -c 130.940M \
+              --channels 130.025,131.550,131.725 \
+              --feed-airframes --station-id XX-YOUR-STATION
+          ```
+          EOF
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "$GITHUB_REF_NAME" dist/* \
+            --title "xng $GITHUB_REF_NAME" \
+            --notes-file notes.md \
+            --verify-tag

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,7 +3,6 @@ name: Rust
 on:
   push:
     branches: [ "master" ]
-    tags: [ "v*" ]
   pull_request:
     branches: [ "master" ]
 
@@ -18,9 +17,7 @@ jobs:
     - name: Install dependencies
       run: sudo apt install -y libsoapysdr-dev libairspy-dev libairspyhf-dev protobuf-compiler
     - name: Build
-      run: cargo build --verbose --release
-    - name: Version
-      run: echo "::set-output name=version::$(cargo run -- --version)"
+      run: cargo build --verbose --release --features airspy,airspyhf
     - name: Run tests
       run: cargo test --workspace --verbose
     - name: Run tests (native Airspy backends)
@@ -32,39 +29,3 @@ jobs:
         name: xng-debian-package-latest
         path: |
           ./build/*.deb
-
-  release:
-    runs-on: ubuntu-latest
-    needs: build
-    if: startsWith(github.ref, 'refs/tags/v')
-    steps:
-    - name: Get version
-      id: version
-      run: echo "version=$(cat ${{ github.workspace }}/build/version)" >> $GITHUB_STATE
-    - name: Create release
-      id: create_release
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name: ${{ github.ref }}
-        release_name: Release ${{ github.ref }}
-        draft: false
-        prerelease: false
-    - name: Download artifact from previous job
-      uses: actions/download-artifact@v4
-      with:
-        name: xng-debian-package-latest
-        path: ${{ github.workspace }}/build
-    - name: List assets
-      run: |
-        ls -la ${{ github.workspace }}/build
-    - name: Upload Debian package
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ${{ github.workspace }}/build/*.deb
-        asset_name: xng_${{ steps.version.outputs.version }}_amd64.deb
-        asset_content_type: application/x-deb

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3516,7 +3516,7 @@ dependencies = [
 
 [[package]]
 name = "xng"
-version = "0.2.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3555,7 +3555,7 @@ dependencies = [
 
 [[package]]
 name = "xng-acars"
-version = "0.2.0"
+version = "0.9.0"
 dependencies = [
  "crc",
  "serde",
@@ -3565,7 +3565,7 @@ dependencies = [
 
 [[package]]
 name = "xng-dsp"
-version = "0.2.0"
+version = "0.9.0"
 dependencies = [
  "crc",
  "num-complex",
@@ -3574,7 +3574,7 @@ dependencies = [
 
 [[package]]
 name = "xng-mode-acars"
-version = "0.2.0"
+version = "0.9.0"
 dependencies = [
  "chrono",
  "num-complex",
@@ -3586,7 +3586,7 @@ dependencies = [
 
 [[package]]
 name = "xng-mode-adsb"
-version = "0.2.0"
+version = "0.9.0"
 dependencies = [
  "chrono",
  "num-complex",
@@ -3596,7 +3596,7 @@ dependencies = [
 
 [[package]]
 name = "xng-mode-aero"
-version = "0.2.0"
+version = "0.9.0"
 dependencies = [
  "chrono",
  "num-complex",
@@ -3610,7 +3610,7 @@ dependencies = [
 
 [[package]]
 name = "xng-mode-ais"
-version = "0.2.0"
+version = "0.9.0"
 dependencies = [
  "chrono",
  "num-complex",
@@ -3620,7 +3620,7 @@ dependencies = [
 
 [[package]]
 name = "xng-mode-hfdl"
-version = "0.2.0"
+version = "0.9.0"
 dependencies = [
  "chrono",
  "num-complex",
@@ -3633,7 +3633,7 @@ dependencies = [
 
 [[package]]
 name = "xng-mode-iridium"
-version = "0.2.0"
+version = "0.9.0"
 dependencies = [
  "chrono",
  "crc",
@@ -3648,7 +3648,7 @@ dependencies = [
 
 [[package]]
 name = "xng-mode-stdc"
-version = "0.2.0"
+version = "0.9.0"
 dependencies = [
  "chrono",
  "num-complex",
@@ -3661,7 +3661,7 @@ dependencies = [
 
 [[package]]
 name = "xng-mode-vdl2"
-version = "0.2.0"
+version = "0.9.0"
 dependencies = [
  "chrono",
  "num-complex",
@@ -3674,7 +3674,7 @@ dependencies = [
 
 [[package]]
 name = "xng-proto"
-version = "0.2.0"
+version = "0.9.0"
 dependencies = [
  "chrono",
  "prost",
@@ -3685,7 +3685,7 @@ dependencies = [
 
 [[package]]
 name = "xng-sdr"
-version = "0.2.0"
+version = "0.9.0"
 dependencies = [
  "num-complex",
  "pkg-config",
@@ -3696,7 +3696,7 @@ dependencies = [
 
 [[package]]
 name = "xng-types"
-version = "0.2.0"
+version = "0.9.0"
 dependencies = [
  "chrono",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["legacy"]
 resolver = "2"
 
 [workspace.package]
-version = "0.2.0"
+version = "0.9.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/airframesio/xng"

--- a/build_deb_package.sh
+++ b/build_deb_package.sh
@@ -3,14 +3,14 @@
 DEB_ARCH=$(dpkg --print-architecture)
 DEB_BUILD_ROOT=$(pwd)/build
 
-DEB_PKG_VERSION=$(grep Version $(pwd)/packaging/control | awk '{print $2}')
+DEB_PKG_VERSION=$(grep '^version' $(pwd)/Cargo.toml | head -1 | cut -d'"' -f2)
 DEB_PKG_NAME=xng-${DEB_PKG_VERSION}-${DEB_ARCH}
 
 mkdir -p ${DEB_BUILD_ROOT}/${DEB_PKG_NAME}/DEBIAN
 mkdir -p ${DEB_BUILD_ROOT}/${DEB_PKG_NAME}/usr/bin
 
 cp $(pwd)/target/release/xng ${DEB_BUILD_ROOT}/${DEB_PKG_NAME}/usr/bin/xng
-sed -e s/CURRENT_ARCH/${DEB_ARCH}/ $(pwd)/packaging/control > ${DEB_BUILD_ROOT}/${DEB_PKG_NAME}/DEBIAN/control
+sed -e s/CURRENT_ARCH/${DEB_ARCH}/ -e s/CURRENT_VERSION/${DEB_PKG_VERSION}/ $(pwd)/packaging/control > ${DEB_BUILD_ROOT}/${DEB_PKG_NAME}/DEBIAN/control
 
 echo ${DEB_PKG_VERSION} > ${DEB_BUILD_ROOT}/version
 

--- a/crates/xng-sdr/src/airspy.rs
+++ b/crates/xng-sdr/src/airspy.rs
@@ -165,9 +165,12 @@ impl AirspyIqSource {
 
         let rate = sample_rate.round() as u32;
         if unsafe { ffi::airspy_set_samplerate(dev, rate) } != ffi::AIRSPY_SUCCESS {
+            // Verified on a Mini running the final firmware (v1.0.0-rc10-6):
+            // off-list rates are refused even though libairspy forwards
+            // them, so the advertised list is the only safe guidance.
             let supported = supported_rates(dev);
             return Err(SdrError::Config(format!(
-                "device refused {rate} S/s (advertised rates: {}; arbitrary rates need firmware >= 1.0.7)",
+                "device refused {rate} S/s; use one of its supported rates: {}",
                 supported.iter().map(|r| r.to_string()).collect::<Vec<_>>().join(", ")
             )));
         }

--- a/packaging/control
+++ b/packaging/control
@@ -1,6 +1,6 @@
 Package: xng
-Version: 0.2.0
-Depends: libsoapysdr0.8
+Version: CURRENT_VERSION
+Depends: libsoapysdr0.8, libairspy0, libairspyhf1
 Section: utils
 Priority: optional
 Architecture: CURRENT_ARCH

--- a/src/main.rs
+++ b/src/main.rs
@@ -322,6 +322,7 @@ fn parse_tune(tune: &TuneOpts) -> anyhow::Result<(xng_types::Mode, u64, Vec<u64>
 fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
     init_logging(cli.verbose);
+    tracing::info!("xng v{}", env!("CARGO_PKG_VERSION"));
 
     match cli.command {
         Command::Devices { filter } => commands::devices::run(&filter),

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -211,7 +211,8 @@ fn draw(
     list_state.select(app.selected);
     let list = List::new(items)
         .block(Block::default().borders(Borders::ALL).title(format!(
-            " messages {} ",
+            " xng v{} — messages {} ",
+            env!("CARGO_PKG_VERSION"),
             if app.follow { "(follow)" } else { "(paused)" }
         )))
         .highlight_style(Style::default().bg(Color::DarkGray).add_modifier(Modifier::BOLD));


### PR DESCRIPTION
Sets the project version to **0.9.0** (pre-1.0 until the remaining roadmap lands) and adds the release machinery so `git tag v0.9.0 && git push --tags` produces a complete GitHub release.

## Version
- Workspace version 0.9.0; `xng --version`, a startup log line in every command, and the TUI title bar all report it.
- The .deb version is derived from Cargo.toml (was a stale hand-edited 0.2.0 in `packaging/control`); .deb `Depends` now includes `libairspy0`/`libairspyhf1` to match the binaries.

## Release pipeline (`release.yml`, on `v*` tags)
- Builds `--release --features airspy,airspyhf` for: Linux x86_64, Linux arm64 (native runner), macOS Apple Silicon, macOS Intel — tarballs everywhere plus .debs for both Linux arches, with SHA256SUMS.
- Publishes a GitHub release whose notes describe what xng is, an asset/platform table, runtime library requirements, the ghcr Docker images, and a quick start.
- `rust.yml` loses its tag trigger and the long-broken `set-output`/`create-release@v1` job; `docker.yml`'s branch filter pointed at `main`/`develop` (neither exists) and now builds on `master` too.

## Drive-by accuracy fix
The Airspy refused-rate error claimed a firmware upgrade would enable arbitrary rates. Tested on a Mini running the **final published firmware** (v1.0.0-rc10-6, confirmed against airspyone_firmware releases): off-list rates fail even via the vendor's `airspy_rx`. The message now just lists the device's supported rates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)