### PR TITLE
VDL2: structured bodies for every frame + TUI detail view toggle

### DIFF
--- a/crates/xng-mode-vdl2/src/avlc.rs
+++ b/crates/xng-mode-vdl2/src/avlc.rs
@@ -118,6 +118,83 @@ pub struct AvlcFrame {
     pub raw: Vec<u8>,
 }
 
+/// One XID parameter (ISO 8885 group structure; VDL-specific parameter
+/// names per ICAO Doc 9776).
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct XidParam {
+    /// Group identifier (0x80 = ISO 8885 general, 0xF0 = VDL private).
+    pub group: u8,
+    pub id: u8,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<&'static str>,
+    pub value_hex: String,
+    /// Printable interpretation where the value is plain text (e.g. the
+    /// destination airport parameter).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text: Option<String>,
+}
+
+/// VDL private parameter set names (ICAO Doc 9776 Table 5-3 area).
+fn vdl_param_name(id: u8) -> Option<&'static str> {
+    Some(match id {
+        0x00 => "parameter-set-id",
+        0x01 => "connection-management",
+        0x02 => "signal-quality",
+        0x03 => "xid-sequencing",
+        0x04 => "avlc-options",
+        0x05 => "expedited-sn-connection",
+        0x06 => "lcr-cause",
+        0x40 => "modulation-support",
+        0x41 => "acceptable-alternate-ground-stations",
+        0x42 => "destination-airport",
+        0x43 => "aircraft-position",
+        0x44 => "autotune-frequency",
+        0x45 => "replacement-ground-stations",
+        0x46 => "timer-t4",
+        0x47 => "mac-persistence",
+        0x48 => "counter-m1",
+        0x49 => "timer-tm2",
+        _ => return None,
+    })
+}
+
+/// Parse an XID information field: FI octet, then groups of
+/// `GI | GL(2, big endian) | params{PI, PL, PV}` (ISO 8885).
+pub fn parse_xid(info: &[u8]) -> Option<Vec<XidParam>> {
+    if info.is_empty() {
+        return None;
+    }
+    let mut params = Vec::new();
+    let mut pos = 1; // skip the format identifier octet
+    while pos + 3 <= info.len() {
+        let group = info[pos];
+        let glen = u16::from_be_bytes([info[pos + 1], info[pos + 2]]) as usize;
+        pos += 3;
+        let end = (pos + glen).min(info.len());
+        while pos + 2 <= end {
+            let id = info[pos];
+            let plen = info[pos + 1] as usize;
+            pos += 2;
+            if pos + plen > end {
+                return None; // malformed; don't emit half-parsed garbage
+            }
+            let value = &info[pos..pos + plen];
+            pos += plen;
+            let printable = value.len() >= 2
+                && value.iter().all(|&b| (0x20..0x7F).contains(&b));
+            params.push(XidParam {
+                group,
+                id,
+                name: if group == 0xF0 { vdl_param_name(id) } else { None },
+                value_hex: value.iter().map(|b| format!("{b:02x}")).collect(),
+                text: printable.then(|| String::from_utf8_lossy(value).into_owned()),
+            });
+        }
+        pos = end;
+    }
+    if params.is_empty() { None } else { Some(params) }
+}
+
 /// Scan a descrambled, RS-corrected bit stream for AVLC frames.
 pub fn scan(bits: &[u8]) -> Vec<AvlcFrame> {
     let mut frames = Vec::new();
@@ -310,5 +387,46 @@ mod tests {
         // Flip a payload bit mid-frame (avoid creating a flag/abort).
         bits[8 * 12 + 2] ^= 1;
         assert!(scan(&bits).is_empty());
+    }
+}
+
+#[cfg(test)]
+mod body_tests {
+    use super::*;
+
+    #[test]
+    fn off_air_s_frame_parses_as_rr() {
+        // The exact 11-byte frame a live Airspy session surfaced as
+        // "undecoded": dst/src addresses + control 0xA1 + FCS.
+        let octets = [0x14u8, 0x22, 0xcc, 0x54, 0xb2, 0x0c, 0x42, 0xb5, 0xa1];
+        let bits = build(&[octets.to_vec()]);
+        let frames = scan(&bits);
+        assert_eq!(frames.len(), 1);
+        let f = &frames[0];
+        assert_eq!(f.control, Control::Supervisory { kind: "RR", nr: 5, poll: false });
+        assert_eq!(f.payload, Payload::Empty);
+        assert!(f.info.is_empty());
+    }
+
+    #[test]
+    fn xid_parameters_decode_with_names_and_text() {
+        // FI 0x82, VDL private group 0xF0, two params:
+        // parameter-set-id = "V", destination-airport = "KSMF".
+        let info = [
+            0x82, 0xF0, 0x00, 0x09, 0x00, 0x01, b'V', 0x42, 0x04, b'K', b'S', b'M', b'F',
+        ];
+        let params = parse_xid(&info).expect("params");
+        assert_eq!(params.len(), 2);
+        assert_eq!(params[0].name, Some("parameter-set-id"));
+        assert_eq!(params[1].name, Some("destination-airport"));
+        assert_eq!(params[1].text.as_deref(), Some("KSMF"));
+        assert_eq!(params[1].value_hex, "4b534d46");
+    }
+
+    #[test]
+    fn malformed_xid_returns_none() {
+        // Param claims more bytes than the group holds.
+        let info = [0x82, 0xF0, 0x00, 0x04, 0x42, 0x40];
+        assert!(parse_xid(&info).is_none());
     }
 }

