### PR TITLE
tui auto-tune: pick a sample rate the device actually supports

### DIFF
--- a/crates/xng-sdr/src/airspy.rs
+++ b/crates/xng-sdr/src/airspy.rs
@@ -89,6 +89,21 @@ pub fn enumerate() -> Result<Vec<u64>, SdrError> {
 pub const FREQ_MIN_HZ: u64 = 24_000_000;
 pub const FREQ_MAX_HZ: u64 = 1_750_000_000;
 
+/// The sample rates a connected device advertises (briefly opens it).
+pub fn device_rates(serial: Option<u64>) -> Result<Vec<u32>, SdrError> {
+    let mut dev: *mut ffi::Device = std::ptr::null_mut();
+    let ret = match serial {
+        Some(sn) => unsafe { ffi::airspy_open_sn(&mut dev, sn) },
+        None => unsafe { ffi::airspy_open(&mut dev) },
+    };
+    if ret != ffi::AIRSPY_SUCCESS {
+        return Err(SdrError::Device(format!("airspy_open: error {ret}")));
+    }
+    let rates = supported_rates(dev);
+    unsafe { ffi::airspy_close(dev) };
+    Ok(rates)
+}
+
 /// Map a requested dB gain onto the R820T linearity-optimized composite gain
 /// (22 steps spanning roughly 0..45 dB).
 pub fn linearity_index(gain_db: f64) -> u8 {

--- a/crates/xng-sdr/src/airspyhf.rs
+++ b/crates/xng-sdr/src/airspyhf.rs
@@ -81,6 +81,21 @@ pub fn enumerate() -> Result<Vec<u64>, SdrError> {
     Ok(serials)
 }
 
+/// The sample rates a connected device advertises (briefly opens it).
+pub fn device_rates(serial: Option<u64>) -> Result<Vec<u32>, SdrError> {
+    let mut dev: *mut ffi::Device = std::ptr::null_mut();
+    let ret = match serial {
+        Some(sn) => unsafe { ffi::airspyhf_open_sn(&mut dev, sn) },
+        None => unsafe { ffi::airspyhf_open(&mut dev) },
+    };
+    if ret != ffi::AIRSPYHF_SUCCESS {
+        return Err(SdrError::Device(format!("airspyhf_open: error {ret}")));
+    }
+    let rates = supported_rates(dev);
+    unsafe { ffi::airspyhf_close(dev) };
+    Ok(rates)
+}
+
 /// Manual gain settings derived from a requested dB value.
 ///
 /// The HF+ front end has no conventional gain knob — only a 0..48 dB

--- a/src/commands/scan.rs
+++ b/src/commands/scan.rs
@@ -82,6 +82,39 @@ pub(crate) fn passband(mode: Mode) -> f64 {
     }
 }
 
+/// Per-channel decoder input rate, by mode: an acceptable capture rate
+/// must be an integer multiple of this (the DDC decimates by integers).
+pub(crate) fn channel_rate(mode: Mode) -> f64 {
+    match mode {
+        Mode::Ais => xng_mode_ais::CHANNEL_RATE,
+        Mode::Vdl2 => xng_mode_vdl2::CHANNEL_RATE,
+        Mode::Hfdl => xng_mode_hfdl::CHANNEL_RATE,
+        Mode::StdC => xng_mode_stdc::CHANNEL_RATE,
+        Mode::Iridium => xng_mode_iridium::CHANNEL_RATE,
+        // Consumes the whole capture at its native rate.
+        Mode::Adsb => 1.0,
+        _ => xng_mode_acars::CHANNEL_RATE,
+    }
+}
+
+/// Choose a capture rate the device can actually do: the smallest
+/// advertised rate that divides the mode's channel rate cleanly (CPU
+/// scales with rate). Falls back to the plan rate when nothing matches
+/// or nothing was probed.
+pub(crate) fn pick_auto_rate(advertised: &[u32], mode: Mode, plan_rate: f64) -> f64 {
+    let ch = channel_rate(mode);
+    let mut rates: Vec<u32> = advertised.to_vec();
+    rates.sort_unstable();
+    if rates.iter().any(|&r| r as f64 == plan_rate && (plan_rate / ch).fract().abs() < 1e-9) {
+        return plan_rate;
+    }
+    rates
+        .iter()
+        .map(|&r| r as f64)
+        .find(|r| (r / ch).fract().abs() < 1e-9)
+        .unwrap_or(plan_rate)
+}
+
 /// Cluster channels into capture-width groups.
 pub(crate) fn group_channels(channels: &[u64], sample_rate: f64, passband: f64) -> Vec<(u64, Vec<u64>)> {
     let usable = sample_rate * 0.8 - 2.0 * passband;
@@ -396,6 +429,18 @@ pub(crate) fn scan_group(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn auto_rate_prefers_smallest_divisible_advertised_rate() {
+        // Airspy Mini advertises 6/3 Msps: VDL2 (50 kHz channels) and
+        // ACARS (24 kHz) both divide 3 Msps, so the cheaper rate wins.
+        assert_eq!(pick_auto_rate(&[6_000_000, 3_000_000], Mode::Vdl2, 2_400_000.0), 3_000_000.0);
+        assert_eq!(pick_auto_rate(&[6_000_000, 3_000_000], Mode::AcarsPoa, 2_400_000.0), 3_000_000.0);
+        // Device that advertises the plan rate keeps it.
+        assert_eq!(pick_auto_rate(&[2_400_000], Mode::AcarsPoa, 2_400_000.0), 2_400_000.0);
+        // Nothing probed (SoapySDR path): plan rate.
+        assert_eq!(pick_auto_rate(&[], Mode::AcarsPoa, 2_400_000.0), 2_400_000.0);
+    }
 
     #[test]
     fn auto_window_picks_densest_group_and_keeps_core_first() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -333,13 +333,32 @@ fn parse_tune(tune: &TuneOpts) -> anyhow::Result<(xng_types::Mode, f64, u64, Vec
 }
 
 /// Zero-config tuning for the tui: anything omitted is derived from the
-/// mode's built-in frequency plan — sample rate from the plan, channels
-/// from the densest capture window that fits it (trimmed to a CPU
-/// budget, core channels first), center from the chosen channels.
-fn resolve_tune_auto(tune: &TuneOpts) -> anyhow::Result<(xng_types::Mode, f64, u64, Vec<u64>)> {
+/// mode's built-in frequency plan — sample rate from the plan (checked
+/// against the device's advertised rates where a native backend can
+/// tell us), channels from the densest capture window that fits it
+/// (trimmed to a CPU budget, core channels first), center from the
+/// chosen channels.
+fn resolve_tune_auto(
+    tune: &TuneOpts,
+    sdr: &str,
+) -> anyhow::Result<(xng_types::Mode, f64, u64, Vec<u64>)> {
     let mode: xng_types::Mode = tune.mode.parse().map_err(|e: String| anyhow::anyhow!(e))?;
     let (plan_rate, plan_channels) = commands::scan::plan(mode);
-    let rate = tune.sample_rate.unwrap_or(plan_rate);
+    let rate = match tune.sample_rate {
+        Some(r) => r,
+        None => {
+            let advertised = probe_device_rates(sdr);
+            let r = commands::scan::pick_auto_rate(&advertised, mode, plan_rate);
+            if r != plan_rate {
+                tracing::info!(
+                    "auto-tune: device prefers {} S/s over the plan's {} S/s",
+                    r as u64,
+                    plan_rate as u64
+                );
+            }
+            r
+        }
+    };
 
     // Explicit channels: only the center may need deriving.
     if !tune.channels.is_empty() {
@@ -387,6 +406,24 @@ fn resolve_tune_auto(tune: &TuneOpts) -> anyhow::Result<(xng_types::Mode, f64, u
         rate as u64
     );
     Ok((mode, rate, center, channels))
+}
+
+/// Advertised sample rates of the device `--sdr` selects, where a native
+/// backend can ask (empty when it can't — SoapySDR devices generally
+/// accept the plan rates).
+fn probe_device_rates(sdr: &str) -> Vec<u32> {
+    let args = sdr_args::SdrArgs::parse(sdr);
+    if args.force_soapy {
+        return Vec::new();
+    }
+    let serial = args.serial.as_deref().and_then(|s| sdr_args::parse_airspy_serial(s).ok());
+    match args.driver.as_deref() {
+        #[cfg(feature = "airspy")]
+        Some("airspy") => xng_sdr::airspy::device_rates(serial).unwrap_or_default(),
+        #[cfg(feature = "airspyhf")]
+        Some("airspyhf") => xng_sdr::airspyhf::device_rates(serial).unwrap_or_default(),
+        _ => Vec::new(),
+    }
 }
 
 /// Midpoint of a channel set, nudged off any exact channel so no carrier
@@ -490,7 +527,7 @@ fn main() -> anyhow::Result<()> {
             commands::scan::run(&sdr, gain, &modes, dwell, out.as_deref())
         }
         Command::Tui { sdr, gain, file, format, tune } => {
-            let (mode, rate, center_hz, channels_hz) = resolve_tune_auto(&tune)?;
+            let (mode, rate, center_hz, channels_hz) = resolve_tune_auto(&tune, &sdr)?;
             let source: Box<dyn xng_sdr::IqSource> = match file {
                 Some(path) => {
                     let fmt = match format.as_deref() {


### PR DESCRIPTION
Immediate field bug from #41: zero-config tui on an Airspy Mini picked the plan's 2.4 MS/s, which the Mini (6/3 MS/s only) refuses:

```
INFO xng: auto-tune: 7 channel(s) around 136.812 MHz at 2400000 S/s (budget 48)
Error: invalid configuration: device refused 2400000 S/s; use one of its supported rates: 6000000, 3000000
```

When `-r` is omitted, the resolver now probes the device's advertised rates via the native backend (`device_rates()` on airspy/airspyhf — brief open, read list, close) and picks the **smallest rate that divides the mode's channel rate cleanly** (CPU scales with rate): 3 MS/s on the Mini for both VDL2 (÷50 kHz = 60) and ACARS (÷24 kHz = 125). The substitution is logged. SoapySDR devices keep the plan rates (they accept them); explicit `-r` is always honored.

Unit tests cover the rate picking (smallest divisible, plan-rate preference, empty probe fallback). Live verification on the Mini pending a replug — the device dropped off the USB bus mid-session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced auto-tune functionality now automatically detects and selects optimal sample rates from your connected SDR device when no explicit rate is specified, improving compatibility and performance with Airspy and Airspy HF devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->