### PR TITLE
tui: zero-config tuning from the mode's frequency plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,12 @@ spectrum with channel markers, and a waterfall — over a live SDR or a
 replayed file:
 
 ```bash
+# Zero config: channels, center, and sample rate come from the mode's
+# built-in plan — as many channels as fit the capture width and CPU
+xng tui --sdr driver=rtlsdr
+xng tui --sdr driver=rtlsdr --mode vdl2
+
+# Explicit tuning still works (and is required for --file replay)
 xng tui --sdr driver=rtlsdr -r 2400000 -c 131.500M --channels 131.550,131.125
 xng tui --file capture.cf32 -r 2400000 -c 131.500M --channels 131.550
 ```

--- a/src/commands/scan.rs
+++ b/src/commands/scan.rs
@@ -111,6 +111,27 @@ pub(crate) fn group_channels(channels: &[u64], sample_rate: f64, passband: f64) 
         .collect()
 }
 
+/// Pick the capture window and channel set for zero-config tuning: the
+/// densest window of the mode's plan, trimmed to a CPU budget with the
+/// core (worldwide-primary) channels kept first, then nearest-to-center.
+pub(crate) fn auto_window(mode: Mode, rate: f64, max_channels: usize) -> Option<(u64, Vec<u64>)> {
+    let (_, plan_channels) = plan(mode);
+    if plan_channels.is_empty() {
+        return None;
+    }
+    let groups = group_channels(&plan_channels, rate, passband(mode));
+    let (center, mut chans) = groups.into_iter().max_by_key(|(_, g)| g.len())?;
+    if chans.len() > max_channels {
+        let core = core_channels(mode);
+        chans.sort_by_key(|f| {
+            (!core.contains(f), (*f as i64 - center as i64).unsigned_abs())
+        });
+        chans.truncate(max_channels);
+        chans.sort_unstable();
+    }
+    Some((center, chans))
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub struct ChannelResult {
     pub mode: String,
@@ -370,4 +391,38 @@ pub(crate) fn scan_group(
         })
         .collect();
     Ok((results, systables))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn auto_window_picks_densest_group_and_keeps_core_first() {
+        // The ACARS plan spans ~2.7 MHz: at 2.4 MS/s it splits into two
+        // windows, and the upper one (8 channels) must win.
+        let (center, chans) = auto_window(Mode::AcarsPoa, 2_400_000.0, 64).unwrap();
+        assert!(chans.len() >= 8, "{chans:?}");
+        assert!(chans.contains(&131_550_000));
+        assert!(center > 130_000_000 && center < 132_000_000);
+
+        // A tight budget keeps the core channels in the window.
+        let (_, capped) = auto_window(Mode::AcarsPoa, 2_400_000.0, 3).unwrap();
+        assert_eq!(capped.len(), 3);
+        assert!(capped.contains(&131_550_000), "core channel evicted: {capped:?}");
+        assert!(capped.contains(&131_725_000), "core channel evicted: {capped:?}");
+    }
+
+    #[test]
+    fn auto_window_handles_single_channel_modes() {
+        let (center, chans) = auto_window(Mode::Adsb, 2_000_000.0, 8).unwrap();
+        assert_eq!(chans, vec![1_090_000_000]);
+        // Center is nudged off the channel to keep it away from DC.
+        assert_ne!(center, 1_090_000_000);
+    }
+
+    #[test]
+    fn auto_window_none_for_planless_modes() {
+        assert!(auto_window(Mode::AeroL, 2_400_000.0, 8).is_none());
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,14 +36,18 @@ struct TuneOpts {
     mode: String,
     /// Capture sample rate in Hz (must be an integer multiple of the
     /// mode's channel rate: 24 kHz for ACARS, 48 kHz for AIS; 2400000
-    /// works for both)
+    /// works for both). The tui derives it from the mode's plan when
+    /// omitted; decode/listen require it.
     #[arg(short = 'r', long)]
-    sample_rate: f64,
-    /// Capture center frequency (e.g. 131.500M)
+    sample_rate: Option<f64>,
+    /// Capture center frequency (e.g. 131.500M). The tui derives it from
+    /// the channel set when omitted; decode/listen require it.
     #[arg(short = 'c', long)]
-    center_freq: String,
-    /// Channel frequencies, comma separated (e.g. 131.550,131.725)
-    #[arg(long, value_delimiter = ',', required = true)]
+    center_freq: Option<String>,
+    /// Channel frequencies, comma separated (e.g. 131.550,131.725). The
+    /// tui falls back to the mode's built-in plan (as many channels as
+    /// fit the capture width and CPU budget); decode/listen require it.
+    #[arg(long, value_delimiter = ',')]
     channels: Vec<String>,
 }
 
@@ -308,15 +312,89 @@ fn init_logging(verbose: u8) {
     tracing_subscriber::fmt().with_env_filter(filter).with_writer(std::io::stderr).init();
 }
 
-fn parse_tune(tune: &TuneOpts) -> anyhow::Result<(xng_types::Mode, u64, Vec<u64>)> {
+/// Strict tune parsing for decode/listen: everything must be explicit.
+fn parse_tune(tune: &TuneOpts) -> anyhow::Result<(xng_types::Mode, f64, u64, Vec<u64>)> {
     let mode: xng_types::Mode = tune.mode.parse().map_err(|e: String| anyhow::anyhow!(e))?;
-    let center = freq::parse_hz(&tune.center_freq)?;
+    let rate = tune
+        .sample_rate
+        .ok_or_else(|| anyhow::anyhow!("missing -r/--sample-rate"))?;
+    let center = tune
+        .center_freq
+        .as_deref()
+        .ok_or_else(|| anyhow::anyhow!("missing -c/--center-freq"))?;
+    let center = freq::parse_hz(center)?;
+    anyhow::ensure!(!tune.channels.is_empty(), "missing --channels");
     let channels = tune
         .channels
         .iter()
         .map(|c| freq::parse_hz(c))
         .collect::<anyhow::Result<Vec<u64>>>()?;
-    Ok((mode, center, channels))
+    Ok((mode, rate, center, channels))
+}
+
+/// Zero-config tuning for the tui: anything omitted is derived from the
+/// mode's built-in frequency plan — sample rate from the plan, channels
+/// from the densest capture window that fits it (trimmed to a CPU
+/// budget, core channels first), center from the chosen channels.
+fn resolve_tune_auto(tune: &TuneOpts) -> anyhow::Result<(xng_types::Mode, f64, u64, Vec<u64>)> {
+    let mode: xng_types::Mode = tune.mode.parse().map_err(|e: String| anyhow::anyhow!(e))?;
+    let (plan_rate, plan_channels) = commands::scan::plan(mode);
+    let rate = tune.sample_rate.unwrap_or(plan_rate);
+
+    // Explicit channels: only the center may need deriving.
+    if !tune.channels.is_empty() {
+        let channels = tune
+            .channels
+            .iter()
+            .map(|c| freq::parse_hz(c))
+            .collect::<anyhow::Result<Vec<u64>>>()?;
+        let center = match &tune.center_freq {
+            Some(c) => freq::parse_hz(c)?,
+            None => centroid_off_dc(&channels),
+        };
+        return Ok((mode, rate, center, channels));
+    }
+
+    // Explicit center, channels from the plan: keep plan channels that
+    // fit the capture around that center.
+    if let Some(c) = &tune.center_freq {
+        let center = freq::parse_hz(c)?;
+        let half = (rate * 0.4) as i64; // 80% usable width, half each side
+        let channels: Vec<u64> = plan_channels
+            .iter()
+            .copied()
+            .filter(|f| (*f as i64 - center as i64).abs() <= half)
+            .collect();
+        anyhow::ensure!(
+            !channels.is_empty(),
+            "no {mode} plan channels within the capture around {:.3} MHz; pass --channels",
+            center as f64 / 1e6
+        );
+        return Ok((mode, rate, center, channels));
+    }
+
+    // Fully automatic. DDC-per-channel is cheap, but a small box should
+    // not be saddled with a worldwide plan: budget ~4 channels per core.
+    let budget = std::thread::available_parallelism().map(|n| n.get()).unwrap_or(4) * 4;
+    let (center, channels) = commands::scan::auto_window(mode, rate, budget)
+        .ok_or_else(|| {
+            anyhow::anyhow!("mode {mode} has no built-in frequency plan; pass --channels")
+        })?;
+    tracing::info!(
+        "auto-tune: {} channel(s) around {:.3} MHz at {} S/s (budget {budget})",
+        channels.len(),
+        center as f64 / 1e6,
+        rate as u64
+    );
+    Ok((mode, rate, center, channels))
+}
+
+/// Midpoint of a channel set, nudged off any exact channel so no carrier
+/// sits at DC.
+fn centroid_off_dc(channels: &[u64]) -> u64 {
+    let center =
+        (channels.iter().min().unwrap() + channels.iter().max().unwrap()) / 2;
+    if channels.contains(&center) { center + 25_000 } else { center }
 }
 
 fn main() -> anyhow::Result<()> {
@@ -333,9 +411,9 @@ fn main() -> anyhow::Result<()> {
                     anyhow::anyhow!("cannot guess IQ format; pass --format (cf32|cs16|cs8|cu8)")
                 })?,
             };
-            let (mode, center_hz, channels_hz) = parse_tune(&tune)?;
+            let (mode, rate, center_hz, channels_hz) = parse_tune(&tune)?;
             let (outputs, station_ident) = output.build()?;
-            let source = FileIqSource::open(&file, fmt, tune.sample_rate, center_hz)?;
+            let source = FileIqSource::open(&file, fmt, rate, center_hz)?;
             runtime::run_session(
                 Box::new(source),
                 runtime::SessionConfig {
@@ -412,7 +490,7 @@ fn main() -> anyhow::Result<()> {
             commands::scan::run(&sdr, gain, &modes, dwell, out.as_deref())
         }
         Command::Tui { sdr, gain, file, format, tune } => {
-            let (mode, center_hz, channels_hz) = parse_tune(&tune)?;
+            let (mode, rate, center_hz, channels_hz) = resolve_tune_auto(&tune)?;
             let source: Box<dyn xng_sdr::IqSource> = match file {
                 Some(path) => {
                     let fmt = match format.as_deref() {
@@ -421,9 +499,13 @@ fn main() -> anyhow::Result<()> {
                             anyhow::anyhow!("cannot guess IQ format; pass --format")
                         })?,
                     };
-                    Box::new(FileIqSource::open(&path, fmt, tune.sample_rate, center_hz)?)
+                    // A recording's rate can't be derived from a plan.
+                    let rate = tune.sample_rate.ok_or_else(|| {
+                        anyhow::anyhow!("--file needs an explicit -r/--sample-rate")
+                    })?;
+                    Box::new(FileIqSource::open(&path, fmt, rate, center_hz)?)
                 }
-                None => open_sdr(&sdr, tune.sample_rate, center_hz, gain)?.0,
+                None => open_sdr(&sdr, rate, center_hz, gain)?.0,
             };
             tui::run(
                 source,
@@ -521,10 +603,10 @@ fn open_soapy(
 }
 
 fn listen(sdr: &str, gain: Option<f64>, tune: &TuneOpts, output: &OutputOpts) -> anyhow::Result<()> {
-    let (mode, center_hz, channels_hz) = parse_tune(tune)?;
+    let (mode, rate, center_hz, channels_hz) = parse_tune(tune)?;
     let (outputs, station_ident) = output.build()?;
     let serial = sdr_args::SdrArgs::parse(sdr).serial;
-    let (source, driver) = open_sdr(sdr, tune.sample_rate, center_hz, gain)?;
+    let (source, driver) = open_sdr(sdr, rate, center_hz, gain)?;
     runtime::run_session(
         source,
         runtime::SessionConfig {


### PR DESCRIPTION
`xng tui --sdr driver=rtlsdr` now just works — no `-r`, `-c`, or `--channels` needed.

## Resolution rules
- **Nothing given**: the mode's built-in plan supplies the sample rate and channels; the densest capture window that fits the rate wins, trimmed to a CPU budget (~4 channels per core, DDCs are cheap) with core worldwide channels kept first, nearest-to-center next. The choice is logged (`auto-tune: 8 channel(s) around 131.488 MHz at 2400000 S/s`).
- **`-c` only**: plan channels that fit the capture width around that center.
- **`--channels` only**: center derived from the channel centroid, nudged off DC.
- **`decode`/`listen`**: still strict — a feeder's channel set shouldn't be chosen by a heuristic — with clear missing-flag errors. `--file` replay still requires `-r` (a recording's rate can't come from a plan).

Planless modes (aero, std-c at L-band offsets, hfdl's window-hopping) error with "pass --channels".

Unit tests cover window choice, the CPU cap keeping core channels, single-channel modes (center nudged off DC), and planless fallback. Verified live: zero-config resolves the 8-channel ACARS window at 2.4 MS/s; `-r 6000000` widens it to all 12 plan channels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)