### PR TITLE
ACARS: multi-block reassembly, MIAM, OHMA

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1313,6 +1319,15 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+]
 
 [[package]]
 name = "mio"
@@ -3557,7 +3572,9 @@ dependencies = [
 name = "xng-acars"
 version = "0.9.1"
 dependencies = [
+ "base64",
  "crc",
+ "miniz_oxide",
  "serde",
  "serde_json",
  "xng-types",

--- a/README.md
+++ b/README.md
@@ -297,6 +297,13 @@ ACARS from any carrier flows through one application layer
   text with decoded arguments: `REQUEST CLIMB TO FL360`,
   `AT 14:32 EXPECT M0.84`, `REQUEST DIRECT TO 52°18.5'N 4°46.0'E`,
   multi-element messages included.
+- **MIAM** (ARINC 841): single-transfer CORE PDUs decompressed
+  (DEFLATE), file-transfer signalling decoded.
+- **OHMA**: Boeing aircraft-health JSON unwrapped (base64 + zlib) into
+  structured output.
+- **Multi-block reassembly**: long messages spanning ACARS blocks are
+  stitched back together (libacars-equivalent keying and timeouts), and
+  the application layer re-runs over the complete text.
 - Media advisory, H1 sublabel/MFI handling.
 
 ## Workspace layout

--- a/crates/xng-acars/Cargo.toml
+++ b/crates/xng-acars/Cargo.toml
@@ -8,7 +8,9 @@ repository.workspace = true
 authors.workspace = true
 
 [dependencies]
+base64 = "0.22"
 crc.workspace = true
+miniz_oxide = "0.8"
 serde.workspace = true
 serde_json.workspace = true
 xng-types.workspace = true

--- a/crates/xng-acars/PROVENANCE.md
+++ b/crates/xng-acars/PROVENANCE.md
@@ -26,3 +26,24 @@ independent reimplementation before porting.
 Differences from libacars: Rust-native types with serde serialization;
 CPDLC (AT1/CR1/CC1/DR1) payloads are currently carried as verified raw hex
 pending the FANS-1/A ASN.1 PER decoder; MIAM/OHMA not yet ported.
+
+## Reassembly, MIAM, OHMA (2026-06)
+
+Ported from MIT-licensed libacars with attribution:
+
+- `reasm.rs`: multi-block reassembly semantics from reassembly.c +
+  acars.c — key (tail, label, msg_num), downlink sequencing via the 4th
+  message-number character, uplink sequencing via block id with the
+  A..W wrap, the empty-uplink-ACK skip, per-bearer timeouts.
+- `miam.rs`: miam.c / miam-core.c — ACARS CF frame map (T/F/K/S/A/Y/X),
+  base85 armor ('!' offset, 'z' zero-word), bpad/hpad + '|' framing,
+  v1/v2 DATA header layouts, DEFLATE bodies inflated as raw streams
+  (windowBits −15 equivalence via miniz_oxide). CRC fields parsed but
+  not verified (matches libacars default behavior).
+- `ohma.rs`: ohma.c — OHMA/RYKO marker with downlink/uplink routing
+  prefixes, the duplicated-first-block quirk workaround, base64 → zlib
+  → JSON.
+
+Synthetic roundtrip vectors (compress → render → parse) stand in for
+off-air samples until label-MA/OHMA traffic is captured at the live
+station.

--- a/crates/xng-acars/src/block.rs
+++ b/crates/xng-acars/src/block.rs
@@ -100,6 +100,7 @@ pub fn parse(octets: &[u8]) -> Option<AcarsBlock> {
             msg_num,
             text,
             more_to_come: ch[suffix_idx] == ETB,
+            reassembled: false,
             app: appdec
                 .app
                 .map(|a| serde_json::to_value(&a).unwrap_or_default()),

--- a/crates/xng-acars/src/lib.rs
+++ b/crates/xng-acars/src/lib.rs
@@ -13,6 +13,9 @@ pub mod arinc622;
 pub mod cpdlc;
 pub mod block;
 pub mod media_adv;
+pub mod miam;
+pub mod ohma;
+pub mod reasm;
 pub mod sublabel;
 
 use serde::Serialize;
@@ -28,6 +31,14 @@ pub enum AcarsApp {
         #[serde(flatten)]
         message: adsc::AdscMessage,
     },
+    /// MIAM (ARINC 841) frame: single-transfer CORE PDUs (decompressed)
+    /// or file-transfer signalling.
+    Miam {
+        #[serde(flatten)]
+        frame: miam::MiamFrame,
+    },
+    /// OHMA aircraft-health JSON (Boeing), inflated and parsed.
+    Ohma { message: serde_json::Value },
     /// CPDLC (FANS-1/A) message in an ARINC 622 envelope: header and the
     /// first message element identified from the unaligned-PER body
     /// (element arguments are a planned follow-up).
@@ -68,7 +79,10 @@ pub fn decode(label: &str, text: &str, downlink: bool) -> AppDecode {
     }
 
     out.app = match label {
-        "A6" | "AA" | "B6" | "BA" | "H1" => arinc622::parse(body, downlink),
+        "A6" | "AA" | "B6" | "BA" => arinc622::parse(body, downlink),
+        "H1" => arinc622::parse(body, downlink)
+            .or_else(|| ohma::parse(body).map(|message| AcarsApp::Ohma { message })),
+        "MA" => miam::parse(body).map(|frame| AcarsApp::Miam { frame }),
         "SA" => media_adv::parse(body).map(AcarsApp::MediaAdvisory),
         _ => None,
     };
@@ -88,6 +102,30 @@ pub fn summary(app: &AcarsApp) -> Option<String> {
             m.current_link,
             if m.established { "established" } else { "lost" },
             m.time
+        )),
+        AcarsApp::Miam { frame } => Some(match frame {
+            miam::MiamFrame::SingleTransfer(p) => format!(
+                "MIAM v{} {}{}{}",
+                p.version,
+                p.pdu_type,
+                p.app_id.as_deref().map(|a| format!(" app={a}")).unwrap_or_default(),
+                if p.compressed { format!(" ({} bytes inflated)", p.data_len) } else { String::new() }
+            ),
+            miam::MiamFrame::FileTransferReq { file_id, file_size } => {
+                format!("MIAM file-transfer-req id={file_id} size={file_size}")
+            }
+            miam::MiamFrame::FileSegment { file_id, segment_id } => {
+                format!("MIAM file-segment id={file_id} seg={segment_id}")
+            }
+            f => format!("MIAM {}", serde_json::json!(f)["frame"].as_str().unwrap_or("frame")),
+        }),
+        AcarsApp::Ohma { message } => Some(format!(
+            "OHMA {}",
+            message
+                .pointer("/message/sysid")
+                .or_else(|| message.get("version"))
+                .map(|v| v.to_string().trim_matches('"').to_owned())
+                .unwrap_or_default()
         )),
     }
 }

