### PR TITLE
VDL2: failure-funnel instrumentation + demod v3 findings

### DIFF
--- a/crates/xng-mode-vdl2/examples/offair.rs
+++ b/crates/xng-mode-vdl2/examples/offair.rs
@@ -51,4 +51,12 @@ fn main() {
         }
     }
     println!("total: {n} frames");
+    use std::sync::atomic::Ordering;
+    eprintln!(
+        "stats: fit_pass={} hdr_fail={} rs_fail={} burst_ok={}",
+        xng_mode_vdl2::demod::STAT_FIT_PASS.load(Ordering::Relaxed),
+        xng_mode_vdl2::demod::STAT_HDR_FAIL.load(Ordering::Relaxed),
+        xng_mode_vdl2::demod::STAT_RS_FAIL.load(Ordering::Relaxed),
+        xng_mode_vdl2::demod::STAT_BURST_OK.load(Ordering::Relaxed),
+    );
 }

--- a/crates/xng-mode-vdl2/src/demod.rs
+++ b/crates/xng-mode-vdl2/src/demod.rs
@@ -17,6 +17,13 @@ use crate::interleave;
 use crate::scramble::Scrambler;
 use num_complex::Complex;
 use std::f32::consts::PI;
+use std::sync::atomic::{AtomicUsize, Ordering as AOrd};
+
+/// Failure-funnel counters for off-air studies (see examples/offair.rs).
+pub static STAT_FIT_PASS: AtomicUsize = AtomicUsize::new(0);
+pub static STAT_HDR_FAIL: AtomicUsize = AtomicUsize::new(0);
+pub static STAT_RS_FAIL: AtomicUsize = AtomicUsize::new(0);
+pub static STAT_BURST_OK: AtomicUsize = AtomicUsize::new(0);
 use xng_dsp::rs::ReedSolomon;
 
 pub const SYMBOL_RATE: f64 = 10_500.0;
@@ -260,6 +267,7 @@ impl Vdl2Demod {
                     // wasted work, never a lost burst.
                     if let Some((p, th, cost)) = self.preamble_fit(pos) {
                         if cost < FIT_COST_MAX {
+                            STAT_FIT_PASS.fetch_add(1, AOrd::Relaxed);
                             return Some((p, th));
                         }
                     }
@@ -341,6 +349,7 @@ impl Vdl2Demod {
                         break; // need more samples
                     }
                     Some(Err(())) => {
+                        STAT_HDR_FAIL.fetch_add(1, AOrd::Relaxed);
                         // Bad header: resume hunting just past this UW.
                         self.state = State::Hunt;
                     }
@@ -351,10 +360,12 @@ impl Vdl2Demod {
                         match interleave::deinterleave(&c.bits[HEADER_BITS..n], tl_bits, rs)
                         {
                             Some((avlc_bits, fixed)) => {
+                                STAT_BURST_OK.fetch_add(1, AOrd::Relaxed);
                                 out.push(Burst { bits: avlc_bits, rs_corrected: fixed });
                                 self.cursor = c.next_pos; // skip past the burst
                             }
                             None => {
+                                STAT_RS_FAIL.fetch_add(1, AOrd::Relaxed);
                                 self.last_rs_fail = c.uw_start;
                                 // A false UW lock (e.g. on a burst edge) can
                                 // pass the header FEC with a bogus length and

--- a/docs/notes/VDL2-DEMOD-V2.md
+++ b/docs/notes/VDL2-DEMOD-V2.md
@@ -130,3 +130,32 @@ The remaining gap to dumpvdl2 (41 on this capture) is not
 sample-rate-bound: next step is demod v3 proper — matched filter +
 decision-feedback equalization, the same arc that took HFDL from
 19 to 33.
+
+## Demod v3 attempt: UW-trained LMS equalizer (2026-06, reverted)
+
+Instrumented the failure funnel on the off-air capture at 100 kS/s:
+fit_pass=125, hdr_fail=26, **rs_fail=43**, burst_ok=25 → decision
+quality on accepted bursts is the bottleneck, not acquisition.
+
+Tried HFDL's recipe (7-tap T-spaced LMS trained on the 16-symbol UW,
+2nd-order DD carrier loop). Findings, all measured:
+
+1. **Coherent/absolute D8PSK detection loses outright** on this signal:
+   per-symbol |phase err| 0.07–0.39 rad against π/8 decision regions —
+   the capture has oscillator phase wander that differential detection
+   cancels and absolute tracking does not. (Decoded 1 frame vs 17.)
+2. Differential-on-equalized works in clean loopback (training residual
+   0.001–0.004 rad) but off-air decodes 10–12 vs 17 plain: 16 training
+   symbols leave the taps part-converged, and the residual tap noise
+   injects ISI that outweighs the equalization gain at 9.5 sps.
+   Decision-directed adaptation anchored on the previous output
+   (drift-free for DPSK) recovers some (10→12), not enough.
+3. Watch the lookahead-at-stream-end edge (k+3 window for the last
+   symbols) — it silently stalls collection in loopback tests.
+
+v3 direction that survives these findings: **two-pass decode** — first
+pass with the plain demod, then retrain the equalizer on the *entire*
+decoded burst (hundreds of known symbols instead of 16) and re-decode;
+apply only when pass 1 fails RS. That spends CPU exclusively on the 43
+RS failures and cannot regress the 25 already-good bursts. The funnel
+counters (demod::STAT_*) are kept for that work.


### PR DESCRIPTION
The demod-v3 equalizer attempt, run to a measured conclusion. The algorithm changes are **reverted** (every variant lost to the existing differential demod: best 12 vs 17 off-air); the deliverables are the instrumentation and the findings:

- **Funnel** (off-air, 100 kS/s): `fit_pass=125 hdr_fail=26 rs_fail=43 burst_ok=25` — decision quality is the bottleneck, not acquisition.
- **Coherent D8PSK detection loses to differential** on real signals (oscillator phase wander: 0.07–0.39 rad per-symbol against π/8 regions) — 1 frame vs 17.
- **16 UW training symbols are too few** for a T-spaced LMS: residual tap noise injects more ISI than it removes (10–12 vs 17), even with drift-free DD adaptation.
- **The surviving direction** (documented in the notes): two-pass decode — plain first pass, then retrain on the entire burst and re-decode, applied **only to RS failures**. Spends CPU exclusively on the 43 failures, cannot regress the 25 good bursts.

Demod verified unchanged: 17 frames at 100 kS/s, full suite green. Funnel counters ship (`demod::STAT_*` + offair stats line) for the follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added demodulation statistics reporting to display off-air processing metrics including pass counts, failures, and successes.

* **Documentation**
  * Updated design notes with demodulation optimization attempts and results, documenting improvements to signal processing and diagnostic capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->