### PR TITLE
CPDLC route clearances: FANS-1/A and ATN-B1

### DIFF
--- a/crates/xng-acars/PROVENANCE.md
+++ b/crates/xng-acars/PROVENANCE.md
@@ -58,3 +58,14 @@ libacars's asn1c tables (MIT, as before): VerticalRateEnglish (0..60,
 magnetic/true), Direction (ENUMERATED 0..10), FreeText (IA5 SIZE
 1..256). Route clearances remain unsupported (deep optional-laden
 sequence; staged separately).
+
+## FANS-1/A route clearances (2026-06)
+
+FANSRouteClearance (ten optional components: airports, runways,
+SID/STAR/approach procedures, airway intercept, the route-information
+sequence) decoded with constraints from the libacars asn1c tables (MIT,
+as before): FANSProcedure SIZE(1..6), route sequence SIZE(1..128),
+route legs as published-identifier (fixname + optional lat/lon),
+lat/lon, place-bearing pairs, place-bearing-distance (NM 0.1 / KM), or
+airway designators. trackDetail legs and the trailing
+routeInformationAdditional stay undecoded (reported as present).

--- a/crates/xng-acars/src/cpdlc/mod.rs
+++ b/crates/xng-acars/src/cpdlc/mod.rs
@@ -131,32 +131,136 @@ fn read_position(b: &mut Bits) -> Option<String> {
         0 => read_ia5(b, 3, 1), // fixName SIZE(1..5)
         1 => read_ia5(b, 2, 1), // navaid SIZE(1..4)
         2 => read_ia5(b, 0, 4), // airport SIZE(4)
-        3 => {
-            let lat_has_min = b.read(1)? == 1;
-            let lat_deg = b.read(7)?;
-            let lat_min = if lat_has_min { Some(b.read(10)?) } else { None };
-            let ns = if b.read(1)? == 1 { 'S' } else { 'N' };
-            let lon_has_min = b.read(1)? == 1;
-            let lon_deg = b.read(8)?;
-            let lon_min = if lon_has_min { Some(b.read(10)?) } else { None };
-            let ew = if b.read(1)? == 1 { 'W' } else { 'E' };
-            if lat_deg > 90 || lon_deg > 180 {
-                return None;
-            }
-            let fmt = |deg: u32, min: Option<u32>, dir: char| match min {
-                Some(m) => format!("{deg}°{:.1}'{dir}", m as f32 / 10.0),
-                None => format!("{deg}°{dir}"),
-            };
-            Some(format!(
-                "{} {}",
-                fmt(lat_deg, lat_min, ns),
-                fmt(lon_deg, lon_min, ew)
-            ))
-        }
+        3 => read_latlon(b),
         // placeBearingDistance: not decoded.
         _ => None,
     }
 }
