### PR TITLE
v0.9.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3516,7 +3516,7 @@ dependencies = [
 
 [[package]]
 name = "xng"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3555,7 +3555,7 @@ dependencies = [
 
 [[package]]
 name = "xng-acars"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "crc",
  "serde",
@@ -3565,7 +3565,7 @@ dependencies = [
 
 [[package]]
 name = "xng-dsp"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "crc",
  "num-complex",
@@ -3574,7 +3574,7 @@ dependencies = [
 
 [[package]]
 name = "xng-mode-acars"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "chrono",
  "num-complex",
@@ -3586,7 +3586,7 @@ dependencies = [
 
 [[package]]
 name = "xng-mode-adsb"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "chrono",
  "num-complex",
@@ -3596,7 +3596,7 @@ dependencies = [
 
 [[package]]
 name = "xng-mode-aero"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "chrono",
  "num-complex",
@@ -3610,7 +3610,7 @@ dependencies = [
 
 [[package]]
 name = "xng-mode-ais"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "chrono",
  "num-complex",
@@ -3620,7 +3620,7 @@ dependencies = [
 
 [[package]]
 name = "xng-mode-hfdl"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "chrono",
  "num-complex",
@@ -3633,7 +3633,7 @@ dependencies = [
 
 [[package]]
 name = "xng-mode-iridium"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "chrono",
  "crc",
@@ -3648,7 +3648,7 @@ dependencies = [
 
 [[package]]
 name = "xng-mode-stdc"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "chrono",
  "num-complex",
@@ -3661,7 +3661,7 @@ dependencies = [
 
 [[package]]
 name = "xng-mode-vdl2"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "chrono",
  "num-complex",
@@ -3674,7 +3674,7 @@ dependencies = [
 
 [[package]]
 name = "xng-proto"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "chrono",
  "prost",
@@ -3685,7 +3685,7 @@ dependencies = [
 
 [[package]]
 name = "xng-sdr"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "num-complex",
  "pkg-config",
@@ -3696,7 +3696,7 @@ dependencies = [
 
 [[package]]
 name = "xng-types"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "chrono",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["legacy"]
 resolver = "2"
 
 [workspace.package]
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/airframesio/xng"


### PR DESCRIPTION
Patch release over 0.9.0:
- `scan`/`survey` pick device-supported sample rates per mode (Airspy Mini field fix — every capture group used to fail at the plan's 2.4 MS/s)
- Documentation synced to the implementation (Installing section, ASF2 body list, VDL2 mode row, TUI toggle)
- `xng devices` help no longer claims SoapySDR-only

Tag v0.9.1 follows the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated for patch release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->