### PR TITLE
scan/survey: device-aware sample rates, same as the tui

### DIFF
--- a/src/commands/scan.rs
+++ b/src/commands/scan.rs
@@ -206,11 +206,19 @@ pub fn run(
     let mut results: Vec<ChannelResult> = Vec::new();
     let mut groups_total = 0usize;
     let mut plans = Vec::new();
+    // Plan rates target common hardware (RTL-SDR); devices with a fixed
+    // rate list (Airspy) get the smallest advertised rate that divides
+    // the mode's channel rate.
+    let advertised = crate::probe_device_rates(sdr);
     for &mode in modes {
-        let (rate, channels) = plan(mode);
+        let (plan_rate, channels) = plan(mode);
         if channels.is_empty() {
             tracing::warn!("no built-in frequency plan for mode {mode}; skipping");
             continue;
+        }
+        let rate = pick_auto_rate(&advertised, mode, plan_rate);
+        if rate != plan_rate {
+            tracing::info!("{mode}: device prefers {} S/s over the plan's {} S/s", rate as u64, plan_rate as u64);
         }
         let groups = group_channels(&channels, rate, passband(mode));
         groups_total += groups.len();
@@ -316,7 +324,7 @@ pub fn run(
         if active.is_empty() {
             continue;
         }
-        let (rate, _) = plan(mode);
+        let rate = pick_auto_rate(&advertised, mode, plan(mode).0);
         let freqs: Vec<u64> = active.iter().map(|r| r.frequency_hz).collect();
         let center = (freqs.iter().min().unwrap() + freqs.iter().max().unwrap()) / 2;
         let center = if freqs.contains(&center) { center + 25_000 } else { center };

--- a/src/commands/survey.rs
+++ b/src/commands/survey.rs
@@ -88,7 +88,17 @@ struct ChanAcc {
 pub fn run(opts: SurveyOpts) -> anyhow::Result<()> {
     let mode = opts.mode;
     let (plan_rate, plan_channels) = scan::plan(mode);
-    let rate = opts.sample_rate.unwrap_or(plan_rate);
+    let rate = match opts.sample_rate {
+        Some(r) => r,
+        None => {
+            let advertised = crate::probe_device_rates(&opts.sdr);
+            let r = scan::pick_auto_rate(&advertised, mode, plan_rate);
+            if r != plan_rate {
+                println!("device prefers {} S/s over the plan's {} S/s", r as u64, plan_rate as u64);
+            }
+            r
+        }
+    };
     let passband = scan::passband(mode);
 
     // Ctrl-C ends the survey early but still produces the report.

--- a/src/main.rs
+++ b/src/main.rs
@@ -411,7 +411,7 @@ fn resolve_tune_auto(
 /// Advertised sample rates of the device `--sdr` selects, where a native
 /// backend can ask (empty when it can't — SoapySDR devices generally
 /// accept the plan rates).
-fn probe_device_rates(sdr: &str) -> Vec<u32> {
+pub(crate) fn probe_device_rates(sdr: &str) -> Vec<u32> {
     let args = sdr_args::SdrArgs::parse(sdr);
     if args.force_soapy {
         return Vec::new();


### PR DESCRIPTION
Field report, same class as #42 but in `scan` (and latent in `survey`): every capture group was skipped on an Airspy Mini because the plan's 2.4 MS/s was used unconditionally.

Both commands now use the #42 probe when no explicit rate is given: ask the native backend for advertised rates, take the smallest that divides the mode's channel rate — **per mode**, which matters: the Mini gets 3 MS/s for ACARS/VDL2 but 6 MS/s for AIS (48 kHz channels don't divide 3 MS/s). Scan proposals print the rate actually used; SoapySDR devices keep plan rates (probe returns empty, verified live on the RTL-SDR).

Rate-picking logic is the unit-tested `pick_auto_rate` from #42. Live Airspy verification pending the replug (the Mini is still off the USB bus).

🤖 Generated with [Claude Code](https://claude.com/claude-code)