### PR TITLE
AIS: field-level decode + raw NMEA UDP output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3631,6 +3631,7 @@ version = "0.9.1"
 dependencies = [
  "chrono",
  "num-complex",
+ "serde_json",
  "xng-dsp",
  "xng-types",
 ]

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ conventions — invisible to loopback testing — were caught only this way).
 | Inmarsat Aero C bursts | `aero-c` | C-band | R/T-channel signal units | RF loopback |
 | Inmarsat STD-C / EGC | `std-c` | 1537–1542 MHz | NCS frames, EGC SafetyNET/FleetNET text, logical-channel messages | Off-air EGC capture, field-exact vs reference |
 | Iridium | `iridium` | 1616–1626.5 MHz | Ring alerts (live satellite positions), broadcasts, **ACARS over SBD**, wideband burst hunting across the band | Every layer validated: bit-perfect demod of gr-iridium's reference burst (direct *and* via the wideband hunter) + field-identical decode vs the iridium-toolkit oracle |
-| AIS (ITU-R M.1371) | `ais` | 161.975/162.025 MHz | NMEA AIVDM | Canonical published test vector |
+| AIS (ITU-R M.1371) | `ais` | 161.975/162.025 MHz | NMEA AIVDM + **decoded fields** (positions, kinematics, names, voyage data) for types 1–5/9/18/19/21/24/27, raw-NMEA UDP for marine aggregators | Field-identical vs pyais oracle on canonical vectors |
 | Mode S / ADS-B | `adsb` | 1090 MHz | **CPR positions** (global+local, airborne+surface), velocity/heading/vertical rate, squawk, altitude replies (Q-bit + Gillham), per-aircraft tracking, **SBS/BaseStation output** | Published reference vectors (1090 Riddle worked examples); zero false positives on noise |
 
 All multi-channel modes decode any number of channels from one capture.
@@ -262,6 +262,7 @@ Every mode and every command shares the same output options:
 --jsonl messages.jsonl                         # JSONL file
 --metrics 0.0.0.0:9090                         # Prometheus (frames, CRC, levels)
 --sbs 0.0.0.0:30003                            # SBS/BaseStation TCP (Mode S)