--- a/crates/xng-mode-vdl2/src/lib.rs
+++ b/crates/xng-mode-vdl2/src/lib.rs
@@ -92,7 +92,7 @@ pub fn to_message(f: &Vdl2Frame, frequency_hz: u64, level_dbfs: f32, source: Pro
             b.crc_ok,
             Some(b.parity_errors),
         ),
-        None => (MessageBody::Undecoded, true, None),
+        None => (avlc_body(&f.avlc), true, None),
     };
     Message {
         mode: Mode::Vdl2,
@@ -108,4 +108,42 @@ pub fn to_message(f: &Vdl2Frame, frequency_hz: u64, level_dbfs: f32, source: Pro
         raw: Some(f.avlc.raw.clone()),
         source,
     }
+}
+
+/// Structured body for non-ACARS AVLC frames: the link layer is always
+/// fully parsed (addresses, control), XID parameters are decoded, and
+/// ATN payloads are at least labeled by protocol.
+fn avlc_body(frame: &avlc::AvlcFrame) -> MessageBody {
+    use avlc::{Control, Payload};
+    let kind = match (&frame.control, &frame.payload) {
+        (Control::Unnumbered { kind: "XID", .. }, _) => "xid".to_string(),
+        (Control::Unnumbered { kind, .. }, _) => format!("avlc-{}", kind.to_lowercase()),
+        (Control::Supervisory { kind, .. }, _) => format!("avlc-{}", kind.to_lowercase()),
+        (Control::Info { .. }, Payload::Atn { .. }) => "atn".to_string(),
+        (Control::Info { .. }, _) => "avlc-i".to_string(),
+    };
+    let mut details = serde_json::json!({
+        "dst": frame.dst,
+        "src": frame.src,
+        "control": frame.control,
+    });
+    if let Payload::Atn { ipi } = frame.payload {
+        details["protocol"] = serde_json::json!(match ipi {
+            0x81 => "CLNP",
+            0x82 => "ES-IS",
+            _ => "IDRP",
+        });
+    }
+    if matches!(frame.control, Control::Unnumbered { kind: "XID", .. }) {
+        if let Some(params) = avlc::parse_xid(&frame.info) {
+            details["params"] = serde_json::json!(params);
+        }
+    }
+    if !frame.info.is_empty() {
+        let shown = &frame.info[..frame.info.len().min(64)];
+        details["info_hex"] =
+            serde_json::json!(shown.iter().map(|b| format!("{b:02x}")).collect::<String>());
+        details["info_len"] = serde_json::json!(frame.info.len());
+    }
+    MessageBody::Vdl2 { kind, details }
 }

--- a/crates/xng-proto/src/lib.rs
+++ b/crates/xng-proto/src/lib.rs
@@ -84,6 +84,12 @@ impl From<&Message> for asf2::DecodedMessage {
                     details_json: details.to_string(),
                 }))
             }