+
+fn read_latlon(b: &mut Bits) -> Option<String> {
+    let lat_has_min = b.read(1)? == 1;
+    let lat_deg = b.read(7)?;
+    let lat_min = if lat_has_min { Some(b.read(10)?) } else { None };
+    let ns = if b.read(1)? == 1 { 'S' } else { 'N' };
+    let lon_has_min = b.read(1)? == 1;
+    let lon_deg = b.read(8)?;
+    let lon_min = if lon_has_min { Some(b.read(10)?) } else { None };
+    let ew = if b.read(1)? == 1 { 'W' } else { 'E' };
+    if lat_deg > 90 || lon_deg > 180 {
+        return None;
+    }
+    let fmt = |deg: u32, min: Option<u32>, dir: char| match min {
+        Some(m) => format!("{deg}°{:.1}'{dir}", m as f32 / 10.0),
+        None => format!("{deg}°{dir}"),
+    };
+    Some(format!("{} {}", fmt(lat_deg, lat_min, ns), fmt(lon_deg, lon_min, ew)))
+}
+
+/// FANSPublishedIdentifier: fixName + OPTIONAL latitudeLongitude.
+fn read_published(b: &mut Bits) -> Option<String> {
+    let has_ll = b.read(1)? == 1;
+    let name = read_ia5(b, 3, 1)?; // Fixname SIZE(1..5)
+    if has_ll {
+        Some(format!("{name} ({})", read_latlon(b)?))
+    } else {
+        Some(name)
+    }
+}
+
+/// FANSRouteClearance: ten optional components (constraints from the
+/// libacars asn1c tables). The trailing routeInformationAdditional is
+/// reported present-but-undecoded; it is last, so the route itself is
+/// always reachable.
+fn read_route_clearance(b: &mut Bits) -> Option<String> {
+    let present: Vec<bool> = (0..10).map(|_| b.read(1) == Some(1)).collect();
+    let mut parts: Vec<String> = Vec::new();
+    let read_runway = |b: &mut Bits| -> Option<String> {
+        let dir = b.read(6)? + 1; // (1..36)
+        let cfg = match b.read(2)? {
+            0 => "L",
+            1 => "R",
+            2 => "C",
+            _ => "",
+        };
+        Some(format!("RWY {dir:02}{cfg}"))
+    };
+    let read_procedure = |b: &mut Bits| -> Option<String> {
+        let has_transition = b.read(1)? == 1;
+        let ptype = match b.read(2)? {
+            0 => "ARRIVAL",
+            1 => "APPROACH",
+            _ => "DEPARTURE",
+        };
+        let name = read_ia5(b, 3, 1)?; // FANSProcedure SIZE(1..6)
+        let mut s = format!("{name} ({ptype})");
+        if has_transition {
+            s.push_str(&format!(" TRANS {}", read_ia5(b, 3, 1)?)); // SIZE(1..5)
+        }
+        Some(s)
+    };
+    if present[0] {
+        parts.push(format!("DEP {}", read_ia5(b, 0, 4)?));
+    }
+    if present[1] {
+        parts.push(format!("DEST {}", read_ia5(b, 0, 4)?));
+    }
+    if present[2] {
+        parts.push(format!("DEP {}", read_runway(b)?));
+    }
+    if present[3] {
+        parts.push(format!("SID {}", read_procedure(b)?));
+    }
+    if present[4] {
+        parts.push(format!("ARR {}", read_runway(b)?));
+    }
+    if present[5] {
+        parts.push(format!("APPROACH {}", read_procedure(b)?));
+    }
+    if present[6] {
+        parts.push(format!("STAR {}", read_procedure(b)?));
+    }
+    if present[7] {
+        parts.push(format!("INTERCEPT {}", read_ia5(b, 3, 1)?)); // SIZE(1..5)
+    }
+    if present[8] {
+        // FANSRouteInformationSequence SIZE(1..128).
+        let n = b.read(7)? as usize + 1;
+        let mut legs = Vec::with_capacity(n);
+        for _ in 0..n {
+            let leg = match b.read(3)? {
+                0 => read_published(b)?,
+                1 => read_latlon(b)?,
+                2 => format!(
+                    "{} BRG {} / {} BRG {}",
+                    read_published(b)?,
+                    read_degrees(b)?,
+                    read_published(b)?,
+                    read_degrees(b)?
+                ),
+                3 => {
+                    let pb = read_published(b)?;
+                    let deg = read_degrees(b)?;
+                    let dist = if b.read(1)? == 0 {
+                        format!("{:.1} NM", b.read(14)? as f64 / 10.0)
+                    } else {
+                        format!("{} KM", b.read(10)? + 1)
+                    };
+                    format!("{pb} BRG {deg} DIST {dist}")
+                }
+                4 => read_ia5(b, 3, 1)?, // airway SIZE(1..5)
+                _ => return None, // trackDetail: not decoded
+            };
+            legs.push(leg);
+        }
+        parts.push(format!("ROUTE {}", legs.join(" ")));
+    }
+    if present[9] {
+        parts.push("[+additional data undecoded]".into());
+    }
+    Some(parts.join(", "))
+}
+
+
 
 /// FANSTime: hours (0..23, 5 bits) + minutes (0..59, 6 bits).
 fn read_time(b: &mut Bits) -> Option<String> {
@@ -235,6 +339,10 @@ fn read_args(tag: &str, b: &mut Bits) -> Option<Vec<String>> {
         "Degrees" => Some(vec![read_degrees(b)?]),
         "DirectionDegrees" => Some(vec![read_direction(b)?, read_degrees(b)?]),
         "FreeText" => Some(vec![read_freetext(b)?]),
+        "RouteClearance" => Some(vec![read_route_clearance(b)?]),
+        "PositionRouteClearance" => {
+            Some(vec![read_position(b)?, read_route_clearance(b)?])
+        }
         _ => None,
     }
 }