+--nmea-udp 5.9.207.224:5321                    # raw AIVDM datagrams (AIS)
 --asf2-grpc http://ingest:6001                 # asf-2.0 over gRPC
 --asf2-quic ingest:6011                        # asf-2.0 over QUIC (TLS verified)
 ```

--- a/crates/xng-mode-ais/Cargo.toml
+++ b/crates/xng-mode-ais/Cargo.toml
@@ -8,6 +8,7 @@ repository.workspace = true
 authors.workspace = true
 
 [dependencies]
+serde_json.workspace = true
 chrono.workspace = true
 num-complex.workspace = true
 xng-dsp.workspace = true

--- a/crates/xng-mode-ais/PROVENANCE.md
+++ b/crates/xng-mode-ais/PROVENANCE.md
@@ -19,3 +19,12 @@ The end-to-end test is anchored to a widely published example AIVDM
 sentence (type 1, MMSI 477553000) reconstructed back to wire bits, so the
 bit-order/armoring conventions are verified against real-world data, not
 just self-consistency.
+
+## Field-level decode (2026-06)
+
+Message-type field layouts (1-5, 9, 18/19, 21, 24, 27: positions at
+1/600000 deg, SOG tenths of knots, 6-bit ASCII strings, nav-status
+table) implemented from ITU-R M.1371-5 as already referenced. Validated
+against pyais (MIT) as a decode oracle: the canonical type 1, two-part
+type 5, and type 18 sentences decode field-identically (vendored as
+unit vectors with the oracle outputs recorded, 2026-06-10).

--- a/crates/xng-mode-ais/src/fields.rs
+++ b/crates/xng-mode-ais/src/fields.rs
@@ -1,0 +1,260 @@
+//! Field-level AIS message decoding (ITU-R M.1371-5): positions,
+//! kinematics, static/voyage data for the common message types.
+//! Validated against pyais (MIT) as a decode oracle — see the vendored
+//! vectors below.
+
+use serde_json::{Value, json};
+
+fn u(bits: &[u8], s: usize, n: usize) -> Option<u64> {
+    if s + n > bits.len() {
+        return None;
+    }
+    Some(bits[s..s + n].iter().fold(0u64, |v, &b| (v << 1) | b as u64))
+}
+
+fn i(bits: &[u8], s: usize, n: usize) -> Option<i64> {
+    let v = u(bits, s, n)?;
+    let sign = 1u64 << (n - 1);
+    Some(if v & sign != 0 { v as i64 - (1i64 << n) } else { v as i64 })
+}
+
+/// 6-bit ASCII: 0..31 → '@'..'_', 32..63 → ' '..'?'. Trims '@' padding.
+fn sixbit(bits: &[u8], s: usize, chars: usize) -> Option<String> {
+    let mut out = String::new();
+    for k in 0..chars {
+        let v = u(bits, s + 6 * k, 6)? as u8;
+        out.push(if v < 32 { (v + 64) as char } else { v as char });
+    }
+    Some(out.trim_end_matches(['@', ' ']).to_string())
+}
+
+fn position(bits: &[u8], lon_start: usize) -> Option<(f64, f64)> {
+    let lon = i(bits, lon_start, 28)? as f64 / 600_000.0;
+    let lat = i(bits, lon_start + 28, 27)? as f64 / 600_000.0;
+    if lon.abs() > 180.0 || lat.abs() > 90.0 {
+        return None; // 181/91 = not available
+    }
+    Some((lat, lon))
+}
+
+fn sog(bits: &[u8], s: usize) -> Option<f64> {
+    match u(bits, s, 10)? {
+        1023 => None,
+        v => Some(v as f64 / 10.0),
+    }
+}
+
+fn cog(bits: &[u8], s: usize) -> Option<f64> {
+    match u(bits, s, 12)? {
+        3600.. => None,
+        v => Some(v as f64 / 10.0),
+    }
+}
+
+fn heading(bits: &[u8], s: usize) -> Option<u64> {
+    match u(bits, s, 9)? {
+        511 => None,
+        v => Some(v),
+    }
+}
+
+const NAV_STATUS: [&str; 16] = [
+    "under way (engine)",
+    "at anchor",
+    "not under command",
+    "restricted manoeuvrability",
+    "constrained by draught",
+    "moored",
+    "aground",
+    "engaged in fishing",
+    "under way (sailing)",
+    "reserved (HSC)",
+    "reserved (WIG)",
+    "reserved",
+    "reserved",
+    "reserved",
+    "AIS-SART",
+    "undefined",
+];
+
+/// Decode the fields of an AIS message; `None` when the type is not
+/// (yet) field-decoded. Positions in degrees, speeds in knots.
+pub fn decode(msg_type: u8, bits: &[u8]) -> Option<Value> {
+    let mut d = serde_json::Map::new();
+    let mut put = |k: &str, v: Value| {
+        if !v.is_null() {
+            d.insert(k.into(), v);
+        }
+    };
+    match msg_type {
+        // Class A position reports.
+        1..=3 => {
+            let status = u(bits, 38, 4)? as usize;
+            put("nav_status", json!(NAV_STATUS[status]));
+            put("sog_kt", json!(sog(bits, 50)));
+            if let Some((lat, lon)) = position(bits, 61) {
+                put("lat", json!(lat));
+                put("lon", json!(lon));
+            }
+            put("cog_deg", json!(cog(bits, 116)));
+            put("heading_deg", json!(heading(bits, 128)));
+        }
+        // Base station report.
+        4 => {
+            if let (Some(y), Some(mo), Some(da), Some(h), Some(mi), Some(s)) = (
+                u(bits, 38, 14),
+                u(bits, 52, 4),
+                u(bits, 56, 5),
+                u(bits, 61, 5),
+                u(bits, 66, 6),
+                u(bits, 72, 6),
+            ) {
+                if y > 0 {
+                    put("utc", json!(format!("{y:04}-{mo:02}-{da:02}T{h:02}:{mi:02}:{s:02}Z")));
+                }
+            }
+            if let Some((lat, lon)) = position(bits, 79) {
+                put("lat", json!(lat));
+                put("lon", json!(lon));
+            }
+        }
+        // Static and voyage data.
+        5 => {
+            put("imo", json!(u(bits, 40, 30)));
+            put("callsign", json!(sixbit(bits, 70, 7)));
+            put("name", json!(sixbit(bits, 112, 20)));
+            put("ship_type", json!(u(bits, 232, 8)));
+            put("draught_m", json!(u(bits, 294, 8)? as f64 / 10.0));
+            put("destination", json!(sixbit(bits, 302, 20)));
+        }
+        // SAR aircraft.
+        9 => {
+            match u(bits, 38, 12)? {
+                4095 => {}
+                alt => put("altitude_m", json!(alt)),
+            }
+            put("sog_kt", json!(sog(bits, 50)));
+            if let Some((lat, lon)) = position(bits, 61) {
+                put("lat", json!(lat));
+                put("lon", json!(lon));
+            }
+        }
+        // Class B position reports (19 adds name/type).
+        18 | 19 => {
+            put("sog_kt", json!(sog(bits, 46)));
+            if let Some((lat, lon)) = position(bits, 57) {
+                put("lat", json!(lat));
+                put("lon", json!(lon));
+            }
+            put("cog_deg", json!(cog(bits, 112)));
+            put("heading_deg", json!(heading(bits, 124)));
+            if msg_type == 19 {
+                put("name", json!(sixbit(bits, 143, 20)));
+                put("ship_type", json!(u(bits, 263, 8)));
+            }
+        }
+        // Aids to navigation.
+        21 => {
+            put("aton_type", json!(u(bits, 38, 5)));
+            put("name", json!(sixbit(bits, 43, 20)));
+            if let Some((lat, lon)) = position(bits, 164) {
+                put("lat", json!(lat));
+                put("lon", json!(lon));
+            }
+        }
+        // Static data report (part A: name; part B: type + callsign).
+        24 => match u(bits, 38, 2)? {
+            0 => put("name", json!(sixbit(bits, 40, 20))),
+            1 => {
+                put("ship_type", json!(u(bits, 40, 8)));
+                put("callsign", json!(sixbit(bits, 90, 7)));
+            }
+            _ => return None,
+        },
+        // Long-range position report.
+        27 => {
+            let lon = i(bits, 44, 18)? as f64 / 600.0;
+            let lat = i(bits, 62, 17)? as f64 / 600.0;
+            if lon.abs() <= 180.0 && lat.abs() <= 90.0 {
+                put("lat", json!(lat));
+                put("lon", json!(lon));
+            }
+            match u(bits, 79, 6)? {
+                63 => {}
+                v => put("sog_kt", json!(v)),
+            }
+        }
+        _ => return None,
+    }
+    if d.is_empty() { None } else { Some(Value::Object(d)) }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// AIVDM armored payload → bit vector.
+    fn bits_of(payload: &str, fill: usize) -> Vec<u8> {
+        let mut bits = Vec::new();
+        for c in payload.bytes() {
+            let mut v = c as i32 - 48;
+            if v > 40 {
+                v -= 8;
+            }
+            for k in (0..6).rev() {
+                bits.push(((v >> k) & 1) as u8);
+            }
+        }
+        bits.truncate(bits.len() - fill);
+        bits
+    }
+
+    fn typed(payload: &str, fill: usize) -> (u8, Vec<u8>) {
+        let bits = bits_of(payload, fill);
+        let t = bits[..6].iter().fold(0u8, |v, &b| (v << 1) | b);
+        (t, bits)
+    }
+
+    // Oracle: pyais 2.x decode of the same sentences (2026-06-10).
+
+    #[test]
+    fn class_a_position_matches_pyais() {
+        let (t, bits) = typed("177KQJ5000G?tO`K>RA1wUbN0TKH", 0);
+        assert_eq!(t, 1);
+        let d = decode(t, &bits).unwrap();
+        assert_eq!(d["nav_status"], "moored");
+        assert!((d["lat"].as_f64().unwrap() - 47.582833).abs() < 1e-5);
+        assert!((d["lon"].as_f64().unwrap() - -122.345833).abs() < 1e-5);
+        assert_eq!(d["sog_kt"], 0.0);
+        assert_eq!(d["cog_deg"], 51.0);
+        assert_eq!(d["heading_deg"], 181);
+    }
+
+    #[test]
+    fn static_voyage_matches_pyais() {
+        // Two-sentence type 5; concatenated payload, 2 fill bits.
+        let payload = concat!(
+            "55P5TL01VIaAL@7WKO@mBplU@<PDhh000000001S;AJ::4A80?4i@E53",
+            "1@0000000000000"
+        );
+        let (t, bits) = typed(payload, 2);
+        assert_eq!(t, 5);
+        let d = decode(t, &bits).unwrap();
+        assert_eq!(d["imo"], 6710932);
+        assert_eq!(d["callsign"], "WDA9674");
+        assert_eq!(d["name"], "MT.MITCHELL");
+        assert_eq!(d["ship_type"], 99);
+        assert_eq!(d["destination"], "SEATTLE");
+        assert_eq!(d["draught_m"], 6.0);
+    }
+
+    #[test]
+    fn class_b_position_matches_pyais() {
+        let (t, bits) = typed("B52K>;h00Fc>jpUlNV@ikwpUoP06", 0);
+        assert_eq!(t, 18);
+        let d = decode(t, &bits).unwrap();
+        assert!((d["lat"].as_f64().unwrap() - 40.68454).abs() < 1e-5);
+        assert!((d["lon"].as_f64().unwrap() - -74.072132).abs() < 1e-5);
+        assert_eq!(d["sog_kt"], 0.1);
+    }
+}

