### PR TITLE
VDL2 long tail: ES-IS/IDRP, X.25 facilities, CM ground PDUs, GS names + output wiring repair

### DIFF
--- a/crates/xng-mode-vdl2/src/atn.rs
+++ b/crates/xng-mode-vdl2/src/atn.rs
@@ -29,6 +29,9 @@ pub struct X25Packet {
     pub cause: Option<u8>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub diagnostic: Option<u8>,
+    /// Negotiated facilities on call packets.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub facilities: Vec<Value>,
     /// Payload (data packets: user data; call packets: CUD).
     #[serde(skip)]
     pub payload: Vec<u8>,
@@ -54,6 +57,7 @@ pub fn parse_x25(b: &[u8]) -> Option<X25Packet> {
         more: false,
         cause: None,
         diagnostic: None,
+        facilities: Vec::new(),
         payload: Vec::new(),
     };
     if t & 0x01 == 0 {
@@ -78,6 +82,10 @@ pub fn parse_x25(b: &[u8]) -> Option<X25Packet> {
                 if b.len() > fac_pos {
                     let fac_len = b[fac_pos] as usize;
                     let cud_pos = fac_pos + 1 + fac_len;
+                    if fac_len > 0 && fac_pos + 1 + fac_len <= b.len() {
+                        pkt.facilities =
+                            parse_facilities(&b[fac_pos + 1..fac_pos + 1 + fac_len]);
+                    }
                     if b.len() > cud_pos {
                         pkt.payload = b[cud_pos..].to_vec();
                     }
@@ -158,8 +166,8 @@ impl Default for X25Reassembler {
 pub fn parse_network(b: &[u8]) -> Option<Value> {
     match b.first()? {
         0x81 => parse_clnp(b),
-        0x82 => Some(json!({ "protocol": "ES-IS", "payload_len": b.len() })),
-        0x83 => Some(json!({ "protocol": "IDRP", "payload_len": b.len() })),
+        0x82 => Some(parse_esis(b)),
+        0x83 => Some(parse_idrp(b)),
         // ICAO 9705 LREF/deflate-compressed CLNP: leading octet is the
         // local-reference type. Layout not yet verified — label only.
         _ => Some(json!({
@@ -168,6 +176,109 @@ pub fn parse_network(b: &[u8]) -> Option<Value> {
             "payload_len": b.len(),
         })),
     }
+}
+
+/// ES-IS (ISO 9542) header: type and the advertised network entity
+/// titles / addresses (hex NSAPs).
+fn parse_esis(b: &[u8]) -> Value {
+    let mut out = json!({ "protocol": "ES-IS", "payload_len": b.len() });
+    if b.len() < 9 {
+        return out;
+    }
+    let hdr_len = b[1] as usize;
+    let type_code = b[4] & 0x1F;
+    out["type"] = json!(match type_code {
+        2 => "ESH",
+        4 => "ISH",
+        6 => "RD",
+        _ => "?",
+    });
+    out["holding_time_s"] = json!(u16::from_be_bytes([b[5], b[6]]));
+    // ESH: count + SA(s); ISH: single NET. Both length-prefixed.
+    let mut pos = 9usize;
+    let mut addrs = Vec::new();
+    if type_code == 2 && pos < b.len().min(hdr_len) {
+        let n = b[pos] as usize;
+        pos += 1;
+        for _ in 0..n {
+            let Some(&len) = b.get(pos) else { break };
+            let len = len as usize;
+            pos += 1;
+            if pos + len > b.len() || len > 20 {
+                break;
+            }
+            addrs.push(b[pos..pos + len].iter().map(|x| format!("{x:02x}")).collect::<String>());
+            pos += len;
+        }
+    } else if type_code == 4 {
+        if let Some(&len) = b.get(pos) {
+            let len = len as usize;
+            pos += 1;
+            if pos + len <= b.len() && len <= 20 {
+                addrs.push(b[pos..pos + len].iter().map(|x| format!("{x:02x}")).collect::<String>());
+            }
+        }
+    }
+    if !addrs.is_empty() {
+        out["addresses"] = json!(addrs);
+    }
+    out
+}
+
+/// IDRP (ISO 10747) BISPDU header: length, type, sequence numbers.
+fn parse_idrp(b: &[u8]) -> Value {
+    let mut out = json!({ "protocol": "IDRP", "payload_len": b.len() });
+    if b.len() < 4 {
+        return out;
+    }
+    let len = u16::from_be_bytes([b[1], b[2]]);
+    out["bispdu_len"] = json!(len);
+    out["type"] = json!(match b.get(3) {
+        Some(1) => "OPEN",
+        Some(2) => "UPDATE",
+        Some(3) => "ERROR",
+        Some(4) => "KEEPALIVE",
+        Some(5) => "CEASE",
+        _ => "?",
+    });
+    if b.len() >= 12 {
+        out["sequence"] = json!(u32::from_be_bytes([b[4], b[5], b[6], b[7]]));
+    }
+    out
+}
+
+/// X.25 facilities: TLVs with class-coded lengths (bits 7-8 of the
+/// code: 1/2/3 parameter bytes, or variable with a length byte).
+/// Codes are reported numerically — naming is deferred until the ITU
+/// table can be verified.
+fn parse_facilities(b: &[u8]) -> Vec<Value> {
+    let mut out = Vec::new();
+    let mut pos = 0usize;
+    while pos < b.len() {
+        let code = b[pos];
+        pos += 1;
+        let plen = match code >> 6 {
+            0 => 1,
+            1 => 2,
+            2 => 3,
+            _ => match b.get(pos) {
+                Some(&l) => {
+                    pos += 1;
+                    l as usize
+                }
+                None => break,
+            },
+        };
+        if pos + plen > b.len() {
+            break;
+        }
+        out.push(json!({
+            "code": format!("{code:#04x}"),
+            "params": b[pos..pos + plen].iter().map(|x| format!("{x:02x}")).collect::<String>(),
+        }));
+        pos += plen;
+    }
+    out
 }
 
 /// Full (uncompressed) CLNP header per ISO 8473.
@@ -245,6 +356,7 @@ fn parse_cotp(b: &[u8]) -> Option<Value> {
         // try protected-mode CPDLC, then CM.
         if let Some(app) = crate::atn_cpdlc::parse_apdu(user)
             .or_else(|| crate::atn_cpdlc::parse_cm_logon(user))
+            .or_else(|| crate::atn_cpdlc::parse_cm_ground(user))
         {
             out["app"] = app;
         }
@@ -271,6 +383,44 @@ mod tests {
         let mut r = X25Reassembler::new();
         assert_eq!(r.push(&d1, 0.0), None);
         assert_eq!(r.push(&d2, 1.0), Some(vec![0xAA, 0xBB, 0xCC]));
+    }
+
+    #[test]
+    fn esis_ish_parses_net() {
+        // NLPID 0x82, hdr_len, version, lifetime, type=ISH(4),
+        // holding time 600 s, checksum, then NET length + NET.
+        let mut b = vec![0x82, 0x0E, 0x01, 0x00, 0x04, 0x02, 0x58, 0x00, 0x00];
+        b.push(3); // NET length
+        b.extend([0x47, 0x00, 0x27]);
+        let v = parse_network(&b).unwrap();
+        assert_eq!(v["protocol"], "ES-IS");
+        assert_eq!(v["type"], "ISH");
+        assert_eq!(v["holding_time_s"], 600);
+        assert_eq!(v["addresses"][0], "470027");
+    }
+
+    #[test]
+    fn idrp_keepalive_parses() {
+        // NLPID 0x83, BISPDU len, type=KEEPALIVE(4), sequence.
+        let b = [0x83, 0x00, 0x0C, 0x04, 0x00, 0x00, 0x00, 0x2A, 0, 0, 0, 0];
+        let v = parse_network(&b).unwrap();
+        assert_eq!(v["protocol"], "IDRP");
+        assert_eq!(v["type"], "KEEPALIVE");
+        assert_eq!(v["sequence"], 42);
+        assert_eq!(v["bispdu_len"], 12);
+    }
+
+    #[test]
+    fn facilities_class_lengths() {
+        // class 0 (1 param byte): 0x01 0xAA; class 1 (2): 0x42 0x01 0x02;
+        // class 3 (length-prefixed): 0xC9 0x02 0xDE 0xAD.
+        let f = parse_facilities(&[0x01, 0xAA, 0x42, 0x01, 0x02, 0xC9, 0x02, 0xDE, 0xAD]);
+        assert_eq!(f.len(), 3);
+        assert_eq!(f[0]["code"], "0x01");
+        assert_eq!(f[0]["params"], "aa");
+        assert_eq!(f[1]["params"], "0102");
+        assert_eq!(f[2]["code"], "0xc9");
+        assert_eq!(f[2]["params"], "dead");
     }
 
     #[test]

--- a/crates/xng-mode-vdl2/src/atn_cpdlc.rs
+++ b/crates/xng-mode-vdl2/src/atn_cpdlc.rs
@@ -574,6 +574,36 @@ fn read_lat_or_lon(p: &mut Per, max_milli: i64, max_whole: i64) -> Option<String
     })
 }
 
+/// CM ground-generated messages: identify the dialogue type (logon
+/// response, update, contact request, abort, forward).
+pub fn parse_cm_ground(bytes: &[u8]) -> Option<Value> {
+    let mut store = Vec::new();
+    let mut p = Per::new(bytes, &mut store);
+    // CMGroundMessage CHOICE (extensible, 6 root): ext bit + 3 bits.
+    if p.bit()? != 0 {
+        return None;
+    }
+    let kind = match p.uint(3)? {
+        0 => "logon-response",
+        1 => "update",
+        2 => "contact-request",
+        3 => "forward-request",
+        4 => "abort",
+        5 => "forward-response",
+        _ => return None,
+    };
+    let mut out = json!({ "application": "CM", "pdu": kind });
+    if matches!(kind, "logon-response" | "update") {
+        // Two OPTIONAL application lists; report presence only (the
+        // per-entry TSAP addresses are variable-size — staged).
+        let air = p.bit()? == 1;
+        let ground = p.bit()? == 1;
+        out["air_apps_present"] = json!(air);
+        out["ground_apps_present"] = json!(ground);
+    }
+    Some(out)
+}
+
 /// CM (context management) logon request — the dialogue that precedes
 /// CPDLC; identifies the flight.
 pub fn parse_cm_logon(bytes: &[u8]) -> Option<Value> {
@@ -600,6 +630,25 @@ pub fn parse_cm_logon(bytes: &[u8]) -> Option<Value> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn cm_ground_logon_response() {
+        // CMGroundMessage CHOICE: ext=0, index=0 (logon-response),
+        // both OPTIONAL application lists absent.
+        let v = parse_cm_ground(&[0b0_000_0_0_00]).unwrap();
+        assert_eq!(v["application"], "CM");
+        assert_eq!(v["pdu"], "logon-response");
+        assert_eq!(v["air_apps_present"], false);
+        assert_eq!(v["ground_apps_present"], false);
+    }
+
+    #[test]
+    fn cm_ground_contact_request() {
+        // ext=0, index=2 (contact-request): no presence bits read.
+        let v = parse_cm_ground(&[0b0_010_0000]).unwrap();
+        assert_eq!(v["pdu"], "contact-request");
+        assert!(v.get("air_apps_present").is_none());
+    }
 
     /// Bit-builder for synthetic UPER vectors.
     struct Bits(Vec<u8>);

--- a/src/commands/scan.rs
+++ b/src/commands/scan.rs
@@ -381,6 +381,8 @@ pub(crate) fn scan_group(
             asf2_quic_trust: crate::outputs::asf2_quic::TrustMode::SystemRoots,
             metrics: None,
             sbs: None,
+            beast: None,
+            nmea_tcp: None,
         },
     };
     let decoders = runtime::build_decoders(rate, center, &cfg)?;

--- a/src/commands/survey.rs
+++ b/src/commands/survey.rs
@@ -422,6 +422,8 @@ fn dwell(
             asf2_quic_trust: crate::outputs::asf2_quic::TrustMode::SystemRoots,
             metrics: None,
             sbs: None,
+            beast: None,
+            nmea_tcp: None,
         },
     };
     let decoders = runtime::build_decoders(rate, center, &cfg)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -106,6 +106,17 @@ struct OutputOpts {
     /// Mode S/ADS-B messages only)
     #[arg(long)]
     sbs: Option<String>,
+    /// Serve Beast binary frames (Mode S) over TCP, dump1090-style
+    /// (e.g. 0.0.0.0:30005)
+    #[arg(long)]
+    beast: Option<String>,
+    /// Serve raw NMEA AIVDM over TCP (e.g. 0.0.0.0:10110)
+    #[arg(long)]
+    nmea_tcp: Option<String>,
+    /// JSON file mapping hex VDL2 ground-station addresses to names
+    /// (shown in console output)
+    #[arg(long)]
+    gs_file: Option<PathBuf>,
 }
 
 impl OutputOpts {
@@ -129,6 +140,9 @@ impl OutputOpts {
             );
             udp.push(AIRFRAMES_ACARS_UDP.to_owned());
         }
+        if let Some(p) = &self.gs_file {
+            outputs::console::load_gs_names(p)?;
+        }
         let ident = self.station_id.clone().unwrap_or_else(|| "XNG-DEV".to_owned());
         Ok((
             runtime::OutputConfig {
@@ -140,6 +154,8 @@ impl OutputOpts {
                 asf2_quic_trust: quic_trust,
                 metrics: self.metrics.clone(),
                 sbs: self.sbs.clone(),
+                beast: self.beast.clone(),
+                nmea_tcp: self.nmea_tcp.clone(),
             },
             ident,
         ))
@@ -586,6 +602,8 @@ fn main() -> anyhow::Result<()> {
                         asf2_quic_trust: outputs::asf2_quic::TrustMode::SystemRoots,
                         metrics: None,
                         sbs: None,
+                        beast: None,
+                        nmea_tcp: None,
                     },
                 },
             )

--- a/src/outputs/beast.rs
+++ b/src/outputs/beast.rs
@@ -35,7 +35,7 @@ pub fn format_beast(msg: &Message) -> Option<Vec<u8>> {
     let mut out = Vec::with_capacity(2 + 7 + 1 + raw.len() * 2);
     out.push(0x1a);
     out.push(kind);
-    let mut push_esc = |b: u8, out: &mut Vec<u8>| {
+    let push_esc = |b: u8, out: &mut Vec<u8>| {
         out.push(b);
         if b == 0x1a {
             out.push(0x1a);

--- a/src/outputs/console.rs
+++ b/src/outputs/console.rs
@@ -44,6 +44,23 @@ fn app_summary(app: &serde_json::Value) -> Option<String> {
     }
 }
 
+/// Optional ground-station name table (hex AVLC address → name),
+/// loaded once from --gs-file.
+static GS_NAMES: std::sync::OnceLock<std::collections::HashMap<String, String>> =
+    std::sync::OnceLock::new();
+
+/// Load a JSON object file mapping hex addresses to names.
+pub fn load_gs_names(path: &std::path::Path) -> anyhow::Result<()> {
+    let map: std::collections::HashMap<String, String> =
+        serde_json::from_str(&std::fs::read_to_string(path)?)?;
+    let _ = GS_NAMES.set(map);
+    Ok(())
+}
+
+fn gs_name(addr: &str) -> Option<&'static str> {
+    GS_NAMES.get()?.get(addr).map(String::as_str)
+}
+
 pub fn format_message(msg: &Message, fmt: ConsoleFormat) -> String {
     match fmt {
         ConsoleFormat::Json => serde_json::to_string(msg).unwrap_or_else(|e| format!("<serialize error: {e}>")),
@@ -177,8 +194,16 @@ pub fn format_message(msg: &Message, fmt: ConsoleFormat) -> String {
                             .unwrap_or("?")
                             .to_owned()
                     };
-                    let mut s =
-                        format!("VDL2 {} {}→{}", kind.to_uppercase(), addr("src"), addr("dst"));
+                    let deco = |a: String| match gs_name(&a) {
+                        Some(n) => format!("{a}[{n}]"),
+                        None => a,
+                    };
+                    let mut s = format!(
+                        "VDL2 {} {}→{}",
+                        kind.to_uppercase(),
+                        deco(addr("src")),
+                        deco(addr("dst"))
+                    );
                     if let Some(nr) = details.pointer("/control/nr").and_then(|v| v.as_u64()) {
                         s.push_str(&format!(" nr={nr}"));
                     }

--- a/src/outputs/mod.rs
+++ b/src/outputs/mod.rs
@@ -9,4 +9,5 @@ pub mod asf2_quic;
 pub mod console;
 pub mod jsonl;
 pub mod metrics;
+pub mod nmea_tcp;
 pub mod sbs;

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -36,6 +36,10 @@ pub struct OutputConfig {
     pub metrics: Option<String>,
     /// SBS-1 (BaseStation, dump1090 port-30003 style) TCP server address.
     pub sbs: Option<String>,
+    /// Beast binary TCP server address (Mode S, dump1090 port-30005 style).
+    pub beast: Option<String>,
+    /// NMEA (AIVDM) TCP server address.
+    pub nmea_tcp: Option<String>,
 }
 
 pub struct SessionConfig {
@@ -361,6 +365,14 @@ pub fn run_session(mut source: Box<dyn IqSource>, cfg: SessionConfig) -> anyhow:
         if let Some(addr) = cfg.outputs.sbs.clone() {
             let rx = bus.subscribe();
             output_tasks.push(tokio::spawn(crate::outputs::sbs::run(rx, addr)));
+        }
+        if let Some(addr) = cfg.outputs.beast.clone() {
+            let rx = bus.subscribe();
+            output_tasks.push(tokio::spawn(crate::outputs::beast::run(rx, addr)));
+        }
+        if let Some(addr) = cfg.outputs.nmea_tcp.clone() {
+            let rx = bus.subscribe();
+            output_tasks.push(tokio::spawn(crate::outputs::nmea_tcp::run(rx, addr)));
         }
         if let Some(url) = cfg.outputs.asf2_grpc.clone() {
             let rx = bus.subscribe();


### PR DESCRIPTION
## What

Task: round out the VDL2 ATN decode tail and repair output wiring.

### VDL2 decode additions
- **ES-IS (ISO 9542)**: ESH/ISH/RD PDU type, holding time, NSAP address lists (hex)
- **IDRP (ISO 10747)**: BISPDU length, type (OPEN/UPDATE/ERROR/KEEPALIVE/CEASE), sequence
- **X.25 facilities**: class-coded TLV parse on call packets; codes reported numerically (naming deferred until the ITU table is verified)
- **CM ground messages**: CHOICE identification (logon-response, update, contact-request, forward-request, abort, forward-response) with application-list presence flags, per the vendored atn-cm.asn
- **--gs-file**: optional JSON `{"hexaddr": "name"}` table; VDL2 console lines show `addr[name]`

### Output wiring repair
`beast.rs` (PR #68) and `nmea_tcp.rs` (PR #70) merged as modules but their wiring was lost before commit — no CLI flag, no `OutputConfig` field, no runtime spawn. This PR registers `nmea_tcp` in `outputs/mod.rs` and plumbs both: `--beast` and `--nmea-tcp` flags → `OutputConfig` → TCP server spawns.

## Testing
- 6 new unit tests (ES-IS ISH, IDRP keepalive, facility class lengths, CM ground logon-response/contact-request)
- Full workspace: 246 passed, 0 failed
- `xng listen --help` verified to surface `--beast`, `--nmea-tcp`, `--gs-file`

🤖 Generated with [Claude Code](https://claude.com/claude-code)