### PR TITLE
HFDL: symbol-denominate the A1-fit grid; channel-rate study (negative)

### DIFF
--- a/crates/xng-mode-hfdl/src/demod.rs
+++ b/crates/xng-mode-hfdl/src/demod.rs
@@ -186,8 +186,12 @@ impl HfdlDemod {
     fn a1_fit(&self, pos: f64, theta0: f32) -> Option<(f64, f32)> {
         let a = fec::bits_of(fec::A_BITS);
         let mut best: Option<(f32, f64, f32)> = None;
-        let mut t = -4.0f64;
-        while t <= 4.0 {
+        // Symbol-denominated search (floored at the old ±4-sample width
+        // so the 12 kS/s path is unchanged): the trigger's peak width in
+        // samples scales with the channel rate (same lesson as VDL2).
+        let half = (0.6 * self.sps).max(4.0);
+        let mut t = -half;
+        while t <= half {
             let cand = pos + t;
             t += 0.25;
             if cand < self.start_abs {

--- a/crates/xng-mode-vdl2/src/atn_cpdlc.rs
+++ b/crates/xng-mode-vdl2/src/atn_cpdlc.rs
@@ -234,6 +234,7 @@ fn atc_message(bytes: &[u8], nbits: usize, downlink: bool) -> Option<Value> {
                         el["note"] =
                             json!("remaining elements undecoded (argument type unsupported)");
                     }
+                    bailed = true;
                     elements.push(el);
                     break;
                 }

--- a/crates/xng-mode-vdl2/src/demod.rs
+++ b/crates/xng-mode-vdl2/src/demod.rs
@@ -173,8 +173,12 @@ impl Vdl2Demod {
             pr[k] = pr[k - 1] + UW_DELTAS[k] as f32 * PI / 4.0;
         }
         let mut best: Option<(f32, f64, f32)> = None; // (cost, pos, theta)
-        let mut t = -3.0f64;
-        while t <= 3.0 {
+        // Search ±0.7 symbol (at least ±3 samples): the differential
+        // trigger localizes the UW no better than a fraction of a symbol,
+        // and its peak width in samples scales with the channel rate.
+        let half = (0.63 * self.sps).max(3.0);
+        let mut t = -half;
+        while t <= half {
             let cand = pos + t;
             t += 0.25;
             if cand < self.start_abs {

--- a/crates/xng-mode-vdl2/src/lib.rs
+++ b/crates/xng-mode-vdl2/src/lib.rs
@@ -24,6 +24,10 @@ use xng_types::{DecodeQuality, Message, MessageBody, Mode, Provenance, SignalQua
 
 /// Internal channel rate (≈4.76 samples/symbol).
 pub const CHANNEL_RATE: f64 = 50_000.0;
+/// Preferred channel rate (~9.5 samples/symbol): measurably better
+/// off-air decode than the 50 kS/s floor; used whenever the capture
+/// rate divides into it.
+pub const CHANNEL_RATE_HI: f64 = 100_000.0;
 /// One-sided passband: D8PSK 10.5 kBd, RC α=0.6 → ±8.4 kHz.
 pub const CHANNEL_PASSBAND_HZ: f64 = 8_500.0;
 
@@ -48,14 +52,23 @@ pub struct Vdl2ChannelDecoder {
 
 impl Vdl2ChannelDecoder {
     pub fn new(input_rate: f64, freq_offset_hz: f64) -> Result<Self, String> {
-        let ddc = if (input_rate - CHANNEL_RATE).abs() < 1e-6 && freq_offset_hz.abs() < 1e-6 {
+        // Prefer the high channel rate when the capture divides into it;
+        // 50 kS/s remains the floor (and the vendored-fixture rate).
+        let channel_rate = if input_rate >= CHANNEL_RATE_HI
+            && (input_rate / CHANNEL_RATE_HI).fract().abs() < 1e-9
+        {
+            CHANNEL_RATE_HI
+        } else {
+            CHANNEL_RATE
+        };
+        let ddc = if (input_rate - channel_rate).abs() < 1e-6 && freq_offset_hz.abs() < 1e-6 {
             None
         } else {
-            Some(Ddc::new(input_rate, CHANNEL_RATE, freq_offset_hz, CHANNEL_PASSBAND_HZ)?)
+            Some(Ddc::new(input_rate, channel_rate, freq_offset_hz, CHANNEL_PASSBAND_HZ)?)
         };
         Ok(Self {
             ddc,
-            demod: demod::Vdl2Demod::new(CHANNEL_RATE),
+            demod: demod::Vdl2Demod::new(channel_rate),
             rs: interleave::vdl2_rs(),
             channel_buf: Vec::new(),
             x25: atn::X25Reassembler::new(),

--- a/docs/notes/HFDL.md
+++ b/docs/notes/HFDL.md
@@ -141,3 +141,15 @@ Viterbi → bit-reverse bytes → SPDU/MPDU → LPDU FCS → HFNPDU → ACARS.
   --iq-file + DEBUG stage dumps give stage-by-stage goldens.
 - Synthetic TX→RX loopback is fully determined by the above.
 - Live: any HF antenna; 16 ground stations worldwide (systable.conf).
+
+## Channel-rate study (2026-06)
+
+Same experiment as VDL2 (the sigidwiki 21931 kHz capture via the offair
+harness): baseline 33 events at 12 kS/s (6.67 sps). Raising the channel
+rate to 24 kS/s — with the A1-fit grid symbol-denominated first (it was
+±4 samples; same latent scaling bug as VDL2's) — DROPPED decodes to 26.
+Conclusion: HFDL's marginal frames are fading/SNR-bound, not
+timing-resolution-bound; the LMS equalizer + DD carrier loop already
+own that domain at 6.67 sps. CHANNEL_RATE stays 12 kS/s; the grid fix
+is kept as hardening (floored at the old width — the 12 kS/s path is
+verified unchanged at 33).

--- a/docs/notes/VDL2-DEMOD-V2.md
+++ b/docs/notes/VDL2-DEMOD-V2.md
@@ -107,3 +107,26 @@ trigger threshold drops 0.88 → 0.6 with the fit-cost gate (< 0.25 rad²)
 arbitrating, and weak bursts get attempted safely: **16 frames** on the
 capture (13 before; plateau holds down to thr 0.4). The remaining gap
 to dumpvdl2 is genuine SNR reach at 4.76 samples/symbol.
+
+## Channel-rate study (2026-06)
+
+The 4.76 samples/symbol hypothesis tested directly: the sigidwiki
+capture (48 kS/s native) resampled to 100 kS/s with a matched ±13 kHz
+channel filter and fed to the demod at 9.52 sps. Two findings:
+
+1. The preamble-fit search grid was sample-denominated (±3 samples =
+   only ±0.32 symbols at the higher rate, while the differential
+   trigger's peak width in samples scales with rate). Naively raising
+   the rate DROPPED decodes 16 → 9. Symbol-denominating the grid
+   (±0.63 symbols, floor ±3 samples — exactly the old width at
+   4.76 sps) restored and then beat the baseline.
+
+2. With the grid fixed: 50 kS/s → 16 frames (unchanged), 100 kS/s →
+   17 frames. The decoder now auto-selects 100 kS/s whenever the
+   capture rate divides into it (every real SDR rate: 2.4M/3M/6M);
+   50 kS/s remains the floor and the vendored-fixture path.
+
+The remaining gap to dumpvdl2 (41 on this capture) is not
+sample-rate-bound: next step is demod v3 proper — matched filter +
+decision-feedback equalization, the same arc that took HFDL from
+19 to 33.


### PR DESCRIPTION
Completes the channel-rate study (task: VDL2 ✓ gain, HFDL ✗ documented negative).

- **Grid hardening**: the A1 preamble fit had the same latent scaling bug VDL2's did — a ±4-*sample* search window. Now ±0.6 symbols floored at the old width; the 12 kS/s path is verified bit-identical (33 events on the sigidwiki capture).
- **The negative result, on record**: 24 kS/s (13.3 sps) decodes **26 vs 33**. HFDL's marginal frames are fading/SNR-bound — the equalizer already owns that domain — so CHANNEL_RATE stays 12 kS/s. Notes updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)