@@ -567,5 +675,56 @@ mod composite_tests {
         let m = decode(&b.0, true).expect("decode");
         assert_eq!(m.element, "dM67FreeText");
         assert_eq!(m.text, "DUE WX");
+    }
+}
+
+#[cfg(test)]
+mod route_tests {
+    use super::*;
+
+    struct Builder(Vec<u8>, usize);
+    impl Builder {
+        fn new() -> Self {
+            Builder(vec![0u8; 96], 0)
+        }
+        fn push(&mut self, v: u32, n: usize) {
+            for k in (0..n).rev() {
+                let bit = ((v >> k) & 1) as u8;
+                self.0[self.1 / 8] |= bit << (7 - self.1 % 8);
+                self.1 += 1;
+            }
+        }
+        fn ia5(&mut self, s: &str) {
+            for c in s.bytes() {
+                self.push(c as u32, 7);
+            }
+        }
+    }
+
+    /// dM40RouteClearance "ASSIGNED ROUTE [routeclearance]" with a
+    /// destination airport and a two-leg route.
+    #[test]
+    fn assigned_route_decodes() {
+        let mut b = Builder::new();
+        b.push(0, 1); // single element
+        b.push(0, 1); // no msg ref
+        b.push(0, 1); // no timestamp
+        b.push(22, 6); // msg id
+        b.push(40, 8); // dM40RouteClearance
+        // presence map: destination airport (bit 1) + route list (bit 8)
+        b.push(0b0100000010, 10);
+        b.ia5("KSFO"); // airport SIZE(4): no length bits
+        b.push(1, 7); // 2 legs (SIZE 1..128)
+        b.push(4, 3); // airway identifier
+        b.push(3, 3); // SIZE(1..5) length 4
+        b.ia5("J501");
+        b.push(0, 3); // published identifier
+        b.push(0, 1); // no latlon
+        b.push(2, 3); // fixname length 3
+        b.ia5("OAK");
+        let m = decode(&b.0, true).expect("decode");
+        assert_eq!(m.element, "dM40RouteClearance");
+        assert!(m.text.contains("DEST KSFO"), "{}", m.text);
+        assert!(m.text.contains("ROUTE J501 OAK"), "{}", m.text);
     }
 }

--- a/crates/xng-mode-vdl2/src/atn_cpdlc.rs
+++ b/crates/xng-mode-vdl2/src/atn_cpdlc.rs
@@ -443,6 +443,15 @@ fn read_argument(p: &mut Per, ty: &str) -> Option<Vec<String>> {
         "TimeLevel" => vec![read_time(p)?, read_level(p)?],
         "TimePosition" => vec![read_time(p)?, read_position(p)?],
         "DirectionDegrees" => vec![read_direction(p)?, read_degrees(p)?],
+        // The clearance itself rides in constrainedData; elements carry
+        // an index into it.
+        "RouteClearanceIndex" => {
+            vec![format!("(route clearance #{})", p.constrained(1, 2)?)]
+        }
+        "PositionRouteClearanceIndex" => vec![
+            read_position(p)?,
+            format!("(route clearance #{})", p.constrained(1, 2)?),
+        ],
         _ => return None,
     })
 }