+            MessageBody::Vdl2 { kind, details } => {
+                Some(asf2::decoded_message::Body::Vdl2(asf2::Vdl2Body {
+                    kind: kind.clone(),
+                    details_json: details.to_string(),
+                }))
+            }
             MessageBody::Hfdl { kind, details } => {
                 Some(asf2::decoded_message::Body::Hfdl(asf2::HfdlBody {
                     kind: kind.clone(),

--- a/crates/xng-types/src/message.rs
+++ b/crates/xng-types/src/message.rs
@@ -98,6 +98,12 @@ pub enum MessageBody {
         kind: String,
         details: serde_json::Value,
     },
+    /// VDL2 non-ACARS frame: AVLC link events (acks, XID handoffs) and
+    /// ATN traffic, with addresses and decoded parameters.
+    Vdl2 {
+        kind: String,
+        details: serde_json::Value,
+    },
     /// HFDL non-ACARS event (squitter, logon, performance data, ...).
     Hfdl {
         kind: String,

--- a/docs/REFERENCES.md
+++ b/docs/REFERENCES.md
@@ -18,6 +18,8 @@ attribution. GPL projects are listed as fact references only.
 | ARINC 618-6 (Air/Ground Character-Oriented Protocol) | ACARS framing: differential MSK (§4.4.2), odd parity LSB-first (§4.4.2.1), preamble (§4.2-4.3), block format (§2.1-2.3), BCS CRC + "K7" worked example (§2.2.10) | public copy: https://pdfcoffee.com/324981622-618-6-airground-character-oriented-protocol-specification-pdfpdf-pdf-free.html |
 | ETSI EN 301 841-1 V1.4.1 | VDL2 radio conformance (mirrors Annex 10) | https://www.etsi.org/deliver/etsi_en/301800_301899/30184101/01.04.01_60/en_30184101v010401p.pdf |
 | ETSI EN 301 841-2 V1.2.1 | AVLC link layer: frame structure (Table 5.1a), addresses (Table 5.2/5.3), control field (Table 5.5) | https://www.etsi.org/deliver/etsi_en/301800_301899/30184102/01.02.01_60/en_30184102v010201p.pdf |
+| ICAO Doc 9776 (VDL2 Technical Manual) | XID: VDL private parameter set identifiers/names (connection management, destination airport, autotune, timers) | public ICAO manual |
+| ISO/IEC 8885 | XID frame structure: FI octet, GI/GL groups, PI/PL/PV parameters | via Doc 9776 and EN 301 841-2 citations |
 | ITU-R M.1371-5 | AIS: GMSK/NRZI, HDLC framing, training sequence, message bit ordering | freely published by ITU |
 | ISO/IEC 13239 | HDLC framing conventions (flags, stuffing, FCS) referenced by AVLC and AIS | via EN 301 841-2 citations |
 | ISO/IEC TR 9577 | AVLC payload protocol identification (0xFF ACARS escape, 0x81 CLNP, 0x82 ES-IS, 0x83 IDRP) | via Wiley excerpt + GE patent below |

--- a/proto/asf2.proto
+++ b/proto/asf2.proto
@@ -83,6 +83,11 @@ message HfdlBody {
   string details_json = 2;
 }
 
+message Vdl2Body {
+  string kind = 1;          // xid | avlc-rr | avlc-i | avlc-ua | ...
+  string details_json = 2;  // addresses, control, decoded parameters
+}
+
 message IridiumBody {
   string kind = 1;
   string details_json = 2;
@@ -120,6 +125,7 @@ message DecodedMessage {
     StdcBody stdc = 14;
     HfdlBody hfdl = 15;
     IridiumBody iridium = 16;
+    Vdl2Body vdl2 = 17;
   }
 }
 

--- a/src/outputs/console.rs
+++ b/src/outputs/console.rs
@@ -92,6 +92,40 @@ pub fn format_message(msg: &Message, fmt: ConsoleFormat) -> String {
                     }
                     s
                 }
+                MessageBody::Vdl2 { kind, details } => {
+                    let addr = |k: &str| {
+                        details
+                            .get(k)
+                            .and_then(|a| a.get("addr"))
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("?")
+                            .to_owned()
+                    };
+                    let mut s =
+                        format!("VDL2 {} {}→{}", kind.to_uppercase(), addr("src"), addr("dst"));
+                    if let Some(nr) = details.pointer("/control/nr").and_then(|v| v.as_u64()) {
+                        s.push_str(&format!(" nr={nr}"));
+                    }
+                    if let Some(p) = details.get("protocol").and_then(|v| v.as_str()) {
+                        s.push_str(&format!(" [{p}]"));
+                    }
+                    if let Some(params) = details.get("params").and_then(|v| v.as_array()) {
+                        let named: Vec<String> = params
+                            .iter()
+                            .filter_map(|p| {
+                                let name = p.get("name")?.as_str()?;
+                                match p.get("text").and_then(|t| t.as_str()) {
+                                    Some(t) => Some(format!("{name}={t}")),
+                                    None => Some(name.to_string()),
+                                }
+                            })
+                            .collect();
+                        if !named.is_empty() {
+                            s.push_str(&format!(" | {}", named.join(", ")));
+                        }
+                    }
+                    s
+                }
                 MessageBody::Hfdl { kind, details } => {
                     let mut s = format!("HFDL {kind}");
                     for key in ["gs_id", "flight", "icao", "frame_index"] {

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -24,6 +24,8 @@ struct App {
     messages: VecDeque<Message>,
     selected: Option<usize>,
     follow: bool,
+    /// Detail pane shows a human-readable summary; 'v' toggles raw JSON.
+    detail_json: bool,
     waterfall: VecDeque<Vec<f32>>,
     started: Instant,
     session_line: String,
@@ -63,6 +65,7 @@ pub fn run(mut source: Box<dyn IqSource>, cfg: SessionConfig) -> anyhow::Result<
         messages: VecDeque::new(),
         selected: None,
         follow: true,
+        detail_json: false,
         waterfall: VecDeque::new(),
         started: Instant::now(),
         session_line: format!(
@@ -133,6 +136,9 @@ pub fn run(mut source: Box<dyn IqSource>, cfg: SessionConfig) -> anyhow::Result<
                         }
                         KeyCode::End | KeyCode::Char('G') | KeyCode::Char('f') => {
                             app.follow = true;
+                        }
+                        KeyCode::Char('v') => {
+                            app.detail_json = !app.detail_json;
                         }
                         KeyCode::Char('c') => {
                             app.messages.clear();
@@ -221,12 +227,19 @@ fn draw(
     let detail = app
         .selected
         .and_then(|i| app.messages.get(i))
-        .map(|m| serde_json::to_string_pretty(m).unwrap_or_default())
+        .map(|m| {
+            if app.detail_json {
+                serde_json::to_string_pretty(m).unwrap_or_default()
+            } else {
+                detail_pretty(m)
+            }
+        })
         .unwrap_or_else(|| "no message selected".into());
+    let title = if app.detail_json { " detail (json — v: pretty) " } else { " detail (v: json) " };
     f.render_widget(
         Paragraph::new(detail)
             .wrap(Wrap { trim: false })
-            .block(Block::default().borders(Borders::ALL).title(" detail ")),
+            .block(Block::default().borders(Borders::ALL).title(title)),
         main[1],
     );
 
@@ -239,7 +252,7 @@ fn draw(
     draw_stats(f, stats, bottom[1]);
 
     f.render_widget(
-        Paragraph::new(" q quit | j/k scroll | f follow | c clear ")
+        Paragraph::new(" q quit | j/k scroll | f follow | v detail view | c clear ")
             .style(Style::default().fg(Color::DarkGray)),
         outer[3],
     );
@@ -347,4 +360,95 @@ fn draw_stats(f: &mut Frame, stats: &[(u64, u64, u64, f32)], area: Rect) {
         Paragraph::new(lines).block(Block::default().borders(Borders::ALL).title(" channels ")),
         area,
     );
+}
+
+/// Human-readable detail pane: the message's vitals, the same summary
+/// line the console prints, and the body's fields walked out as
+/// indented `key: value` lines (raw JSON is one `v` press away).
+fn detail_pretty(m: &Message) -> String {
+    use xng_types::MessageBody;
+    let mut out = String::new();
+    out.push_str(&format!(
+        "{}  {}  {:.3} MHz\n",
+        m.timestamp.format("%H:%M:%S%.3f"),
+        m.mode,
+        m.frequency_hz as f64 / 1e6
+    ));
+    if let Some(rssi) = m.signal.rssi_db {
+        out.push_str(&format!("signal   {rssi:.1} dBFS\n"));
+    }
+    let fec = m.decode.fec_corrected.unwrap_or(0);
+    out.push_str(&format!(
+        "decode   CRC {}{}\n",
+        if m.decode.crc_ok { "ok" } else { "FAILED" },
+        if fec > 0 { format!(" · {fec} FEC-corrected") } else { String::new() }
+    ));
+    out.push('\n');
+    out.push_str(&format_message(m, ConsoleFormat::Pretty));
+    out.push('\n');
+
+    match &m.body {
+        MessageBody::Acars(a) => {
+            if !a.text.is_empty() {
+                out.push('\n');
+                out.push_str(&a.text);
+                out.push('\n');
+            }
+        }
+        MessageBody::Vdl2 { details, .. }
+        | MessageBody::Hfdl { details, .. }
+        | MessageBody::Iridium { details, .. }
+        | MessageBody::StdC { details, .. } => {
+            out.push('\n');
+            walk_json(details, 0, &mut out);
+        }
+        _ => {}
+    }
+
+    if let Some(raw) = &m.raw {
+        let shown = &raw[..raw.len().min(48)];
+        out.push_str(&format!(
+            "\nraw      {}{} ({} bytes)\n",
+            shown.iter().map(|b| format!("{b:02x}")).collect::<String>(),
+            if raw.len() > shown.len() { "…" } else { "" },
+            raw.len()
+        ));
+    }
+    out
+}
+
+fn walk_json(v: &serde_json::Value, indent: usize, out: &mut String) {
+    let pad = "  ".repeat(indent);
+    match v {
+        serde_json::Value::Object(map) => {
+            for (k, val) in map {
+                match val {
+                    serde_json::Value::Object(_) | serde_json::Value::Array(_) => {
+                        out.push_str(&format!("{pad}{k}:\n"));
+                        walk_json(val, indent + 1, out);
+                    }
+                    _ => out.push_str(&format!("{pad}{k}: {}\n", scalar(val))),
+                }
+            }
+        }
+        serde_json::Value::Array(items) => {
+            for item in items {
+                match item {
+                    serde_json::Value::Object(_) | serde_json::Value::Array(_) => {
+                        out.push_str(&format!("{pad}-\n"));
+                        walk_json(item, indent + 1, out);
+                    }
+                    _ => out.push_str(&format!("{pad}- {}\n", scalar(item))),
+                }
+            }
+        }
+        _ => out.push_str(&format!("{pad}{}\n", scalar(v))),
+    }
+}
+
+fn scalar(v: &serde_json::Value) -> String {
+    match v {
+        serde_json::Value::String(s) => s.clone(),
+        other => other.to_string(),
+    }
 }


### PR DESCRIPTION
Live TUI session on the Airspy showed VDL2 acks as `FRAME (11 raw bytes)` with `body: undecoded` — but the AVLC layer had already parsed addresses, control, and payload class; `to_message` was throwing it away.

## Decode as much as we can
- New `MessageBody::Vdl2 { kind, details }` (+ asf2 `Vdl2Body` field 17, console arm): every non-ACARS frame now carries link-layer kind (`avlc-rr`, `avlc-ua`, `xid`, `atn`, …), src/dst addresses with types, and the full control field.
- ATN payloads labeled by IPI: CLNP / ES-IS / IDRP (ISO TR 9577, already referenced).
- **XID parameters decoded**: ISO 8885 group walk with the VDL private parameter set named per ICAO Doc 9776 (connection-management, destination-airport, autotune-frequency, …); printable values rendered as text. Console: `VDL2 XID 0468D2→2D4917 | destination-airport=KSMF`.
- The off-air fixture's ack frame renders as `VDL2 AVLC-RR 0468D2→2D4917 nr=2`; the exact screenshot frame (control 0xA1 → RR nr=5) is a regression test, plus XID name/text and malformed-XID tests.

## TUI detail toggle
`v` switches the detail pane between a human-readable rendering (vitals, the console summary line, body fields as indented key/value, full ACARS text, truncated raw hex) and raw JSON; the pane title indicates the active view and the help line documents the key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)