--- a/crates/xng-mode-ais/src/lib.rs
+++ b/crates/xng-mode-ais/src/lib.rs
@@ -10,6 +10,7 @@
 
 pub mod demod;
 pub mod frame;
+pub mod fields;
 pub mod modulate;
 pub mod nmea;
 
@@ -111,6 +112,7 @@ pub fn to_message(
             nmea,
             msg_type: Some(f.msg_type),
             mmsi: Some(f.mmsi),
+            details: fields::decode(f.msg_type, &f.message_bits),
         },
         raw: Some(f.wire_bytes.clone()),
         source,

--- a/crates/xng-proto/src/lib.rs
+++ b/crates/xng-proto/src/lib.rs
@@ -64,11 +64,12 @@ impl From<&Message> for asf2::DecodedMessage {
                     reassembled: a.reassembled,
                 }))
             }
-            MessageBody::Ais { nmea, msg_type, mmsi } => {
+            MessageBody::Ais { nmea, msg_type, mmsi, details } => {
                 Some(asf2::decoded_message::Body::Ais(asf2::AisBody {
                     nmea: nmea.clone(),
                     msg_type: msg_type.map(u32::from),
                     mmsi: *mmsi,
+                    details_json: details.as_ref().map(|v| v.to_string()),
                 }))
             }
             MessageBody::ModeS {

--- a/crates/xng-types/src/message.rs
+++ b/crates/xng-types/src/message.rs
@@ -86,6 +86,9 @@ pub enum MessageBody {
         msg_type: Option<u8>,
         #[serde(skip_serializing_if = "Option::is_none")]
         mmsi: Option<u32>,
+        /// Decoded fields (position, kinematics, static/voyage data).
+        #[serde(skip_serializing_if = "Option::is_none")]
+        details: Option<serde_json::Value>,
     },
     /// Mode S / ADS-B frame summary (positions/BDS depth land later).
     ModeS {

--- a/proto/asf2.proto
+++ b/proto/asf2.proto
@@ -77,6 +77,7 @@ message AisBody {
   repeated string nmea = 1;
   optional uint32 msg_type = 2;
   optional uint32 mmsi = 3;
+  optional string details_json = 4;  // decoded fields (position, name, ...)
 }
 
 message HfdlBody {

--- a/src/commands/scan.rs
+++ b/src/commands/scan.rs
@@ -380,6 +380,7 @@ pub(crate) fn scan_group(
             asf2_quic_trust: crate::outputs::asf2_quic::TrustMode::SystemRoots,
             metrics: None,
             sbs: None,
+            nmea_udp: vec![],
         },
     };
     let decoders = runtime::build_decoders(rate, center, &cfg)?;

--- a/src/commands/survey.rs
+++ b/src/commands/survey.rs
@@ -421,6 +421,7 @@ fn dwell(
             asf2_quic_trust: crate::outputs::asf2_quic::TrustMode::SystemRoots,
             metrics: None,
             sbs: None,
+            nmea_udp: vec![],
         },
     };
     let decoders = runtime::build_decoders(rate, center, &cfg)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -90,6 +90,10 @@ struct OutputOpts {
     /// Mode S/ADS-B messages only)
     #[arg(long)]
     sbs: Option<String>,
+    /// Send raw NMEA AIVDM sentences to host:port over UDP (repeatable;
+    /// AIS messages only — the format marine aggregators ingest)
+    #[arg(long)]
+    nmea_udp: Vec<String>,
 }
 
 impl OutputOpts {
@@ -124,6 +128,7 @@ impl OutputOpts {
                 asf2_quic_trust: quic_trust,
                 metrics: self.metrics.clone(),
                 sbs: self.sbs.clone(),
+                nmea_udp: self.nmea_udp.clone(),
             },
             ident,
         ))
@@ -568,6 +573,7 @@ fn main() -> anyhow::Result<()> {
                         asf2_quic_trust: outputs::asf2_quic::TrustMode::SystemRoots,
                         metrics: None,
                         sbs: None,
+                        nmea_udp: vec![],
                     },
                 },
             )