--- a/crates/xng-acars/src/miam.rs
+++ b/crates/xng-acars/src/miam.rs
@@ -1,0 +1,294 @@
+//! MIAM (Media Independent Aircraft Messaging, ARINC 841) — ported from
+//! MIT-licensed libacars (miam.c / miam-core.c; see PROVENANCE.md).
+//!
+//! MIAM rides on ACARS label MA. The first text character selects the
+//! ACARS Convergence Function frame: 'T' single transfer (a complete
+//! MIAM CORE PDU), 'F'/'K'/'S'/'A'/'Y'/'X' file-transfer signalling.
+//! CORE PDUs carry a base85-armored header and body around a '|'
+//! delimiter; DEFLATE-compressed bodies are inflated (raw stream, as
+//! libacars inflates with windowBits −15).
+
+use serde::Serialize;
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(tag = "frame", rename_all = "snake_case")]
+pub enum MiamFrame {
+    SingleTransfer(CorePdu),
+    FileTransferReq { file_id: u16, file_size: u32 },
+    FileTransferAccept { file_id: u16, segment_size: u8 },
+    FileSegment { file_id: u16, segment_id: u16 },
+    FileTransferAbort { file_id: u16, reason: u8 },
+    XoffInd { file_id: Option<u16> },
+    XonInd { file_id: Option<u16> },
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct CorePdu {
+    pub version: u8,
+    pub pdu_type: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub aircraft_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub app_id: Option<String>,
+    pub msg_num: Option<u8>,
+    pub compressed: bool,
+    /// Inner content when it decodes as text (often an embedded ACARS
+    /// message or XML document).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text: Option<String>,
+    /// Inner content length in bytes (text or binary).
+    pub data_len: usize,
+}
+
+/// Parse a label-MA ACARS text as MIAM. `None` = not MIAM.
+pub fn parse(text: &str) -> Option<MiamFrame> {
+    let (first, rest) = {
+        let mut ch = text.chars();
+        (ch.next()?, ch.as_str())
+    };
+    let num = |s: &str, n: usize| -> Option<u32> { s.get(..n)?.parse().ok() };
+    match first {
+        'T' => core_pdu(rest).map(MiamFrame::SingleTransfer),
+        'F' => Some(MiamFrame::FileTransferReq {
+            file_id: num(rest, 3)? as u16,
+            file_size: num(&rest[3..], 6)?,
+        }),
+        'K' => Some(MiamFrame::FileTransferAccept {
+            file_id: num(rest, 3)? as u16,
+            segment_size: {
+                let c = rest.as_bytes().get(3).copied()?;
+                match c {
+                    b'0'..=b'9' => c - b'0',
+                    b'A'..=b'F' => c - b'A' + 10,
+                    _ => return None,
+                }
+            },
+        }),
+        'S' => Some(MiamFrame::FileSegment {
+            file_id: num(rest, 3)? as u16,
+            segment_id: num(&rest[3..], 3)? as u16,
+        }),
+        'A' => Some(MiamFrame::FileTransferAbort {
+            file_id: num(rest, 3)? as u16,
+            reason: num(&rest[3..], 1)? as u8,
+        }),
+        'Y' => Some(MiamFrame::XoffInd { file_id: num(rest, 3).map(|v| v as u16) }),
+        'X' => Some(MiamFrame::XonInd { file_id: num(rest, 3).map(|v| v as u16) }),
+        _ => None,
+    }
+}
+
+/// base85 with '!' (0x21) zero digit and 'z' shorthand for an all-zero
+/// word; 5 chars → 4 bytes, big-endian.
+fn base85_decode(s: &str) -> Option<Vec<u8>> {
+    let mut out = Vec::with_capacity(s.len() / 5 * 4 + 8);
+    let b = s.as_bytes();
+    let mut i = 0;
+    while i < b.len() {
+        if b[i] == b'z' {
+            out.extend_from_slice(&[0, 0, 0, 0]);
+            i += 1;
+            continue;
+        }
+        if i + 5 > b.len() {
+            return None; // truncated group
+        }
+        let mut v: u64 = 0;
+        for k in 0..5 {
+            let d = b[i + k];
+            if !(0x21..0x21 + 85).contains(&d) {
+                return None;
+            }
+            v = v * 85 + (d - 0x21) as u64;
+        }
+        out.extend_from_slice(&(v as u32).to_be_bytes());
+        i += 5;
+    }
+    Some(out)
+}
+
+fn core_pdu(text: &str) -> Option<CorePdu> {
+    let b = text.as_bytes();
+    if b.len() < 3 {
+        return None;
+    }
+    let bpad = b[0];
+    let hpad = b[1];
+    if !matches!(bpad, b'0'..=b'3' | b'-' | b'.') || !matches!(hpad, b'0'..=b'3') {
+        return None;
+    }
+    let rest = &text[2..];
+    let (hdr_txt, body_txt) = rest.split_once('|')?;
+    if hdr_txt.is_empty() {
+        return None;
+    }
+    let mut hdr = base85_decode(hdr_txt)?;
+    let hpad = (hpad - b'0') as usize;
+    if hdr.len() < hpad + 1 {
+        return None;
+    }
+    hdr.truncate(hdr.len() - hpad);
+
+    let body: Vec<u8> = match bpad {
+        b'0'..=b'3' => {
+            let mut v = base85_decode(body_txt)?;
+            let p = (bpad - b'0') as usize;
+            if v.len() >= p {
+                v.truncate(v.len() - p);
+            }
+            v
+        }
+        b'-' => body_txt.as_bytes().to_vec(),
+        _ => Vec::new(), // '.': no body
+    };
+
+    let version = hdr[0] & 0xF;
+    let pdu_type_v = (hdr[0] >> 4) & 0xF;
+    let pdu_type = match pdu_type_v {
+        0 => "data",
+        1 => "ack",
+        2 => "aloha",
+        3 => "aloha-reply",
+        _ => "unknown",
+    };
+    let mut pdu = CorePdu {
+        version,
+        pdu_type,
+        aircraft_id: None,
+        app_id: None,
+        msg_num: None,
+        compressed: false,
+        text: None,
+        data_len: 0,
+    };
+    if pdu_type_v != 0 || !(version == 1 || version == 2) {
+        return Some(pdu); // non-DATA PDUs: type identification only
+    }
+
+    // DATA PDU header walk (v1 carries pdu_len + aircraft id; v2 skips
+    // straight to the message fields after one reserved octet).
+    let mut h = &hdr[1..];
+    if version == 1 {
+        if h.len() < 19 {
+            return Some(pdu);
+        }
+        h = &h[3..]; // 24-bit pdu_len (over header+body; not re-checked)
+        pdu.aircraft_id = Some(String::from_utf8_lossy(&h[..7]).trim().to_owned());
+        h = &h[7..];
+    } else {
+        if h.len() < 6 {
+            return Some(pdu);
+        }
+        h = &h[1..];
+    }
+    pdu.msg_num = Some((h[0] >> 1) & 0x7F);
+    h = &h[1..];
+    let compression = ((h[0] << 2) | ((h[1] >> 6) & 0x3)) & 0x7;
+    let app_type = h[1] & 0xF;
+    h = &h[2..];
+    let app_id_len = match app_type {
+        0 => 2,
+        1 => 4,
+        2 | 3 => 6,
+        t if version == 2 && (t & 0x8) != 0 && t != 0xD => (t & 0x7) as usize + 1,
+        _ => 0,
+    };
+    if app_id_len > 0 && h.len() >= app_id_len {
+        pdu.app_id = Some(String::from_utf8_lossy(&h[..app_id_len]).trim().to_owned());
+    }
+    pdu.compressed = compression == 0x1; // DEFLATE
+
+    let data: Vec<u8> = if pdu.compressed && !body.is_empty() {
+        // Raw deflate stream (libacars: inflateInit2 windowBits −15).
+        miniz_oxide::inflate::decompress_to_vec(&body).ok()?
+    } else {
+        body
+    };
+    pdu.data_len = data.len();
+    if !data.is_empty() && data.iter().all(|&c| c == b'\r' || c == b'\n' || c == b'\t' || (0x20..0x7F).contains(&c)) {
+        pdu.text = Some(String::from_utf8_lossy(&data).into_owned());
+    }
+    Some(pdu)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn base85_encode(data: &[u8]) -> String {
+        let mut s = String::new();
+        for chunk in data.chunks(4) {
+            let mut w = [0u8; 4];
+            w[..chunk.len()].copy_from_slice(chunk);
+            let mut v = u32::from_be_bytes(w) as u64;
+            let mut digits = [0u8; 5];
+            for d in digits.iter_mut().rev() {
+                *d = (v % 85) as u8 + 0x21;
+                v /= 85;
+            }
+            s.extend(digits.iter().map(|&d| d as char));
+        }
+        s
+    }
+
+    #[test]
+    fn base85_roundtrip() {
+        let data = b"MIAM-CORE-TEST!!";
+        let enc = base85_encode(data);
+        assert_eq!(base85_decode(&enc).unwrap(), data);
+        // 'z' shorthand
+        assert_eq!(base85_decode("z").unwrap(), vec![0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn file_transfer_frames_parse() {
+        assert_eq!(
+            parse("F012000345"),
+            Some(MiamFrame::FileTransferReq { file_id: 12, file_size: 345 })
+        );
+        assert_eq!(
+            parse("S012003"),
+            Some(MiamFrame::FileSegment { file_id: 12, segment_id: 3 })
+        );
+        assert_eq!(parse("not miam"), None);
+    }
+
+    #[test]
+    fn v1_data_pdu_with_deflate_body_roundtrips() {
+        // Build a v1 DATA PDU: header (ver 1, type 0), pdu_len, aircraft
+        // id, msg_num/ack, compression=DEFLATE, app_type=2-char + CRC32.
+        let inner = b"#T2BThis is the embedded MIAM payload";
+        let compressed =
+            miniz_oxide::deflate::compress_to_vec(inner, 6);
+        let mut hdr = vec![0x01u8]; // version 1, pdu_type DATA
+        let total = 20 + compressed.len();
+        hdr.extend_from_slice(&[(total >> 16) as u8, (total >> 8) as u8, total as u8]);
+        hdr.extend_from_slice(b".N12345"); // aircraft id (7)
+        hdr.push((42 << 1) | 1); // msg_num 42, ack
+        // compression DEFLATE (0x1), encoding ISO5, app_type 0 (2-char):
+        // comp = ((h0<<2)|(h1>>6))&7 → h0=0x00, h1=0b01_00_0000
+        hdr.push(0x00);
+        hdr.push(0x40);
+        hdr.extend_from_slice(b"T2"); // app id
+        hdr.extend_from_slice(&[0xDE, 0xAD, 0xBE, 0xEF]); // CRC32 (not checked)
+        // Pad both parts to whole base85 words; the pad counts ride in
+        // the two characters after the frame id.
+        let hpad = (4 - hdr.len() % 4) % 4;
+        let bpad = (4 - compressed.len() % 4) % 4;
+        let mut hdr_p = hdr.clone();
+        hdr_p.extend(std::iter::repeat(0).take(hpad));
+        let mut body_p = compressed.clone();
+        body_p.extend(std::iter::repeat(0).take(bpad));
+        let txt = format!("T{bpad}{hpad}{}|{}", base85_encode(&hdr_p), base85_encode(&body_p));
+
+        let MiamFrame::SingleTransfer(pdu) = parse(&txt).expect("miam") else {
+            panic!("expected single transfer");
+        };
+        assert_eq!(pdu.version, 1);
+        assert_eq!(pdu.pdu_type, "data");
+        assert_eq!(pdu.aircraft_id.as_deref(), Some(".N12345"));
+        assert_eq!(pdu.msg_num, Some(42));
+        assert!(pdu.compressed);
+        assert_eq!(pdu.text.as_deref(), Some(std::str::from_utf8(inner).unwrap()));
+    }
+}

--- a/crates/xng-acars/src/ohma.rs
+++ b/crates/xng-acars/src/ohma.rs
@@ -1,0 +1,77 @@
+//! OHMA: Boeing aircraft-health JSON carried in ACARS (typically H1/T1
+//! SMT downlinks). Recognition and framing ported from MIT-licensed
+//! libacars (ohma.c; see PROVENANCE.md): an optional routing prefix,
+//! the "OHMA"/"RYKO" marker, then base64 of a zlib stream containing
+//! JSON.
+
+use base64::Engine;
+
+/// Decode an OHMA message from ACARS text. `None` = not OHMA.
+pub fn parse(text: &str) -> Option<serde_json::Value> {
+    let mut ptr = text;
+    loop {
+        // Long downlink form: '/' + 7-char ground address + '.';
+        // uplink form: '/' + 2 chars + '.'.
+        let b = ptr.as_bytes();
+        if b.len() >= 13 && b[0] == b'/' && b[8] == b'.' {
+            ptr = &ptr[9..];
+        } else if b.len() >= 8 && b[0] == b'/' && b[3] == b'.' {
+            ptr = &ptr[4..];
+        }
+        if !(ptr.starts_with("OHMA") || ptr.starts_with("RYKO")) {
+            return None;
+        }
+        let prefix_len = text.len() - ptr.len() + 4;
+        let payload = &ptr[4..];
+        // Reassembly quirk (observed by libacars): a sender bug can
+        // duplicate the first block, yielding "...OHMAxxx/O2.OHMAxxxyyy".
+        // If the prefix recurs inside the payload, restart from there.
+        if let Some(pos) = payload.find(&text[..prefix_len]) {
+            ptr = &payload[pos..];
+            continue;
+        }
+        let cleaned: String =
+            payload.chars().filter(|c| !matches!(c, '\r' | '\n')).collect();
+        let bin = base64::engine::general_purpose::STANDARD
+            .decode(cleaned.as_bytes())
+            .ok()?;
+        // The payload is a zlib stream (CMF/FLG header + raw deflate).
+        let inflated = miniz_oxide::inflate::decompress_to_vec_zlib(&bin).ok()?;
+        return serde_json::from_slice(&inflated).ok();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_ohma(json: &str, prefix: &str) -> String {
+        let compressed = miniz_oxide::deflate::compress_to_vec_zlib(json.as_bytes(), 6);
+        let b64 = base64::engine::general_purpose::STANDARD.encode(&compressed);
+        format!("{prefix}OHMA{b64}")
+    }
+
+    #[test]
+    fn short_form_decodes() {
+        let v = parse(&make_ohma(r#"{"version":1,"message":{"sysid":"APU"}}"#, "")).unwrap();
+        assert_eq!(v["message"]["sysid"], "APU");
+    }
+
+    #[test]
+    fn long_form_prefix_skipped() {
+        let v = parse(&make_ohma(r#"{"a":2}"#, "/RTNBOCR.")).unwrap();
+        assert_eq!(v["a"], 2);
+    }
+
+    #[test]
+    fn uplink_prefix_skipped() {
+        let v = parse(&make_ohma(r#"{"b":3}"#, "/O2.")).unwrap();
+        assert_eq!(v["b"], 3);
+    }
+
+    #[test]
+    fn non_ohma_rejected() {
+        assert!(parse("#DFB engine report").is_none());
+        assert!(parse("OHMAnot-base64!!").is_none());
+    }
+}

--- a/crates/xng-acars/src/reasm.rs
+++ b/crates/xng-acars/src/reasm.rs
@@ -1,0 +1,206 @@
+//! Multi-block ACARS reassembly, ported from MIT-licensed libacars
+//! (reassembly.c + acars.c keying; see PROVENANCE.md).
+//!
+//! Long ACARS messages span blocks: each block carries a slice of the
+//! text, intermediate blocks end with ETB (`more_to_come`), the final
+//! with ETX. Downlinks sequence via the 4th character of the message
+//! number (A, B, C ...) under a constant 3-char message id; uplinks
+//! sequence via the block id itself (cycling A..W). Fragments are keyed
+//! by (tail, label, msg_num) and joined when the final block arrives
+//! with a contiguous sequence.
+
+use std::collections::HashMap;
+use xng_types::AcarsCore;
+
+/// Outcome of offering one block to the reassembler.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Reasm {
+    /// Single-block message (or uplink ACK quirk): nothing to do.
+    Skipped,
+    /// Fragment stored; message not yet complete.
+    InProgress,
+    /// This (sequence number, payload) was already seen.
+    Duplicate,
+    /// Final block arrived: the returned string is the full text.
+    Complete(String),
+    /// Final block arrived but the sequence has holes.
+    Incomplete,
+}
+
+#[derive(Hash, PartialEq, Eq, Clone)]
+struct Key {
+    tail: String,
+    label: String,
+    /// 3-char message number (downlinks); empty for uplinks.
+    msg_num: String,
+}
+
+struct Entry {
+    frags: HashMap<i32, String>,
+    deadline: f64,
+}
+
+/// Uplink block ids cycle A..W ('X'..'Z' are reserved for ACKs).
+const UPLINK_SEQ_WRAP: i32 = ('X' as i32) - ('A' as i32);
+
+pub struct Reassembler {
+    entries: HashMap<Key, Entry>,
+    timeout_secs: f64,
+}
+
+impl Reassembler {
+    /// `timeout_secs`: fragment lifetime — libacars uses ~120 s on VHF
+    /// and several minutes on satcom/HF bearers.
+    pub fn new(timeout_secs: f64) -> Self {
+        Self { entries: HashMap::new(), timeout_secs }
+    }
+
+    /// Offer a parsed block. `now_secs` is any monotonic seconds source.
+    pub fn push(&mut self, core: &AcarsCore, now_secs: f64) -> Reasm {
+        self.entries.retain(|_, e| e.deadline > now_secs);
+
+        let Some(block_id) = core.block_id else { return Reasm::Skipped };
+        let downlink = ('0'..='9').contains(&block_id);
+        let (seq, msg_num, wrap) = if downlink {
+            // Downlink message number "M01A": 3-char id + sequence char.
+            let Some(num) = core.msg_num.as_deref() else { return Reasm::Skipped };
+            if num.len() < 4 {
+                return Reasm::Skipped;
+            }
+            let seq = num.as_bytes()[3] as i32 - 'A' as i32;
+            (seq, num[..3].to_owned(), i32::MAX)
+        } else {
+            // Empty-text uplink ACKs use out-of-sequence block ids (X,Y,Z).
+            if core.text.is_empty() {
+                return Reasm::Skipped;
+            }
+            (block_id as i32 - 'A' as i32, String::new(), UPLINK_SEQ_WRAP)
+        };
+        if seq < 0 {
+            return Reasm::Skipped;
+        }
+        let final_block = !core.more_to_come;
+
+        let key = Key {
+            tail: core.tail.clone().unwrap_or_default(),
+            label: core.label.clone(),
+            msg_num,
+        };
+        // The common case: a single-block message with no pending state.
+        if final_block && !self.entries.contains_key(&key) && (seq == 0 || !downlink) {
+            return Reasm::Skipped;
+        }
+
+        let entry = self.entries.entry(key.clone()).or_insert_with(|| Entry {
+            frags: HashMap::new(),
+            deadline: now_secs + self.timeout_secs,
+        });
+        if entry.frags.contains_key(&seq) {
+            return Reasm::Duplicate;
+        }
+        entry.frags.insert(seq, core.text.clone());
+
+        if !final_block {
+            return Reasm::InProgress;
+        }
+        let entry = self.entries.remove(&key).expect("just inserted");
+        // Join in sequence order; require contiguity from the first seen
+        // sequence number (downlinks start at 0; uplink block ids may
+        // wrap, handled by sorting modulo the wrap point).
+        let mut seqs: Vec<i32> = entry.frags.keys().copied().collect();
+        seqs.sort_unstable();
+        let contiguous = if downlink {
+            seqs[0] == 0 && seqs.windows(2).all(|w| w[1] == w[0] + 1)
+        } else {
+            // Uplinks: contiguous modulo wrap.
+            seqs.windows(2).all(|w| w[1] == w[0] + 1 || (w[0] == wrap - 1 && w[1] == 0))
+        };
+        if !contiguous {
+            return Reasm::Incomplete;
+        }
+        Some(())
+            .map(|_| seqs.iter().map(|s| entry.frags[s].as_str()).collect::<String>())
+            .map(Reasm::Complete)
+            .unwrap()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn core(tail: &str, label: &str, block_id: char, msg_num: Option<&str>, text: &str, more: bool) -> AcarsCore {
+        AcarsCore {
+            mode: '2',
+            tail: Some(tail.into()),
+            label: label.into(),
+            sublabel: None,
+            mfi: None,
+            block_id: Some(block_id),
+            ack: None,
+            flight: Some("UA0001".into()),
+            msg_num: msg_num.map(|s| s.into()),
+            text: text.into(),
+            more_to_come: more,
+            reassembled: false,
+            app: None,
+        }
+    }
+
+    #[test]
+    fn single_block_is_skipped() {
+        let mut r = Reassembler::new(120.0);
+        let c = core("N12345", "H1", '2', Some("M01A"), "HELLO", false);
+        assert_eq!(r.push(&c, 0.0), Reasm::Skipped);
+    }
+
+    #[test]
+    fn downlink_two_blocks_reassemble() {
+        let mut r = Reassembler::new(120.0);
+        let a = core("N12345", "H1", '2', Some("M01A"), "FIRST-", true);
+        let b = core("N12345", "H1", '3', Some("M01B"), "SECOND", false);
+        assert_eq!(r.push(&a, 0.0), Reasm::InProgress);
+        assert_eq!(r.push(&b, 5.0), Reasm::Complete("FIRST-SECOND".into()));
+    }
+
+    #[test]
+    fn uplink_blocks_key_on_block_id() {
+        let mut r = Reassembler::new(120.0);
+        let a = core("N12345", "H1", 'A', None, "/O2.OHMAabcd", true);
+        let b = core("N12345", "H1", 'B', None, "efgh", false);
+        assert_eq!(r.push(&a, 0.0), Reasm::InProgress);
+        assert_eq!(r.push(&b, 1.0), Reasm::Complete("/O2.OHMAabcdefgh".into()));
+    }
+
+    #[test]
+    fn duplicate_fragment_detected() {
+        let mut r = Reassembler::new(120.0);
+        let a = core("N12345", "H1", '2', Some("M01A"), "X", true);
+        assert_eq!(r.push(&a, 0.0), Reasm::InProgress);
+        assert_eq!(r.push(&a, 1.0), Reasm::Duplicate);
+    }
+
+    #[test]
+    fn timeout_drops_stale_fragments() {
+        let mut r = Reassembler::new(120.0);
+        let a = core("N12345", "H1", '2', Some("M01A"), "FIRST-", true);
+        let b = core("N12345", "H1", '3', Some("M01B"), "SECOND", false);
+        assert_eq!(r.push(&a, 0.0), Reasm::InProgress);
+        // Final block arrives after the timeout: first fragment is gone,
+        // sequence starts at B → holes → incomplete.
+        assert_eq!(r.push(&b, 200.0), Reasm::Incomplete);
+    }
+
+    #[test]
+    fn interleaved_aircraft_do_not_mix() {
+        let mut r = Reassembler::new(120.0);
+        let a1 = core("N11111", "H1", '2', Some("M01A"), "AAA", true);
+        let b1 = core("N22222", "H1", '2', Some("M55A"), "BBB", true);
+        let a2 = core("N11111", "H1", '3', Some("M01B"), "aaa", false);
+        let b2 = core("N22222", "H1", '3', Some("M55B"), "bbb", false);
+        r.push(&a1, 0.0);
+        r.push(&b1, 0.0);
+        assert_eq!(r.push(&a2, 1.0), Reasm::Complete("AAAaaa".into()));
+        assert_eq!(r.push(&b2, 1.0), Reasm::Complete("BBBbbb".into()));
+    }
+}

--- a/crates/xng-mode-acars/src/lib.rs
+++ b/crates/xng-mode-acars/src/lib.rs
@@ -108,6 +108,7 @@ pub fn to_message(
                 msg_num: f.msg_num.clone(),
                 text: f.text.clone(),
                 more_to_come: f.more_to_come,
+                reassembled: false,
                 app: appdec.app.map(|a| serde_json::to_value(&a).unwrap_or_default()),
             })
         },

--- a/crates/xng-proto/src/lib.rs
+++ b/crates/xng-proto/src/lib.rs
@@ -61,6 +61,7 @@ impl From<&Message> for asf2::DecodedMessage {
                     msg_num: a.msg_num.clone(),
                     text: a.text.clone(),
                     more_to_come: a.more_to_come,
+                    reassembled: a.reassembled,
                 }))
             }
             MessageBody::Ais { nmea, msg_type, mmsi } => {

--- a/crates/xng-types/src/message.rs
+++ b/crates/xng-types/src/message.rs
@@ -62,6 +62,9 @@ pub struct AcarsCore {
     pub text: String,
     /// True when more blocks follow (ETB rather than ETX).
     pub more_to_come: bool,
+    /// True when `text` was reassembled from multiple blocks.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub reassembled: bool,
     /// Decoded application layer (ADS-C, CPDLC envelope, media advisory,
     /// ...), as produced by xng-acars.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/proto/asf2.proto
+++ b/proto/asf2.proto
@@ -70,6 +70,7 @@ message AcarsBody {
   optional string mfi = 11;
   // Decoded application layer (ADS-C etc.) as JSON, when present.
   optional string app_json = 12;
+  bool reassembled = 13;
 }
 
 message AisBody {

--- a/src/commands/extern_cmd.rs
+++ b/src/commands/extern_cmd.rs
@@ -132,6 +132,7 @@ pub fn parse_line(line: &str, format: ExternFormat, station: &StationIdentity) -
                 msg_num: str_of(a, &["msg_num", "msgno"]).map(String::from),
                 text,
                 more_to_come: false,
+                reassembled: false,
                 app: appdec.app.map(|x| serde_json::to_value(&x).unwrap_or_default()),
             })
         }

--- a/src/commands/scan.rs
+++ b/src/commands/scan.rs
@@ -406,6 +406,7 @@ pub(crate) fn scan_group(
         bus,
         stop,
         Some((live.clone(), center, rate)),
+        None,
     )?;
     let _ = stop_thread.join();
 

--- a/src/commands/survey.rs
+++ b/src/commands/survey.rs
@@ -444,6 +444,7 @@ fn dwell(
         bus.clone(),
         stop,
         Some((live.clone(), center, rate)),
+        None,
     )?;
     let _ = stop_thread.join();
     let levels = live.stats.lock().unwrap().clone();

--- a/src/main.rs
+++ b/src/main.rs
@@ -417,12 +417,13 @@ pub(crate) fn probe_device_rates(sdr: &str) -> Vec<u32> {
     if args.force_soapy {
         return Vec::new();
     }
-    let serial = args.serial.as_deref().and_then(|s| sdr_args::parse_airspy_serial(s).ok());
+    let serial = || args.serial.as_deref().and_then(|s| sdr_args::parse_airspy_serial(s).ok());
+    let _ = &serial; // used only by the cfg'd arms below
     match args.driver.as_deref() {
         #[cfg(feature = "airspy")]
-        Some("airspy") => xng_sdr::airspy::device_rates(serial).unwrap_or_default(),
+        Some("airspy") => xng_sdr::airspy::device_rates(serial()).unwrap_or_default(),
         #[cfg(feature = "airspyhf")]
-        Some("airspyhf") => xng_sdr::airspyhf::device_rates(serial).unwrap_or_default(),
+        Some("airspyhf") => xng_sdr::airspyhf::device_rates(serial()).unwrap_or_default(),
         _ => Vec::new(),
     }
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -18,7 +18,7 @@ use xng_mode_iridium::{IridiumChannelDecoder, IridiumWidebandDecoder};
 use xng_mode_stdc::StdcChannelDecoder;
 use xng_mode_vdl2::Vdl2ChannelDecoder;
 use xng_sdr::{IqSource, SdrError};
-use xng_types::{AppInfo, ChannelInfo, Message, Mode, Provenance, SdrInfo, StationIdentity};
+use xng_types::{AppInfo, ChannelInfo, Message, MessageBody, Mode, Provenance, SdrInfo, StationIdentity};
 
 pub struct OutputConfig {
     /// Console format (always on).
@@ -380,7 +380,14 @@ pub fn run_session(mut source: Box<dyn IqSource>, cfg: SessionConfig) -> anyhow:
             let stop = stop.clone();
             {
                 let live = live.clone();
+                // Satellite/HF ACARS blocks arrive minutes apart; VHF
+                // bearers are quick (libacars timeout profiles).
+                let reasm_timeout = match cfg.mode {
+                    Mode::AcarsPoa | Mode::Vdl2 => 120.0,
+                    _ => 660.0,
+                };
                 move || {
+                    let mut reasm = xng_acars::reasm::Reassembler::new(reasm_timeout);
                     decode_loop(
                         &mut *source,
                         decoders,
@@ -389,6 +396,7 @@ pub fn run_session(mut source: Box<dyn IqSource>, cfg: SessionConfig) -> anyhow:
                         bus,
                         stop,
                         Some((live, capture_center, sample_rate)),
+                        Some(&mut reasm),
                     )
                 }
             }
@@ -422,6 +430,7 @@ pub(crate) fn decode_loop(
     bus: MessageBus,
     stop: Arc<AtomicBool>,
     live: Option<(Arc<LiveState>, u64, f64)>,
+    mut reasm: Option<&mut xng_acars::reasm::Reassembler>,
 ) -> anyhow::Result<Vec<(u64, u64, u64)>> {
     use std::sync::atomic::Ordering as AtomOrd;
     let mut spectrum_fft: Option<std::sync::Arc<dyn rustfft::Fft<f32>>> = None;
@@ -496,7 +505,10 @@ pub(crate) fn decode_loop(
             let (msgs, seen, ok) = dec.process(&buf[..n], *freq, &prov);
             stats[i].1 += seen;
             stats[i].2 += ok;
-            for msg in msgs {
+            for mut msg in msgs {
+                if let Some(r) = reasm.as_deref_mut() {
+                    apply_reassembly(&mut msg, r);
+                }
                 bus.publish(msg);
             }
             if let Some((state, _, _)) = &live {
@@ -509,6 +521,28 @@ pub(crate) fn decode_loop(
         }
     }
     Ok(stats)
+}
+
+/// Offer ACARS bodies to the multi-block reassembler; when a message
+/// completes, replace the text with the full assembly and re-run the
+/// application layer over it (long CPDLC/OHMA/MIAM payloads only decode
+/// from complete text).
+fn apply_reassembly(msg: &mut Message, r: &mut xng_acars::reasm::Reassembler) {
+    use xng_acars::reasm::Reasm;
+    let MessageBody::Acars(core) = &mut msg.body else { return };
+    if !msg.decode.crc_ok {
+        return;
+    }
+    let now = msg.timestamp.timestamp_millis() as f64 / 1e3;
+    if let Reasm::Complete(full) = r.push(core, now) {
+        let downlink = core.block_id.is_some_and(|b| b.is_ascii_digit());
+        let dec = xng_acars::decode(&core.label, &full, downlink);
+        core.text = full;
+        core.reassembled = true;
+        if let Some(app) = dec.app {
+            core.app = serde_json::to_value(&app).ok();
+        }
+    }
 }
 
 fn decoders_len_hint(i: usize) -> usize {

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -49,6 +49,7 @@ pub fn run(mut source: Box<dyn IqSource>, cfg: SessionConfig) -> anyhow::Result<
         let live = live.clone();
         let sdr = cfg.sdr.clone();
         move || {
+            let mut reasm = xng_acars::reasm::Reassembler::new(300.0);
             runtime::decode_loop(
                 &mut *source,
                 decoders,
@@ -57,6 +58,7 @@ pub fn run(mut source: Box<dyn IqSource>, cfg: SessionConfig) -> anyhow::Result<
                 bus,
                 stop,
                 Some((live, capture_center, sample_rate)),
+                Some(&mut reasm),
             )
         }
     });


### PR DESCRIPTION
Gap series **2/6** (vs libacars) — lifts every ACARS carrier at once, including the live Airframes feed.

- **Multi-block reassembly**: libacars-equivalent keying ((tail, label, msg-num), downlink seq via the 4th msg-number char, uplink seq via block id with A..W wrap, empty-ACK skip, per-bearer timeouts). A per-session reassembler replaces the final block's text with the full assembly, sets a new `reassembled` flag (JSON + asf2), and **re-runs the application layer** over complete text.
- **MIAM (ARINC 841)**: CF frames (T/F/K/S/A/Y/X), base85 armor, v1/v2 DATA headers, raw-DEFLATE bodies inflated (miniz_oxide); summaries like `MIAM v1 data app=T2 (1207 bytes inflated)`.
- **OHMA**: Boeing health JSON — marker+prefix recognition (incl. the duplicated-first-block sender bug workaround), base64 → zlib → JSON.

All three ported from MIT libacars with attribution (PROVENANCE updated). 11 new unit tests incl. full compress→render→parse roundtrips; whole workspace green. Off-air MA/OHMA samples will accrue from the live station.

🤖 Generated with [Claude Code](https://claude.com/claude-code)