### PR TITLE
Cross-cutting: HFDL station names + cross-channel dedup

### DIFF
--- a/crates/xng-mode-hfdl/src/pdu.rs
+++ b/crates/xng-mode-hfdl/src/pdu.rs
@@ -10,6 +10,30 @@ fn fcs_ok(span: &[u8], trailer: &[u8]) -> bool {
     trailer.len() >= 2 && HDLC_FCS.checksum(span) == u16::from_le_bytes([trailer[0], trailer[1]])
 }
 
+/// ARINC HFDL ground-station names (public station list, as used by
+/// the HFDL community and the over-the-air system table assignments).
+pub fn gs_name(id: u8) -> Option<&'static str> {
+    Some(match id {
+        1 => "San Francisco, USA",
+        2 => "Molokai, Hawaii",
+        3 => "Reykjavik, Iceland",
+        4 => "Riverhead, New York",
+        5 => "Auckland, New Zealand",
+        6 => "Hat Yai, Thailand",
+        7 => "Shannon, Ireland",
+        8 => "Johannesburg, South Africa",
+        9 => "Barrow, Alaska",
+        10 => "Muan, South Korea",
+        11 => "Albrook, Panama",
+        13 => "Santa Cruz, Bolivia",
+        14 => "Krasnoyarsk, Russia",
+        15 => "Al Muharraq, Bahrain",
+        16 => "Agana, Guam",
+        17 => "Canarias, Spain",
+        _ => return None,
+    })
+}
+
 /// 20-bit two's-complement coordinate, degrees ×180/2^19.
 fn coordinate(v: u32) -> f64 {
     let r = ((v << 12) as i32) >> 12;
@@ -61,6 +85,7 @@ impl PduParser {
             kind: "squitter".into(),
             details: json!({
                 "gs_id": p[1] & 0x7F,
+                "gs_name": gs_name(p[1] & 0x7F),
                 "utc_sync": p[1] >> 7 == 1,
                 "frame_index": (p[2] as u16) | ((p[3] as u16 & 0x0F) << 8),
                 "frame_offset": p[3] >> 4,
@@ -87,7 +112,7 @@ impl PduParser {
                 return;
             }
             let sizes = (0..n).map(|i| p[6 + i] as usize + 1).collect();
-            (hdr, sizes, json!({ "dir": "downlink", "gs_id": p[1] & 0x7F, "aircraft_id": p[2] }))
+            (hdr, sizes, json!({ "dir": "downlink", "gs_id": p[1] & 0x7F, "gs_name": gs_name(p[1] & 0x7F), "aircraft_id": p[2] }))
         } else {
             let n_ac = ((p[0] >> 4) & 0x7) as usize + 1;
             let mut sizes = Vec::new();
@@ -109,7 +134,7 @@ impl PduParser {
                 idx += count;
                 acs.push(json!({ "aircraft_id": ac_id, "lpdus": count }));
             }
-            (idx, sizes, json!({ "dir": "uplink", "gs_id": p[1] & 0x7F, "aircraft": acs }))
+            (idx, sizes, json!({ "dir": "uplink", "gs_id": p[1] & 0x7F, "gs_name": gs_name(p[1] & 0x7F), "aircraft": acs }))
         };
         if p.len() < hdr_len + 2 || !fcs_ok(&p[..hdr_len], &p[hdr_len..]) {
             return;

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -444,6 +444,7 @@ pub(crate) fn decode_loop(
     let mut buf = vec![Complex::new(0.0f32, 0.0f32); READ_CHUNK];
     let mut stats: Vec<(u64, u64, u64)> = decoders.iter().map(|(f, _)| (*f, 0, 0)).collect();
     let mut consecutive_errors: u32 = 0;
+    let mut dedup = DedupFilter::new();
 
     while !stop.load(Ordering::Relaxed) {
         let n = match source.read(&mut buf) {
@@ -512,6 +513,9 @@ pub(crate) fn decode_loop(
             stats[i].1 += seen;
             stats[i].2 += ok;
             for mut msg in msgs {
+                if dedup.is_duplicate(&msg) {
+                    continue;
+                }
                 if let Some(r) = reasm.as_deref_mut() {
                     apply_reassembly(&mut msg, r);
                 }
@@ -527,6 +531,45 @@ pub(crate) fn decode_loop(
         }
     }
     Ok(stats)
+}
+
+/// Suppresses cross-channel duplicates: the same transmission decoded
+/// on two frequencies (ACARS uplinks especially) produces byte-identical
+/// raw payloads within a short window. Keyed on the raw frame bytes.
+pub(crate) struct DedupFilter {
+    seen: std::collections::HashMap<u64, std::time::Instant>,
+}
+
+const DEDUP_WINDOW: std::time::Duration = std::time::Duration::from_millis(2500);
+
+impl DedupFilter {
+    pub(crate) fn new() -> Self {
+        Self { seen: std::collections::HashMap::new() }
+    }
+
+    /// True when this message is a duplicate of one just published.
+    pub(crate) fn is_duplicate(&mut self, msg: &Message) -> bool {
+        let Some(raw) = &msg.raw else { return false };
+        if raw.is_empty() {
+            return false;
+        }
+        let now = std::time::Instant::now();
+        if self.seen.len() > 1024 {
+            self.seen.retain(|_, t| now.duration_since(*t) < DEDUP_WINDOW);
+        }
+        use std::hash::{Hash, Hasher};
+        let mut h = std::collections::hash_map::DefaultHasher::new();
+        raw.hash(&mut h);
+        msg.mode.as_str().hash(&mut h);
+        let key = h.finish();
+        match self.seen.get(&key) {
+            Some(t) if now.duration_since(*t) < DEDUP_WINDOW => true,
+            _ => {
+                self.seen.insert(key, now);
+                false
+            }
+        }
+    }
 }
 
 /// Offer ACARS bodies to the multi-block reassembler; when a message


### PR DESCRIPTION
Gap series **6/6** (the achievable parts).

- **HFDL ground-station names**: squitters/uplinks/downlinks carry `gs_name` ("Shannon, Ireland") alongside `gs_id`, from the public ARINC station list.
- **Cross-channel dedup**: byte-identical raw payloads within 2.5 s (same transmission heard on two frequencies) publish once — keyed on (mode, raw); raw-less messages never filtered.
- Audit corrections: STD-C EGC service/priority names already existed; Aero C-channel AMBE needs C-channel demod (roadmap); **ATN-B1 CPDLC element decode is blocked on the ICAO Doc 9880 ASN.1 modules** — dumpvdl2 only ships asn1c-generated GPL C, which is unportable, so it needs the spec text itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)