### PR TITLE
VDL2: 100 kS/s channel path + symbol-denominated preamble grid

### DIFF
--- a/crates/xng-mode-vdl2/src/atn_cpdlc.rs
+++ b/crates/xng-mode-vdl2/src/atn_cpdlc.rs
@@ -234,6 +234,7 @@ fn atc_message(bytes: &[u8], nbits: usize, downlink: bool) -> Option<Value> {
                         el["note"] =
                             json!("remaining elements undecoded (argument type unsupported)");
                     }
+                    bailed = true;
                     elements.push(el);
                     break;
                 }

--- a/crates/xng-mode-vdl2/src/demod.rs
+++ b/crates/xng-mode-vdl2/src/demod.rs
@@ -173,8 +173,12 @@ impl Vdl2Demod {
             pr[k] = pr[k - 1] + UW_DELTAS[k] as f32 * PI / 4.0;
         }
         let mut best: Option<(f32, f64, f32)> = None; // (cost, pos, theta)
-        let mut t = -3.0f64;
-        while t <= 3.0 {
+        // Search ±0.7 symbol (at least ±3 samples): the differential
+        // trigger localizes the UW no better than a fraction of a symbol,
+        // and its peak width in samples scales with the channel rate.
+        let half = (0.63 * self.sps).max(3.0);
+        let mut t = -half;
+        while t <= half {
             let cand = pos + t;
             t += 0.25;
             if cand < self.start_abs {

--- a/crates/xng-mode-vdl2/src/lib.rs
+++ b/crates/xng-mode-vdl2/src/lib.rs
@@ -24,6 +24,10 @@ use xng_types::{DecodeQuality, Message, MessageBody, Mode, Provenance, SignalQua
 
 /// Internal channel rate (≈4.76 samples/symbol).
 pub const CHANNEL_RATE: f64 = 50_000.0;
+/// Preferred channel rate (~9.5 samples/symbol): measurably better
+/// off-air decode than the 50 kS/s floor; used whenever the capture
+/// rate divides into it.
+pub const CHANNEL_RATE_HI: f64 = 100_000.0;
 /// One-sided passband: D8PSK 10.5 kBd, RC α=0.6 → ±8.4 kHz.
 pub const CHANNEL_PASSBAND_HZ: f64 = 8_500.0;
 
@@ -48,14 +52,23 @@ pub struct Vdl2ChannelDecoder {
 
 impl Vdl2ChannelDecoder {
     pub fn new(input_rate: f64, freq_offset_hz: f64) -> Result<Self, String> {
-        let ddc = if (input_rate - CHANNEL_RATE).abs() < 1e-6 && freq_offset_hz.abs() < 1e-6 {
+        // Prefer the high channel rate when the capture divides into it;
+        // 50 kS/s remains the floor (and the vendored-fixture rate).
+        let channel_rate = if input_rate >= CHANNEL_RATE_HI
+            && (input_rate / CHANNEL_RATE_HI).fract().abs() < 1e-9
+        {
+            CHANNEL_RATE_HI
+        } else {
+            CHANNEL_RATE
+        };
+        let ddc = if (input_rate - channel_rate).abs() < 1e-6 && freq_offset_hz.abs() < 1e-6 {
             None
         } else {
-            Some(Ddc::new(input_rate, CHANNEL_RATE, freq_offset_hz, CHANNEL_PASSBAND_HZ)?)
+            Some(Ddc::new(input_rate, channel_rate, freq_offset_hz, CHANNEL_PASSBAND_HZ)?)
         };
         Ok(Self {
             ddc,
-            demod: demod::Vdl2Demod::new(CHANNEL_RATE),
+            demod: demod::Vdl2Demod::new(channel_rate),
             rs: interleave::vdl2_rs(),
             channel_buf: Vec::new(),
             x25: atn::X25Reassembler::new(),

--- a/docs/notes/VDL2-DEMOD-V2.md
+++ b/docs/notes/VDL2-DEMOD-V2.md
@@ -107,3 +107,26 @@ trigger threshold drops 0.88 → 0.6 with the fit-cost gate (< 0.25 rad²)
 arbitrating, and weak bursts get attempted safely: **16 frames** on the
 capture (13 before; plateau holds down to thr 0.4). The remaining gap
 to dumpvdl2 is genuine SNR reach at 4.76 samples/symbol.
+
+## Channel-rate study (2026-06)
+
+The 4.76 samples/symbol hypothesis tested directly: the sigidwiki
+capture (48 kS/s native) resampled to 100 kS/s with a matched ±13 kHz
+channel filter and fed to the demod at 9.52 sps. Two findings:
+
+1. The preamble-fit search grid was sample-denominated (±3 samples =
+   only ±0.32 symbols at the higher rate, while the differential
+   trigger's peak width in samples scales with rate). Naively raising
+   the rate DROPPED decodes 16 → 9. Symbol-denominating the grid
+   (±0.63 symbols, floor ±3 samples — exactly the old width at
+   4.76 sps) restored and then beat the baseline.
+
+2. With the grid fixed: 50 kS/s → 16 frames (unchanged), 100 kS/s →
+   17 frames. The decoder now auto-selects 100 kS/s whenever the
+   capture rate divides into it (every real SDR rate: 2.4M/3M/6M);
+   50 kS/s remains the floor and the vendored-fixture path.
+
+The remaining gap to dumpvdl2 (41 on this capture) is not
+sample-rate-bound: next step is demod v3 proper — matched filter +
+decision-feedback equalization, the same arc that took HFDL from
+19 to 33.


### PR DESCRIPTION
The channel-rate study from the roadmap, executed against the full sigidwiki capture:

| config | frames |
|---|---|
| 50 kS/s (4.76 sps), sample-denominated grid (old) | 16 |
| 100 kS/s naively | **9** — exposed a latent scaling bug |
| 100 kS/s + symbol-denominated grid | **17** |
| 50 kS/s + the fix (floored at the old width) | 16 — bit-identical |

The bug: the preamble-fit search grid was ±3 *samples* (only ±0.32 symbols at 9.52 sps, while the trigger's peak width in samples scales with rate). Now ±0.63 *symbols*, floored at ±3 samples.

The decoder auto-selects 100 kS/s whenever the capture rate divides into it (2.4M/3M/6M all do); 50 kS/s remains the floor and the fixture path, so CI vectors are untouched. Study notes document the numbers and the v3 direction (matched filter + DFE — HFDL's 19→33 arc) for the remaining gap to dumpvdl2's 41.

Also fixes the ATN-B1 `bailed` flag lost in a rebase (route clearances could misread after an unsupported element argument).

🤖 Generated with [Claude Code](https://claude.com/claude-code)