### PR TITLE
v0.10.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3531,7 +3531,7 @@ dependencies = [
 
 [[package]]
 name = "xng"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3570,7 +3570,7 @@ dependencies = [
 
 [[package]]
 name = "xng-acars"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "base64",
  "crc",
@@ -3582,7 +3582,7 @@ dependencies = [
 
 [[package]]
 name = "xng-dsp"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "crc",
  "num-complex",
@@ -3591,7 +3591,7 @@ dependencies = [
 
 [[package]]
 name = "xng-mode-acars"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "chrono",
  "num-complex",
@@ -3603,7 +3603,7 @@ dependencies = [
 
 [[package]]
 name = "xng-mode-adsb"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "chrono",
  "num-complex",
@@ -3613,7 +3613,7 @@ dependencies = [
 
 [[package]]
 name = "xng-mode-aero"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "chrono",
  "num-complex",
@@ -3627,7 +3627,7 @@ dependencies = [
 
 [[package]]
 name = "xng-mode-ais"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "chrono",
  "num-complex",
@@ -3637,7 +3637,7 @@ dependencies = [
 
 [[package]]
 name = "xng-mode-hfdl"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "chrono",
  "num-complex",
@@ -3650,7 +3650,7 @@ dependencies = [
 
 [[package]]
 name = "xng-mode-iridium"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "chrono",
  "crc",
@@ -3665,7 +3665,7 @@ dependencies = [
 
 [[package]]
 name = "xng-mode-stdc"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "chrono",
  "num-complex",
@@ -3678,7 +3678,7 @@ dependencies = [
 
 [[package]]
 name = "xng-mode-vdl2"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "chrono",
  "num-complex",
@@ -3691,7 +3691,7 @@ dependencies = [
 
 [[package]]
 name = "xng-proto"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "chrono",
  "prost",
@@ -3702,7 +3702,7 @@ dependencies = [
 
 [[package]]
 name = "xng-sdr"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "num-complex",
  "pkg-config",
@@ -3713,7 +3713,7 @@ dependencies = [
 
 [[package]]
 name = "xng-types"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "chrono",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["legacy"]
 resolver = "2"
 
 [workspace.package]
-version = "0.10.0"
+version = "0.10.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/airframesio/xng"

--- a/README.md
+++ b/README.md
@@ -294,10 +294,11 @@ ACARS from any carrier flows through one application layer
 
 - **ADS-C** (ARINC 622): full decode — positions, altitudes, contract
   tags — conformance-tested against real off-air messages.
-- **CPDLC** (FANS-1/A): controller↔pilot datalink rendered as readable
-  text with decoded arguments: `REQUEST CLIMB TO FL360`,
-  `AT 14:32 EXPECT M0.84`, `REQUEST DIRECT TO 52°18.5'N 4°46.0'E`,
-  multi-element messages included.
+- **CPDLC, both dialects**: FANS-1/A (over ACARS) and ATN-B1
+  (over VDL2/CLNP) rendered as readable text with decoded arguments —
+  `REQUEST CLIMB TO FL360`, `AT 14:32 EXPECT M0.84`, free text,
+  vertical rates, headings, multi-element messages, and **route
+  clearances** (`ASSIGNED ROUTE DEST KSFO, ROUTE J501 OAK`).
 - **MIAM** (ARINC 841): single-transfer CORE PDUs decompressed
   (DEFLATE), file-transfer signalling decoded.
 - **OHMA**: Boeing aircraft-health JSON unwrapped (base64 + zlib) into


### PR DESCRIPTION
Patch release: CPDLC argument-complete in both dialects (ATN-B1 arguments + phraseology rendering, FANS composites/free-text/vertical-rate/degrees, route clearances both stacks). README application-layer section updated. Tag follows merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Patch version released as 0.10.1

* **Documentation**
  * Extended CPDLC protocol support documentation to comprehensively cover both FANS-1/A over ACARS and ATN-B1 over VDL2/CLNP dialects with all relevant details
  * Updated application layer documentation with enhanced examples and clearer descriptions of readable text rendering for decoded protocol messages and route clearance operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->