### PR TITLE
VDL2 v4: confidence-driven RS erasure retry

### DIFF
--- a/crates/xng-mode-vdl2/examples/offair.rs
+++ b/crates/xng-mode-vdl2/examples/offair.rs
@@ -53,10 +53,11 @@ fn main() {
     println!("total: {n} frames");
     use std::sync::atomic::Ordering;
     eprintln!(
-        "stats: fit_pass={} hdr_fail={} rs_fail={} burst_ok={}",
+        "stats: fit_pass={} hdr_fail={} rs_fail={} soft_ok={} burst_ok={}",
         xng_mode_vdl2::demod::STAT_FIT_PASS.load(Ordering::Relaxed),
         xng_mode_vdl2::demod::STAT_HDR_FAIL.load(Ordering::Relaxed),
         xng_mode_vdl2::demod::STAT_RS_FAIL.load(Ordering::Relaxed),
+        xng_mode_vdl2::demod::STAT_SOFT_OK.load(Ordering::Relaxed),
         xng_mode_vdl2::demod::STAT_BURST_OK.load(Ordering::Relaxed),
     );
 }

--- a/crates/xng-mode-vdl2/src/demod.rs
+++ b/crates/xng-mode-vdl2/src/demod.rs
@@ -23,6 +23,7 @@ use std::sync::atomic::{AtomicUsize, Ordering as AOrd};
 pub static STAT_FIT_PASS: AtomicUsize = AtomicUsize::new(0);
 pub static STAT_HDR_FAIL: AtomicUsize = AtomicUsize::new(0);
 pub static STAT_RS_FAIL: AtomicUsize = AtomicUsize::new(0);
+pub static STAT_SOFT_OK: AtomicUsize = AtomicUsize::new(0);
 pub static STAT_BURST_OK: AtomicUsize = AtomicUsize::new(0);
 use xng_dsp::rs::ReedSolomon;
 
