### PR TITLE
VDL2 notes: failure forensics round 2 (three hypotheses falsified, one left standing)

### DIFF
--- a/docs/notes/VDL2-DEMOD-V2.md
+++ b/docs/notes/VDL2-DEMOD-V2.md
@@ -228,3 +228,31 @@ Remaining gap (19 vs 41): the oracle decodes multiple frames from
 burst sequences we still partially miss; next instrumentation step is
 time-aligning our decoded burst list against dumpvdl2's per-burst
 timestamps to see exactly which transmissions remain.
+
+## Failure forensics round 2 (2026-06, all rescue ladders falsified)
+
+With the gated estimator in (19 frames), the remaining oracle gap was
+chased through three more measured hypotheses:
+
+- **Content diff vs dumpvdl2**: we decode the short frames (11-octet
+  RRs) of conversations whose long I-frames we miss, plus zero of the
+  six GSIF broadcast XIDs. Pattern: long bursts fail, short ones pass.
+- **Clock-skew re-walk** (±25..100 ppm): zero rescues. Falsified.
+- **Symbol-offset re-walk** (±1, ±2 symbols): six "rescues" — every
+  one RS-passing garbage with zero FCS-valid frames and no 0x7E flags
+  in the bytes. Cause: low-redundancy RS rows (2 check octets ≈ 0.4%
+  random-pass odds) pass deterministically once lucky. Falsified, and
+  a hazard quantified: **on short/low-k rows an RS pass is weak
+  evidence — never emit or change control flow on it without FCS.**
+- **Residual trajectories on real failures**: flat head-to-tail (no
+  drift), and several failures show GOOD residuals (0.10-0.12 rad
+  mean) — the constellation locks while the bits are wrong.
+
+Locked-constellation-with-wrong-bits and a clean residual leaves one
+suspect standing: the 25-bit header FEC accepting a near-codeword with
+a wrong transmission length (collection length and interleaver layout
+both wrong → clean symbols, garbage deinterleave). Next experiment:
+on RS failure, ladder over the header codewords within FEC distance
+of the received header bits and retry the deinterleave per candidate
+length (data is already collected for the longest). FCS-arbitrated as
+always.


### PR DESCRIPTION
Documentation-only. Three more measured hypotheses on the 19-vs-41 gap:

- **Oracle content diff**: short frames of a conversation decode while its long I-frames fail; all six GSIF broadcasts missed.
- **Clock skew** (±25–100 ppm re-walks): zero rescues — falsified.
- **Symbol offset** (±1/±2 re-walks): six "rescues", all RS-passing garbage (no 0x7E flags) — falsified, and a hazard quantified: low-redundancy RS rows (2 check octets) random-pass at ~0.4%, so **RS-pass must never gate control flow without FCS**.
- **Residuals on real failures**: flat and often *good* (0.10 rad) — constellation locked, bits wrong.

The one suspect that survives all evidence: **header FEC accepting a near-codeword with a wrong transmission length** (poisons collection length + interleaver layout while symbols stay clean). Its experiment is specified in the notes: FEC-distance header-candidate ladder on RS failure, FCS-arbitrated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)