### PR TITLE
v0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3531,7 +3531,7 @@ dependencies = [
 
 [[package]]
 name = "xng"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3570,7 +3570,7 @@ dependencies = [
 
 [[package]]
 name = "xng-acars"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "base64",
  "crc",
@@ -3582,7 +3582,7 @@ dependencies = [
 
 [[package]]
 name = "xng-dsp"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "crc",
  "num-complex",
@@ -3591,7 +3591,7 @@ dependencies = [
 
 [[package]]
 name = "xng-mode-acars"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "chrono",
  "num-complex",
@@ -3603,7 +3603,7 @@ dependencies = [
 
 [[package]]
 name = "xng-mode-adsb"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "chrono",
  "num-complex",
@@ -3613,7 +3613,7 @@ dependencies = [
 
 [[package]]
 name = "xng-mode-aero"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "chrono",
  "num-complex",
@@ -3627,7 +3627,7 @@ dependencies = [
 
 [[package]]
 name = "xng-mode-ais"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "chrono",
  "num-complex",
@@ -3637,7 +3637,7 @@ dependencies = [
 
 [[package]]
 name = "xng-mode-hfdl"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "chrono",
  "num-complex",
@@ -3650,7 +3650,7 @@ dependencies = [
 
 [[package]]
 name = "xng-mode-iridium"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "chrono",
  "crc",
@@ -3665,7 +3665,7 @@ dependencies = [
 
 [[package]]
 name = "xng-mode-stdc"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "chrono",
  "num-complex",
@@ -3678,7 +3678,7 @@ dependencies = [
 
 [[package]]
 name = "xng-mode-vdl2"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "chrono",
  "num-complex",
@@ -3691,7 +3691,7 @@ dependencies = [
 
 [[package]]
 name = "xng-proto"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "chrono",
  "prost",
@@ -3702,7 +3702,7 @@ dependencies = [
 
 [[package]]
 name = "xng-sdr"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "num-complex",
  "pkg-config",
@@ -3713,7 +3713,7 @@ dependencies = [
 
 [[package]]
 name = "xng-types"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "chrono",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["legacy"]
 resolver = "2"
 
 [workspace.package]
-version = "0.9.1"
+version = "0.10.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/airframesio/xng"


### PR DESCRIPTION
The competitive-gap release (PRs #48–#54):
- **ADS-B**: CPR positions (global+local), velocity, squawk, altitude replies, per-aircraft tracking, `--sbs` BaseStation output
- **ACARS**: multi-block reassembly, MIAM (ARINC 841), OHMA — on every carrier including the live Airframes feed
- **Iridium**: pager messages with multi-part reassembly (bitsparser-oracle-validated), voice/IP/sync tagging
- **AIS**: field decode for 11 message types (pyais-oracle-validated), `--nmea-udp` for marine aggregators
- **VDL2**: ATN transport (X.25 with M-bit reassembly, CLNP, COTP), **ATN-B1 protected-mode CPDLC** (238/114 element tables with ICAO phraseology), CM logon, semantic XID ground-station lists
- **HFDL**: ground-station names
- **Runtime**: cross-channel duplicate suppression

Tag v0.10.0 follows the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 0.10.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->