@@ -66,6 +67,9 @@ struct Collecting {
     prev: Complex<f32>,
     /// Descrambled bits collected so far.
     bits: Vec<u8>,
+    /// Per-symbol decision confidence: |phase residual| at the π/4 grid
+    /// (small = confident). One entry per data symbol.
+    conf: Vec<f32>,
     scr: Scrambler,
     /// Total bits to collect once the header is decoded.
     needed: Option<usize>,
@@ -306,6 +310,7 @@ impl Vdl2Demod {
             let idx = (idx_f as i32).rem_euclid(8) as usize;
             let residual = ph - idx_f * (PI / 4.0);
             c.theta += PHASE_GAIN * residual;
+            c.conf.push(residual.abs());
             let (x, y, z) = GRAY_INV[idx];
             for b in [x, y, z] {
                 c.bits.push(b ^ c.scr.next_bit());
@@ -337,6 +342,7 @@ impl Vdl2Demod {
                             theta,
                             prev,
                             bits: Vec::new(),
+                            conf: Vec::new(),
                             scr: Scrambler::new(),
                             needed: None,
                         }));
@@ -357,12 +363,30 @@ impl Vdl2Demod {
                         let n = c.needed.unwrap();
                         let hdr: [u8; HEADER_BITS] = c.bits[..HEADER_BITS].try_into().unwrap();
                         let tl_bits = header::decode(&hdr).unwrap() as usize;
-                        match interleave::deinterleave(&c.bits[HEADER_BITS..n], tl_bits, rs)
-                        {
-                            Some((avlc_bits, fixed)) => {
+                        match interleave::deinterleave_soft(
+                            &c.bits[HEADER_BITS..n],
+                            &c.conf,
+                            HEADER_BITS,
+                            tl_bits,
+                            rs,
+                        ) {
+                            Some((avlc_bits, fixed, soft)) => {
                                 STAT_BURST_OK.fetch_add(1, AOrd::Relaxed);
+                                if soft {
+                                    STAT_SOFT_OK.fetch_add(1, AOrd::Relaxed);
+                                }
                                 out.push(Burst { bits: avlc_bits, rs_corrected: fixed });
-                                self.cursor = c.next_pos; // skip past the burst
+                                // An erasure-assisted pass may be a
+                                // miscorrection (the AVLC FCS arbitrates);
+                                // never let it swallow a later burst —
+                                // rewind like an RS failure instead of
+                                // skipping ahead.
+                                if soft {
+                                    self.last_rs_fail = c.uw_start;
+                                    self.cursor = c.uw_start + 1.0;
+                                } else {
+                                    self.cursor = c.next_pos; // skip past the burst
+                                }
                             }
                             None => {
                                 STAT_RS_FAIL.fetch_add(1, AOrd::Relaxed);

--- a/crates/xng-mode-vdl2/src/interleave.rs
+++ b/crates/xng-mode-vdl2/src/interleave.rs
@@ -104,16 +104,51 @@ pub fn interleave(data_bits: &[u8], rs: &ReedSolomon) -> Vec<u8> {
 
 /// RX: transmitted post-header bits → corrected data bits (TL of them).
 /// Returns (data_bits, rs_corrected_octets) or None if uncorrectable.
+/// Hard-decision deinterleave (kept for loopback tests and as the
+/// zero-confidence fallback).
 pub fn deinterleave(tx_bits: &[u8], tl_bits: usize, rs: &ReedSolomon) -> Option<(Vec<u8>, usize)> {
+    deinterleave_soft(tx_bits, &[], 0, tl_bits, rs).map(|(b, c, _)| (b, c))
+}
+
+/// Deinterleave with soft-decision erasure retries: each RS row is
+/// first tried as-is; on failure, the transmitted octets with the
+/// lowest decision confidence are marked as erasures and the row is
+/// retried (RS(255,249) trades one error of budget for two erasures:
+/// 2·errors + erasures ≤ 6, with untransmitted check octets already
+/// consuming part of the budget). The AVLC FCS downstream rejects any
+/// miscorrection this invites.
+///
+/// `sym_conf` holds |phase residual| per burst symbol (3 bits each);
+/// `bit_offset` is `tx_bits[0]`'s position in the burst bit stream
+/// (the header is not symbol-aligned). Empty conf = hard decisions.
+pub fn deinterleave_soft(
+    tx_bits: &[u8],
+    sym_conf: &[f32],
+    bit_offset: usize,
+    tl_bits: usize,
+    rs: &ReedSolomon,
+) -> Option<(Vec<u8>, usize, bool)> {
     let lay = layout(tl_bits)?;
     if tx_bits.len() < lay.total_tx_bits {
         return None;
     }
     let octets = bits_to_octets(&tx_bits[..lay.total_tx_bits]);
+    // Worst-bit confidence per TX octet (symbols are 3 bits; an octet
+    // spans 2-4 symbols — take the largest residual touching it).
+    let octet_conf: Vec<f32> = (0..octets.len())
+        .map(|o| {
+            let first_sym = (bit_offset + o * 8) / 3;
+            let last_sym = (bit_offset + o * 8 + 7) / 3;
+            (first_sym..=last_sym)
+                .map(|s| sym_conf.get(s).copied().unwrap_or(0.0))
+                .fold(0.0f32, f32::max)
+        })
+        .collect();
 
     let c = lay.rows.len();
     let mut grid: Vec<Vec<u8>> = vec![vec![0u8; 255]; c];
-    let mut it = octets.iter();
+    let mut cgrid: Vec<Vec<f32>> = vec![vec![0.0f32; 255]; c];
+    let mut it = octets.iter().zip(&octet_conf);
     for col in 0..255 {
         for r in 0..c {
             let n = lay.rows[r];
@@ -121,27 +156,68 @@ pub fn deinterleave(tx_bits: &[u8], tl_bits: usize, rs: &ReedSolomon) -> Option<
             let transmitted =
                 (col < n) || (col >= ROW_DATA_OCTETS && col < ROW_DATA_OCTETS + k);
             if transmitted {
-                grid[r][col] = *it.next()?;
+                let (&o, &cf) = it.next()?;
+                grid[r][col] = o;
+                cgrid[r][col] = cf;
             }
         }
     }
 
     let mut corrected = 0usize;
+    let mut soft_assisted = false;
     let mut data_octets = Vec::new();
     for (r, row) in grid.iter_mut().enumerate() {
         let n = lay.rows[r];
         let k = lay.checks[r];
         if k > 0 {
-            // Untransmitted check octets are erasures.
-            let erasures: Vec<usize> = (ROW_DATA_OCTETS + k..255).collect();
-            match rs.correct(row, &erasures) {
-                Ok(fixed) => corrected += fixed.saturating_sub(erasures.len()),
-                Err(()) => return None,
+            // Untransmitted check octets are always erasures.
+            let base: Vec<usize> = (ROW_DATA_OCTETS + k..255).collect();
+            let budget = 6usize.saturating_sub(base.len());
+            // Transmitted positions ranked least-confident first.
+            let mut ranked: Vec<usize> = (0..255)
+                .filter(|&col| (col < n) || (col >= ROW_DATA_OCTETS && col < ROW_DATA_OCTETS + k))
+                .collect();
+            ranked.sort_by(|&a, &b| {
+                cgrid[r][b].partial_cmp(&cgrid[r][a]).unwrap_or(std::cmp::Ordering::Equal)
+            });
+
+            let mut done = false;
+            // One erasure rung only: erasing the two least-confident
+            // octets keeps a two-error margin (2e + f ≤ 6). Wider rungs
+            // measurably hallucinate codewords (see demod notes).
+            for extra in [0usize, 2] {
+                if extra > budget {
+                    break;
+                }
+                let mut attempt = row.clone();
+                let mut erasures = base.clone();
+                if extra > 0 {
+                    // Only erase genuinely doubtful decisions (residual
+                    // beyond ~half the decision region).
+                    if ranked.len() < extra
+                        || ranked.iter().take(extra).any(|&p| cgrid[r][p] < 0.20)
+                    {
+                        break;
+                    }
+                    erasures.extend(ranked.iter().take(extra).copied());
+                }
+                if let Ok(fixed) = rs.correct(&mut attempt, &erasures) {
+                    corrected += fixed.saturating_sub(base.len());
+                    if extra > 0 {
+                        soft_assisted = true;
+                    }
+                    *row = attempt;
+                    done = true;
+                    break;
+                }
+            }
+            if !done {
+                return None;
             }
         }
         data_octets.extend_from_slice(&row[..n]);
     }
-    Some((octets_to_bits(&data_octets, tl_bits), corrected))
+    Some((octets_to_bits(&data_octets, tl_bits), corrected, soft_assisted))
 }
 
 #[cfg(test)]

--- a/docs/notes/VDL2-DEMOD-V2.md
+++ b/docs/notes/VDL2-DEMOD-V2.md
@@ -182,3 +182,25 @@ per-symbol confidence into RS erasure marking (the decoder corrects
 row doubles the correction budget exactly where it is needed), or
 confidence-driven re-decision of boundary symbols. That is the v4
 direction; the funnel counters remain in place for it.
+
+## v4: soft-decision RS erasures (2026-06, shipped with caveats)
+
+Implemented: per-symbol |residual| confidence → on RS row failure,
+retry once with the two least-confident transmitted octets erased
+(2e+f ≤ 6 keeps a two-error margin; flagged octets must have residual
+> 0.20 rad). Erasure-assisted decodes never advance the hunt cursor
+past the burst (rewind, like a failure) so a miscorrection can
+never swallow a later burst — that guard was earned the hard way: an
+unbounded erasure ladder "decoded" every burst (rs_fail 43 → 0) while
+real frames DROPPED 17 → 10 from cursor skips over hallucinated
+codewords.
+
+Off-air result: 13 of 43 RS failures now pass RS, **all 13 rejected by
+the AVLC FCS** — zero verified gain on this capture. Third independent
+confirmation (after the equalizer and two-pass studies) that the
+capture's failing bursts are pervasively weak rather than marginal:
+the 17-vs-41 gap to dumpvdl2 lives in raw demodulation quality
+(filtering/sync ahead of the slicer), not in FEC headroom. The
+machinery ships because it is free on the happy path, regression-proof
+by construction, observable live (soft_ok counter), and exactly
+targets the 4-bad-octet bursts that real reception produces.


### PR DESCRIPTION
The v4 direction from the demod notes, implemented with the two guards the experiments demanded:

- **Mechanism**: per-symbol |phase residual| → on RS row failure, one retry with the 2 least-confident transmitted octets erased (2e+f≤6 keeps a 2-error margin; flagged octets must exceed 0.20 rad residual).
- **Guard 1 — one rung only**: an unbounded erasure ladder "decoded" *every* burst (rs_fail 43→0) while real frames **dropped 17→10** — RS happily hallucinates codewords given enough erasures.
- **Guard 2 — rewind, don't skip**: erasure-assisted decodes never advance the cursor past the burst, so a miscorrection can't swallow the next real burst. The AVLC FCS stays the final arbiter.

**Honest result**: on the off-air capture, zero regression and zero verified gain (13/43 failures pass RS, all FCS-rejected) — the third independent confirmation that this capture's failures are pervasively weak. The machinery ships because it's free on the happy path, regression-proof by construction, live-observable (`soft_ok` counter), and targets exactly the 4-bad-octet bursts real reception produces. Notes updated with the full evidence chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)