@@ -713,5 +722,91 @@ mod tests {
         let v = parse_cm_logon(&b.bytes()).expect("cm");
         assert_eq!(v["pdu"], "logon-request");
         assert_eq!(v["flight_id"], "UAL123");
+    }
+}
+
+#[cfg(test)]
+mod route_tests {
+    use super::*;
+
+    #[test]
+    fn cleared_route_decodes() {
+        // Inner ATCUplinkMessage: uM80 CLEARED [routeClearance] with the
+        // clearance in constrainedData: dest KSFO, route J501 → OAK.
+        struct B(Vec<u8>);
+        impl B {
+            fn push(&mut self, v: u64, n: usize) {
+                for k in (0..n).rev() {
+                    self.0.push(((v >> k) & 1) as u8);
+                }
+            }
+            fn ia5(&mut self, s: &str) {
+                for c in s.bytes() {
+                    self.push(c as u64, 7);
+                }
+            }
+        }
+        let mut m = B(Vec::new());
+        m.push(0, 1); // no msgRef
+        m.push(0, 1); // default logicalAck
+        m.push(3, 6); // msg id
+        m.push(30, 7); // year 2026
+        m.push(5, 4); // June (1..12)
+        m.push(10, 5); // day 11 (1..31)
+        m.push(2, 5);
+        m.push(0, 6);
+        m.push(0, 6);
+        m.push(1, 1); // constrainedData PRESENT
+        m.push(0, 3); // one element
+        m.push(80, 8); // uM80RouteClearance (index arg)
+        m.push(0, 1); // RouteClearanceIndex = 1
+        // constrainedData: ext 0, routeClearanceData present, count 1.
+        m.push(0, 1);
+        m.push(1, 1);
+        m.push(0, 1);
+        // RouteClearance presence: destination airport + route list.
+        m.push(0b010000010, 9);
+        m.ia5("KSFO"); // Airport: fixed SIZE(4), no length bits
+        m.push(1, 7); // route count 2 (1..128)
+        m.push(4, 3); // leg 1: ATS route designator
+        m.push(2, 3); // IA5(2..7) length 4
+        m.ia5("J501");
+        m.push(0, 3); // leg 2: publishedIdentifier
+        m.push(0, 1); // fixName
+        m.push(0, 1); // no latlon
+        m.push(2, 3); // Fix IA5(1..5) length 3
+        m.ia5("OAK");
+        let inner_bits = m.0.len();
+
+        let mut o = B(Vec::new());
+        o.push(0, 1);
+        o.push(3, 3); // ground: send
+        o.push(0, 1);
+        o.push(0, 1);
+        o.push(1, 1);
+        // Length determinant: long form (the message exceeds 127 bits).
+        if inner_bits < 128 {
+            o.push(0, 1);
+            o.push(inner_bits as u64, 7);
+        } else {
+            o.push(0b10, 2);
+            o.push(inner_bits as u64, 14);
+        }
+        o.0.extend(&m.0);
+        o.push(0, 1);
+        o.push(0, 7);
+        let bytes: Vec<u8> = o
+            .0
+            .chunks(8)
+            .map(|c| c.iter().enumerate().fold(0u8, |v, (i, &b)| v | (b << (7 - i))))
+            .collect();
+
+        let v = parse_pdus(&bytes, false).expect("apdu");
+        let msg = &v["message"];
+        assert_eq!(msg["elements"][0]["element"], "uM80RouteClearance");
+        let rc = &msg["route_clearances"][0];
+        assert_eq!(rc["destination_airport"], "KSFO");
+        assert_eq!(rc["route"][0], "J501");
+        assert_eq!(rc["route"][1], "OAK");
     }
 }