--- a/src/outputs/console.rs
+++ b/src/outputs/console.rs
@@ -58,12 +58,35 @@ pub fn format_message(msg: &Message, fmt: ConsoleFormat) -> String {
                     let app = a.app.as_ref().and_then(app_summary).map(|s| format!(" [{s}]")).unwrap_or_default();
                     format!("ACARS {} {} lbl={} {}{}{}", tail, flight, a.label, quality, text, app)
                 }
-                MessageBody::Ais { nmea, msg_type, mmsi } => format!(
-                    "AIS type={} mmsi={} {}",
-                    msg_type.map_or("?".into(), |t| t.to_string()),
-                    mmsi.map_or("?".into(), |m| m.to_string()),
-                    nmea.first().map(String::as_str).unwrap_or("")
-                ),
+                MessageBody::Ais { nmea, msg_type, mmsi, details } => {
+                    let mut s = format!(
+                        "AIS type={} mmsi={}",
+                        msg_type.map_or("?".into(), |t| t.to_string()),
+                        mmsi.map_or("?".into(), |m| m.to_string()),
+                    );
+                    if let Some(d) = details {
+                        if let Some(n) = d.get("name").and_then(|v| v.as_str()) {
+                            s.push_str(&format!(" name={n}"));
+                        }
+                        if let (Some(lat), Some(lon)) = (
+                            d.get("lat").and_then(|v| v.as_f64()),
+                            d.get("lon").and_then(|v| v.as_f64()),
+                        ) {
+                            s.push_str(&format!(" pos={lat:.5},{lon:.5}"));
+                        }
+                        if let Some(v) = d.get("sog_kt").and_then(|v| v.as_f64()) {
+                            s.push_str(&format!(" sog={v}kt"));
+                        }
+                        if let Some(v) = d.get("nav_status").and_then(|v| v.as_str()) {
+                            s.push_str(&format!(" [{v}]"));
+                        }
+                        if let Some(v) = d.get("destination").and_then(|v| v.as_str()) {
+                            s.push_str(&format!(" dest={v}"));
+                        }
+                    }
+                    s.push_str(&format!(" {}", nmea.first().map(String::as_str).unwrap_or("")));
+                    s
+                }
                 MessageBody::ModeS {
                     df,
                     icao,

--- a/src/outputs/mod.rs
+++ b/src/outputs/mod.rs
@@ -8,4 +8,5 @@ pub mod asf2_quic;
 pub mod console;
 pub mod jsonl;
 pub mod metrics;
+pub mod nmea_udp;
 pub mod sbs;

--- a/src/outputs/nmea_udp.rs
+++ b/src/outputs/nmea_udp.rs
@@ -1,0 +1,31 @@
+//! Raw NMEA-over-UDP output: AIVDM sentences as datagrams, the format
+//! marine aggregators (MarineTraffic, AISHub, VesselFinder) ingest.
+
+use std::sync::Arc;
+use tokio::net::UdpSocket;
+use tokio::sync::broadcast;
+use xng_types::{Message, MessageBody};
+
+pub async fn run(
+    mut rx: broadcast::Receiver<Arc<Message>>,
+    target: String,
+) -> std::io::Result<()> {
+    let sock = UdpSocket::bind("0.0.0.0:0").await?;
+    sock.connect(&target).await?;
+    tracing::info!("NMEA UDP output to {target}");
+    loop {
+        match rx.recv().await {
+            Ok(msg) => {
+                let MessageBody::Ais { nmea, .. } = &msg.body else { continue };
+                if !msg.decode.crc_ok {
+                    continue;
+                }
+                for sentence in nmea {
+                    let _ = sock.send(format!("{sentence}\r\n").as_bytes()).await;
+                }
+            }
+            Err(broadcast::error::RecvError::Lagged(_)) => continue,
+            Err(_) => return Ok(()),
+        }
+    }
+}

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -36,6 +36,8 @@ pub struct OutputConfig {
     pub metrics: Option<String>,
     /// SBS-1 (BaseStation, dump1090 port-30003 style) TCP server address.
     pub sbs: Option<String>,
+    /// Raw NMEA (AIVDM) UDP targets for marine aggregators.
+    pub nmea_udp: Vec<String>,
 }
 
 pub struct SessionConfig {
@@ -356,6 +358,10 @@ pub fn run_session(mut source: Box<dyn IqSource>, cfg: SessionConfig) -> anyhow:
         if let Some(addr) = cfg.outputs.sbs.clone() {
             let rx = bus.subscribe();
             output_tasks.push(tokio::spawn(crate::outputs::sbs::run(rx, addr)));
+        }
+        for target in cfg.outputs.nmea_udp.clone() {
+            let rx = bus.subscribe();
+            output_tasks.push(tokio::spawn(crate::outputs::nmea_udp::run(rx, target)));
         }
         if let Some(url) = cfg.outputs.asf2_grpc.clone() {
             let rx = bus.subscribe();


### PR DESCRIPTION
Gap series **4/6** (vs AIS-catcher).

- **Decoded fields** for types 1–5, 9, 18/19, 21, 24, 27: positions, nav status, SOG/COG/heading, static+voyage data (IMO/callsign/name/type/draught/destination), base-station UTC, SAR altitude, AtoN names, long-range reports — flowing through JSON, asf2 (`AisBody.details_json`), and console one-liners.
- **Oracle-validated**: field-identical against pyais (MIT) on the canonical vectors (type 1 Seattle position, two-part type 5 MT.MITCHELL, type 18 class B), vendored with recorded oracle outputs.
- **`--nmea-udp host:port`** (repeatable): raw AIVDM datagrams — the format MarineTraffic/AISHub/VesselFinder ingest; CRC-failed frames excluded.

Off-air AIS validation remains pending RF (no AIS traffic receivable at the test site so far).

🤖 Generated with [Claude Code](https://claude.com/claude-code)