### PR TITLE
docs: sync everything with what v0.9.0 actually ships

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # xng
 
 [![Rust](https://github.com/airframesio/xng/actions/workflows/rust.yml/badge.svg?branch=master)](https://github.com/airframesio/xng/actions/workflows/rust.yml)
+[![Release](https://img.shields.io/github/v/release/airframesio/xng)](https://github.com/airframesio/xng/releases/latest)
 
 **One native SDR decoder for the whole aviation + maritime radio stack.**
 
@@ -12,7 +13,9 @@ capture, one message model, one application layer, and one set of outputs
 (including first-class [airframes.io](https://airframes.io) feeding).
 All nine modes are implemented, validated, and merged — including the
 complete Iridium stack (ring alerts through ACARS-over-SBD with a
-wideband burst-hunting front end).
+wideband burst-hunting front end) — and shipped as tagged releases with
+binaries for Linux (x86_64/arm64, tarball + .deb), macOS Apple Silicon,
+and multi-arch Docker images.
 
 ```bash
 # Two ACARS channels from one RTL-SDR, fed to Airframes:
@@ -48,7 +51,7 @@ conventions — invisible to loopback testing — were caught only this way).
 | Mode | `--mode` | Band | What you get | Validation |
 |---|---|---|---|---|
 | VHF ACARS (ARINC 618) | `acars` (default) | 118–137 MHz | ACARS + applications | Live off-air (RTL-SDR), CRC-verified, **fed to production Airframes end-to-end** |
-| VDL Mode 2 (ICAO Annex 10) | `vdl2` | 136.6–137 MHz | AVLC, ACARS-over-AVLC, XID | Off-air capture vs dumpvdl2 ground truth |
+| VDL Mode 2 (ICAO Annex 10) | `vdl2` | 136.6–137 MHz | ACARS-over-AVLC, AVLC link events with addresses, XID with decoded handoff parameters, ATN protocol labels | Off-air capture vs dumpvdl2 ground truth |
 | HFDL (ARINC 635) | `hfdl` | 2.8–22 MHz | Squitters, logons, positions, ACARS, **over-the-air system table** | Off-air 21 931 kHz capture, field-exact vs dumphfdl |
 | Inmarsat Aero L (JAERO port) | `aero` | 1545–1547 MHz | P-channels 600/1200 bps + 10.5 kbps, ACARS/ADS-C/CPDLC | Real Inmarsat recordings: 600 bps + 10.5k both decode off-air |
 | Inmarsat Aero C bursts | `aero-c` | C-band | R/T-channel signal units | RF loopback |
@@ -66,7 +69,7 @@ second-class path — they get every xng output and the application layer.
 | Device | `--sdr` | Backend | Notes |
 |---|---|---|---|
 | RTL-SDR | `driver=rtlsdr` | SoapySDR | The budget workhorse for VHF (ACARS, VDL2, AIS) and — with an L-band antenna + LNA — Aero, STD-C, Iridium, ADS-B |
-| Airspy R2 / Mini | `driver=airspy` | **native** (libairspy, `--features airspy`) | 24 MHz–1.75 GHz, 12-bit; `serial=…` (hex) selects a unit, `bias=1` powers an LNA |
+| Airspy R2 / Mini | `driver=airspy` | **native** (libairspy, `--features airspy`) | 24 MHz–1.75 GHz, 12-bit; `serial=…` (hex) selects a unit, `bias=1` powers an LNA. Validated live (Mini: off-air ACARS at 6 MS/s) |
 | Airspy HF+ / Discovery | `driver=airspyhf` | **native** (libairspyhf, `--features airspyhf`) | The classic HFDL receiver; 768 kS/s divides cleanly into every xng HF/VHF channel rate |
 | SDRplay (RSP series) | `driver=sdrplay` | SoapySDR | The Soapy module wraps the proprietary API |
 | Anything else | per its Soapy module | SoapySDR | HackRF, LimeSDR, USRP, BladeRF, … |
@@ -77,6 +80,26 @@ native Airspy backends map dB sensibly onto the actual hardware controls
 gain). With a native backend compiled in, its driver name routes to it
 automatically; add `backend=soapy` to force SoapySDR instead. IQ-file
 input (`xng decode`) needs no hardware or SDR libraries at all.
+
+## Installing
+
+Grab a [release](https://github.com/airframesio/xng/releases/latest) —
+tarballs for Linux x86_64/arm64 and macOS Apple Silicon, `.deb` packages
+for Debian/Ubuntu (which declare the runtime libraries), and `SHA256SUMS`.
+The binaries need `libsoapysdr` at runtime (plus `libairspy`/`libairspyhf`
+for native Airspy):
+
+```bash
+sudo apt install ./xng_0.9.0_arm64.deb     # pulls runtime deps
+# or
+tar xzf xng-v0.9.0-x86_64-unknown-linux-gnu.tar.gz && sudo cp xng-*/xng /usr/local/bin/
+```
+
+Multi-arch Docker images (amd64/arm64/armv7) are published per tag:
+
+```bash
+docker run --rm ghcr.io/airframesio/xng:latest --version
+```
 
 ## Building
 
@@ -210,15 +233,18 @@ xng decode vdl2.cf32 --mode vdl2 -r 50000 -c 136.975M --channels 136.975 --json
 
 ### Interactive TUI
 
-Live message browser with a JSON detail pane, per-channel statistics,
-spectrum with channel markers, and a waterfall — over a live SDR or a
-replayed file:
+Live message browser with a detail pane (press `v` to flip between a
+human-readable rendering and raw JSON), per-channel statistics, spectrum
+with channel markers, and a waterfall — over a live SDR or a replayed
+file:
 
 ```bash
 # Zero config: channels, center, and sample rate come from the mode's
-# built-in plan — as many channels as fit the capture width and CPU
+# built-in plan — as many channels as fit the capture width and CPU.
+# Native-backend devices are asked which rates they support (an Airspy
+# Mini gets 3 MS/s automatically, not the plan's 2.4):
 xng tui --sdr driver=rtlsdr
-xng tui --sdr driver=rtlsdr --mode vdl2
+xng tui --sdr driver=airspy --mode vdl2
 
 # Explicit tuning still works (and is required for --file replay)
 xng tui --sdr driver=rtlsdr -r 2400000 -c 131.500M --channels 131.550,131.125

--- a/crates/xng-mode-vdl2/PROVENANCE.md
+++ b/crates/xng-mode-vdl2/PROVENANCE.md
@@ -89,3 +89,16 @@ non-coherently. Off-air result: 13 frames (from 10), including the
 ground-station XID bursts whose symbol errors previously drove RS into
 miscorrection. Remaining gap to dumpvdl2 is hunt trigger sensitivity on
 the weakest bursts.
+
+## AVLC structured bodies + XID parameters (2026-06)
+
+Non-ACARS frames emit structured bodies (addresses, control, payload
+class) — all from the existing EN 301 841-2 clean-room parse. The XID
+parameter walk (FI octet, GI/GL groups, PI/PL/PV) follows ISO/IEC 8885
+as cited by EN 301 841-2; the VDL private parameter set names
+(connection-management, destination-airport, autotune-frequency, ...)
+are from ICAO Doc 9776 (public manual). Values are rendered as hex plus
+printable text where applicable; binary parameter layouts we have not
+verified against the spec are deliberately left as hex rather than
+guessed. ATN payloads are labeled by IPI per ISO TR 9577 (0x81 CLNP,
+0x82 ES-IS, 0x83 IDRP).

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,12 @@
 # xng — Next-Generation Multi-Mode SDR Decoder
 
-**Status:** Architecture blueprint (2026-06-09). This document records the research,
-the decisions made, and the target architecture for the xng rewrite.
+**Status:** Architecture blueprint (2026-06-09), preserved as the design
+record. The rewrite shipped: all nine modes are implemented and validated
+(off-air or reference vectors), the VHF ACARS chain is proven end-to-end
+into production Airframes from a live station, and v0.9.0 is the first
+tagged release with per-platform binaries. The README is the current
+user-facing truth; `docs/REFERENCES.md` and per-crate `PROVENANCE.md`
+track sourcing.
 
 ## 1. Vision
 

--- a/docs/ASF2.md
+++ b/docs/ASF2.md
@@ -1,6 +1,9 @@
 # asf-2.0 — Airframes Standard Format, version 2
 
-**Status:** draft, implemented by xng (client + reference ingest) as of M3.
+**Status:** implemented by xng (client + reference ingest); schema
+`proto/asf2.proto` is canonical. Per-mode bodies as of v0.9.0: ACARS,
+AIS, Mode S, STD-C, HFDL, Iridium, VDL2 (AVLC link events / XID), plus
+`undecoded` with raw bytes always preserved.
 
 One protobuf schema (`proto/asf2.proto`), two transports. Replaces the
 port-per-decoder JSON zoo with a single multiplexed, typed, versioned feed

--- a/src/main.rs
+++ b/src/main.rs
@@ -127,9 +127,10 @@ impl OutputOpts {
 
 #[derive(Subcommand)]
 enum Command {
-    /// List available SDR devices (SoapySDR)
+    /// List available SDR devices (native Airspy backends + SoapySDR)
     Devices {
-        /// SoapySDR filter args, e.g. "driver=rtlsdr"
+        /// SoapySDR filter args, e.g. "driver=rtlsdr" (native devices
+        /// are always listed)
         #[arg(default_value = "")]
         filter: String,
     },


### PR DESCRIPTION
Documentation pass after the v0.9.0 burst of features:

- **README**: release badge + new *Installing* section (release tarballs, .deb with declared runtime deps, ghcr Docker images); VDL2 supported-modes row reflects structured AVLC/XID/ATN bodies; Airspy hardware row records the live Mini validation; TUI section documents the `v` detail toggle and device-aware zero-config rates.
- **docs/ASF2.md**: status updated from "draft as of M3" to implemented, with the current body list (incl. `Vdl2Body`).
- **docs/ARCHITECTURE.md**: header now marks it as the preserved design record and summarizes shipped reality (all nine modes, production feed validation, v0.9.0).
- **xng-mode-vdl2/PROVENANCE.md**: sourcing for the AVLC structured bodies and XID parameters (ISO 8885 walk, Doc 9776 names, hex-not-guessed policy).
- **CLI**: `xng devices` help no longer claims SoapySDR-only.

Cross-checked the README's examples against the live `--help` surface: all ten subcommands documented, flags verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)