--- a/crates/xng-mode-vdl2/src/atn_cpdlc.rs
+++ b/crates/xng-mode-vdl2/src/atn_cpdlc.rs
@@ -215,6 +215,7 @@ fn atc_message(bytes: &[u8], nbits: usize, downlink: bool) -> Option<Value> {
     let idx_bits = 64 - (table.len() as u64 - 1).leading_zeros() as usize;
 
     let mut elements = Vec::new();
+    let mut bailed = false;
     for k in 0..count {
         // Element CHOICE (not extensible in the module).
         let idx = p.uint(idx_bits)? as usize;
@@ -243,13 +244,149 @@ fn atc_message(bytes: &[u8], nbits: usize, downlink: bool) -> Option<Value> {
         elements.push(el);
     }
 
-    Some(json!({
+    let mut out = json!({
         "msg_id": msg_id,
         "msg_ref": msg_ref,
         "timestamp": format!("{y:04}-{mo:02}-{d:02}T{h:02}:{mi:02}:{sec:02}Z"),
         "logical_ack": ack,
         "elements": elements,
-    }))
+    });
+    // constrainedData (route clearances) sits after the element list —
+    // reachable only when every element argument decoded.
+    if _has_constrained && !bailed {
+        // SEQUENCE { routeClearanceData SIZE(1..2) OPTIONAL, ... }:
+        // extension bit + presence bit.
+        if p.bit() == Some(0) && p.bit() == Some(1) {
+            if let Some(n) = p.constrained(1, 2) {
+                let mut rcs = Vec::new();
+                for _ in 0..n {
+                    match read_route_clearance(&mut p) {
+                        Some(rc) => rcs.push(rc),
+                        None => break,
+                    }
+                }
+                if !rcs.is_empty() {
+                    out["route_clearances"] = json!(rcs);
+                }
+            }
+        }
+    }
+    Some(out)
+}
+
+
+/// PublishedIdentifier: fixName | navaid (both name + optional latlon).
+fn read_published(p: &mut Per) -> Option<String> {
+    let navaid = p.bit()? == 1;
+    let has_ll = p.bit()? == 1;
+    let name = if navaid { p.ia5(1, 4)? } else { p.ia5(1, 5)? };
+    if has_ll {
+        let ll = read_latlon(p)?;
+        Some(format!("{name} ({ll})"))
+    } else {
+        Some(name)
+    }
+}
+
+fn read_distance(p: &mut Per) -> Option<String> {
+    Some(if p.bit()? == 0 {
+        format!("{:.1} NM", p.constrained(0, 9999)? as f64 / 10.0)
+    } else {
+        format!("{:.2} KM", p.constrained(0, 8000)? as f64 / 4.0)
+    })
+}
+
+/// ProcedureName: type + IA5(1..20) + optional transition IA5(1..5).
+fn read_procedure(p: &mut Per) -> Option<String> {
+    let has_transition = p.bit()? == 1;
+    let ptype = match p.uint(2)? {
+        0 => "ARRIVAL",
+        1 => "APPROACH",
+        2 => "DEPARTURE",
+        _ => return None,
+    };
+    let name = p.ia5(1, 20)?;
+    let mut s = format!("{name} ({ptype})");
+    if has_transition {
+        s.push_str(&format!(" TRANSITION {}", p.ia5(1, 5)?));
+    }
+    Some(s)
+}
+
+/// Runway: direction (1..36) + L/R/C suffix.
+fn read_runway(p: &mut Per) -> Option<String> {
+    let dir = p.constrained(1, 36)?;
+    let cfg = match p.uint(2)? {
+        0 => "L",
+        1 => "R",
+        2 => "C",
+        _ => "",
+    };
+    Some(format!("RWY {dir:02}{cfg}"))
+}
+
+/// One RouteInformation leg.
+fn read_route_information(p: &mut Per) -> Option<String> {
+    match p.uint(3)? {
+        0 => read_published(p),
+        1 => read_latlon(p),
+        2 => {
+            // PlaceBearingPlaceBearing: SEQUENCE SIZE(2) OF PlaceBearing.
+            let a = format!("{} BRG {}", read_published(p)?, read_degrees(p)?);
+            let b = format!("{} BRG {}", read_published(p)?, read_degrees(p)?);
+            Some(format!("{a} / {b}"))
+        }
+        3 => Some(format!(
+            "{} BRG {} DIST {}",
+            read_published(p)?,
+            read_degrees(p)?,
+            read_distance(p)?
+        )),
+        4 => p.ia5(2, 7), // ATS route designator
+        _ => None,
+    }
+}
+
+/// RouteClearance: 9 optional components; the route itself is the list
+/// of RouteInformation legs. The routeInformationAdditional tail (hold
+/// patterns, RTA, intercepts) is reported present-but-undecoded — it is
+/// last in the structure, so everything before it is safe to decode.
+fn read_route_clearance(p: &mut Per) -> Option<Value> {
+    let present: Vec<bool> = (0..9).map(|_| p.bit() == Some(1)).collect();
+    let mut out = serde_json::Map::new();
+    if present[0] {
+        out.insert("departure_airport".into(), json!(p.ia5(4, 4)?));
+    }
+    if present[1] {
+        out.insert("destination_airport".into(), json!(p.ia5(4, 4)?));
+    }
+    if present[2] {
+        out.insert("departure_runway".into(), json!(read_runway(p)?));
+    }
+    if present[3] {
+        out.insert("departure_procedure".into(), json!(read_procedure(p)?));
+    }
+    if present[4] {
+        out.insert("arrival_runway".into(), json!(read_runway(p)?));
+    }
+    if present[5] {
+        out.insert("approach_procedure".into(), json!(read_procedure(p)?));
+    }
+    if present[6] {
+        out.insert("arrival_procedure".into(), json!(read_procedure(p)?));
+    }
+    if present[7] {
+        let n = p.constrained(1, 128)? as usize;
+        let mut legs = Vec::with_capacity(n);
+        for _ in 0..n {
+            legs.push(read_route_information(p)?);
+        }
+        out.insert("route".into(), json!(legs));
+    }
+    if present[8] {
+        out.insert("additional".into(), json!("present (undecoded)"));
+    }
+    Some(Value::Object(out))
 }
 
 


### PR DESCRIPTION
The last staged CPDLC piece — route clearances decode in **both dialects**.

- **ATN-B1**: the clearance rides in `constrainedData` *after* the elements (elements carry an index — `uM80 CLEARED [routeClearance]`); the decoder reaches it whenever every element argument decoded. Airports, runways, SID/STAR/approach procedures (with transitions), and route legs: published identifiers (± lat/lon), lat/lon, place-bearing pairs, place-bearing-distance, ATS designators. The trailing additional block (holds/RTAs/intercepts) reports present-but-undecoded — it's structurally last, so the route is always reachable.
- **FANS-1/A**: inline `FANSRouteClearance` (ten optionals) with FANS-specific constraints from the libacars asn1c tables (procedures SIZE(1..6), 0.1 NM distances, SIZE(1..128) route).

Synthetic vectors both ways: ATN KSFO/J501→OAK via constrainedData; FANS `dM40` renders `DEST KSFO, ROUTE J501 OAK`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)