### PR TITLE
Outputs: MQTT publishing + ACARS label filtering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,6 +436,16 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -716,6 +726,17 @@ name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin",
+]
 
 [[package]]
 name = "fnv"
@@ -1446,6 +1467,12 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
@@ -1778,7 +1805,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash 2.1.2",
- "rustls",
+ "rustls 0.23.40",
  "socket2 0.6.4",
  "thiserror 2.0.18",
  "tokio",
@@ -1799,7 +1826,7 @@ dependencies = [
  "rand 0.9.4",
  "ring",
  "rustc-hash 2.1.2",
- "rustls",
+ "rustls 0.23.40",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "slab",
@@ -2059,6 +2086,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "rumqttc"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1568e15fab2d546f940ed3a21f48bbbd1c494c90c99c4481339364a497f94a9"
+dependencies = [
+ "bytes",
+ "flume",
+ "futures-util",
+ "log",
+ "rustls-native-certs 0.7.3",
+ "rustls-pemfile",
+ "rustls-webpki 0.102.8",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-rustls",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2108,6 +2153,20 @@ dependencies = [
 
 [[package]]
 name = "rustls"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls"
 version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
@@ -2115,9 +2174,22 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.103.13",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
+dependencies = [
+ "openssl-probe 0.1.6",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 2.11.1",
 ]
 
 [[package]]
@@ -2126,10 +2198,10 @@ version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
- "openssl-probe",
+ "openssl-probe 0.2.1",
  "rustls-pki-types",
  "schannel",
- "security-framework",
+ "security-framework 3.7.0",
 ]
 
 [[package]]
@@ -2157,16 +2229,16 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
 dependencies = [
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "jni",
  "log",
  "once_cell",
- "rustls",
- "rustls-native-certs",
+ "rustls 0.23.40",
+ "rustls-native-certs 0.8.4",
  "rustls-platform-verifier-android",
- "rustls-webpki",
- "security-framework",
+ "rustls-webpki 0.103.13",
+ "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
  "windows-sys 0.61.2",
@@ -2177,6 +2249,17 @@ name = "rustls-platform-verifier-android"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
 
 [[package]]
 name = "rustls-webpki"
@@ -2227,12 +2310,25 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.13.0",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags 2.13.0",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -2418,6 +2514,15 @@ checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
 ]
 
 [[package]]
@@ -2679,6 +2784,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
+dependencies = [
+ "rustls 0.22.4",
+ "rustls-pki-types",
+ "tokio",
 ]
 
 [[package]]
@@ -3541,8 +3657,9 @@ dependencies = [
  "quinn",
  "ratatui",
  "rcgen",
+ "rumqttc",
  "rustfft",
- "rustls",
+ "rustls 0.23.40",
  "rustls-pemfile",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ authors = ["Kevin Elliott", "xng contributors"]
 
 [workspace.dependencies]
 anyhow = "1"
+rumqttc = "0.24"
 chrono = { version = "0.4", features = ["serde"] }
 crc = "3"
 crossbeam-channel = "0.8"
@@ -71,6 +72,7 @@ airspyhf = ["xng-sdr/airspyhf"]
 
 [dependencies]
 anyhow.workspace = true
+rumqttc.workspace = true
 chrono.workspace = true
 clap = { version = "4", features = ["derive"] }
 num-complex.workspace = true

--- a/README.md
+++ b/README.md
@@ -263,9 +263,18 @@ Every mode and every command shares the same output options:
 --metrics 0.0.0.0:9090                         # Prometheus (frames, CRC, levels)
 --sbs 0.0.0.0:30003                            # SBS/BaseStation TCP (Mode S)
 --beast 0.0.0.0:30005                          # Beast binary TCP (Mode S)
+--nmea-tcp 0.0.0.0:10110                       # NMEA AIVDM TCP (AIS)
+--mqtt mqtt://user:pass@broker:1883            # MQTT (JSON to <prefix>/<mode>)
+--mqtt-topic xng                               # MQTT topic prefix
 --asf2-grpc http://ingest:6001                 # asf-2.0 over gRPC
 --asf2-quic ingest:6011                        # asf-2.0 over QUIC (TLS verified)
 ```
+
+ACARS traffic can be filtered by label before it reaches any output:
+`--filter-labels H1,Q0` passes only those labels; `--exclude-labels SQ`
+drops the listed ones. Non-ACARS messages always pass. VDL2 console
+lines can name ground stations via `--gs-file stations.json` (a JSON
+object mapping hex AVLC addresses to names).
 
 **asf-2.0** ([docs/ASF2.md](docs/ASF2.md)) is xng's multiplexed feeding
 protocol: one protobuf schema carrying every channel/SDR/mode over a

--- a/src/commands/scan.rs
+++ b/src/commands/scan.rs
@@ -372,6 +372,7 @@ pub(crate) fn scan_group(
         station_ident: "XNG-SCAN".into(),
         sdr: None,
         receiver_pos: None,
+        label_filter: Default::default(),
         outputs: runtime::OutputConfig {
             console: crate::outputs::console::ConsoleFormat::Pretty,
             jsonl: None,
@@ -383,6 +384,8 @@ pub(crate) fn scan_group(
             sbs: None,
             beast: None,
             nmea_tcp: None,
+            mqtt: None,
+            mqtt_topic: "xng".into(),
         },
     };
     let decoders = runtime::build_decoders(rate, center, &cfg)?;
@@ -411,6 +414,7 @@ pub(crate) fn scan_group(
         stop,
         Some((live.clone(), center, rate)),
         None,
+        Default::default(),
     )?;
     let _ = stop_thread.join();
 

--- a/src/commands/survey.rs
+++ b/src/commands/survey.rs
@@ -413,6 +413,7 @@ fn dwell(
         station_ident: "XNG-SURVEY".into(),
         sdr: None,
         receiver_pos: None,
+        label_filter: Default::default(),
         outputs: runtime::OutputConfig {
             console: ConsoleFormat::Pretty,
             jsonl: None,
@@ -424,6 +425,8 @@ fn dwell(
             sbs: None,
             beast: None,
             nmea_tcp: None,
+            mqtt: None,
+            mqtt_topic: "xng".into(),
         },
     };
     let decoders = runtime::build_decoders(rate, center, &cfg)?;
@@ -449,6 +452,7 @@ fn dwell(
         stop,
         Some((live.clone(), center, rate)),
         None,
+        Default::default(),
     )?;
     let _ = stop_thread.join();
     let levels = live.stats.lock().unwrap().clone();

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,6 +53,13 @@ struct TuneOpts {
     /// ADS-B surface-position decoding
     #[arg(long)]
     receiver_pos: Option<String>,
+    /// Only pass ACARS messages with these labels (comma separated,
+    /// e.g. H1,Q0). Non-ACARS messages always pass.
+    #[arg(long, value_delimiter = ',')]
+    filter_labels: Vec<String>,
+    /// Drop ACARS messages with these labels (comma separated)
+    #[arg(long, value_delimiter = ',')]
+    exclude_labels: Vec<String>,
 }
 
 fn parse_receiver_pos(s: &Option<String>) -> anyhow::Result<Option<(f64, f64)>> {
@@ -117,6 +124,13 @@ struct OutputOpts {
     /// (shown in console output)
     #[arg(long)]
     gs_file: Option<PathBuf>,
+    /// Publish messages as JSON to an MQTT broker
+    /// (mqtt://[user:pass@]host[:port])
+    #[arg(long)]
+    mqtt: Option<String>,
+    /// MQTT topic prefix; messages publish to <prefix>/<mode>
+    #[arg(long, default_value = "xng")]
+    mqtt_topic: String,
 }
 
 impl OutputOpts {
@@ -156,6 +170,8 @@ impl OutputOpts {
                 sbs: self.sbs.clone(),
                 beast: self.beast.clone(),
                 nmea_tcp: self.nmea_tcp.clone(),
+                mqtt: self.mqtt.clone(),
+                mqtt_topic: self.mqtt_topic.clone(),
             },
             ident,
         ))
@@ -504,6 +520,10 @@ fn main() -> anyhow::Result<()> {
                     }),
                     outputs,
                     receiver_pos: parse_receiver_pos(&tune.receiver_pos)?,
+                    label_filter: runtime::LabelFilter {
+                        include: tune.filter_labels.clone(),
+                        exclude: tune.exclude_labels.clone(),
+                    },
                 },
             )
         }
@@ -593,6 +613,10 @@ fn main() -> anyhow::Result<()> {
                     station_ident: "XNG-TUI".into(),
                     sdr: None,
                     receiver_pos: parse_receiver_pos(&tune.receiver_pos)?,
+                    label_filter: runtime::LabelFilter {
+                        include: tune.filter_labels.clone(),
+                        exclude: tune.exclude_labels.clone(),
+                    },
                     outputs: runtime::OutputConfig {
                         console: ConsoleFormat::Pretty,
                         jsonl: None,
@@ -604,6 +628,8 @@ fn main() -> anyhow::Result<()> {
                         sbs: None,
                         beast: None,
                         nmea_tcp: None,
+                        mqtt: None,
+                        mqtt_topic: "xng".into(),
                     },
                 },
             )
@@ -702,6 +728,10 @@ fn listen(sdr: &str, gain: Option<f64>, tune: &TuneOpts, output: &OutputOpts) ->
             }),
             outputs,
             receiver_pos: parse_receiver_pos(&tune.receiver_pos)?,
+                    label_filter: runtime::LabelFilter {
+                        include: tune.filter_labels.clone(),
+                        exclude: tune.exclude_labels.clone(),
+                    },
         },
     )
 }

--- a/src/outputs/mod.rs
+++ b/src/outputs/mod.rs
@@ -9,5 +9,6 @@ pub mod asf2_quic;
 pub mod console;
 pub mod jsonl;
 pub mod metrics;
+pub mod mqtt;
 pub mod nmea_tcp;
 pub mod sbs;

--- a/src/outputs/mqtt.rs
+++ b/src/outputs/mqtt.rs
@@ -1,0 +1,90 @@
+//! MQTT output: publish each normalized message as JSON to
+//! `<prefix>/<mode>` (e.g. `xng/vdl2`). URL form:
+//! `mqtt://[user:pass@]host[:port]` (default port 1883).
+
+use rumqttc::{AsyncClient, MqttOptions, QoS};
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::broadcast;
+use xng_types::Message;
+
+/// Parse `mqtt://[user:pass@]host[:port]` into options.
+fn parse_url(url: &str, client_id: &str) -> anyhow::Result<MqttOptions> {
+    let rest = url
+        .strip_prefix("mqtt://")
+        .ok_or_else(|| anyhow::anyhow!("--mqtt URL must start with mqtt://"))?;
+    let (auth, hostport) = match rest.rsplit_once('@') {
+        Some((a, h)) => (Some(a), h),
+        None => (None, rest),
+    };
+    let (host, port) = match hostport.rsplit_once(':') {
+        Some((h, p)) => (h, p.parse::<u16>()?),
+        None => (hostport, 1883),
+    };
+    let mut opts = MqttOptions::new(client_id, host, port);
+    opts.set_keep_alive(Duration::from_secs(30));
+    if let Some(auth) = auth {
+        let (user, pass) = auth
+            .split_once(':')
+            .ok_or_else(|| anyhow::anyhow!("--mqtt credentials must be user:pass"))?;
+        opts.set_credentials(user, pass);
+    }
+    Ok(opts)
+}
+
+/// Consume the bus until it closes, publishing each message.
+pub async fn run(
+    mut rx: broadcast::Receiver<Arc<Message>>,
+    url: String,
+    topic_prefix: String,
+    station: String,
+) -> anyhow::Result<()> {
+    let opts = parse_url(&url, &format!("xng-{station}"))?;
+    let (client, mut eventloop) = AsyncClient::new(opts, 64);
+    // The event loop must be polled for the client to make progress;
+    // connection errors are retried with a small backoff.
+    tokio::spawn(async move {
+        loop {
+            if let Err(e) = eventloop.poll().await {
+                tracing::warn!("mqtt: {e}; reconnecting");
+                tokio::time::sleep(Duration::from_secs(5)).await;
+            }
+        }
+    });
+    loop {
+        match rx.recv().await {
+            Ok(msg) => {
+                let topic = format!("{topic_prefix}/{}", msg.mode.as_str());
+                let payload = serde_json::to_vec(&*msg)?;
+                if let Err(e) = client.publish(topic, QoS::AtMostOnce, false, payload).await {
+                    tracing::warn!("mqtt publish: {e}");
+                }
+            }
+            Err(broadcast::error::RecvError::Lagged(n)) => {
+                tracing::warn!("mqtt output lagged, dropped {n} messages");
+            }
+            Err(broadcast::error::RecvError::Closed) => break,
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn url_forms() {
+        let o = parse_url("mqtt://broker.local", "id").unwrap();
+        assert_eq!(o.broker_address(), ("broker.local".to_string(), 1883));
+        let o = parse_url("mqtt://broker.local:8883", "id").unwrap();
+        assert_eq!(o.broker_address(), ("broker.local".to_string(), 8883));
+        let o = parse_url("mqtt://u:p@broker.local:1884", "id").unwrap();
+        assert_eq!(o.broker_address(), ("broker.local".to_string(), 1884));
+        assert_eq!(
+            o.credentials(),
+            Some(("u".to_string(), "p".to_string()))
+        );
+        assert!(parse_url("tcp://x", "id").is_err());
+    }
+}

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -40,6 +40,10 @@ pub struct OutputConfig {
     pub beast: Option<String>,
     /// NMEA (AIVDM) TCP server address.
     pub nmea_tcp: Option<String>,
+    /// MQTT broker URL (mqtt://[user:pass@]host[:port]).
+    pub mqtt: Option<String>,
+    /// MQTT topic prefix (messages publish to `<prefix>/<mode>`).
+    pub mqtt_topic: String,
 }
 
 pub struct SessionConfig {
@@ -51,6 +55,31 @@ pub struct SessionConfig {
     pub outputs: OutputConfig,
     /// Receiver location (lat, lon) — enables ADS-B surface decode.
     pub receiver_pos: Option<(f64, f64)>,
+    /// ACARS label filter applied before messages reach the bus.
+    pub label_filter: LabelFilter,
+}
+
+/// Keep/drop filter on the ACARS label. Non-ACARS messages always
+/// pass. An empty filter passes everything.
+#[derive(Clone, Default)]
+pub struct LabelFilter {
+    /// When non-empty, only these labels pass.
+    pub include: Vec<String>,
+    /// Labels dropped even if included.
+    pub exclude: Vec<String>,
+}
+
+impl LabelFilter {
+    pub fn allows(&self, msg: &Message) -> bool {
+        let label = match &msg.body {
+            xng_types::MessageBody::Acars(a) => &a.label,
+            _ => return true,
+        };
+        if !self.include.is_empty() && !self.include.iter().any(|l| l == label) {
+            return false;
+        }
+        !self.exclude.iter().any(|l| l == label)
+    }
 }
 
 const READ_CHUNK: usize = 65_536;
@@ -374,6 +403,17 @@ pub fn run_session(mut source: Box<dyn IqSource>, cfg: SessionConfig) -> anyhow:
             let rx = bus.subscribe();
             output_tasks.push(tokio::spawn(crate::outputs::nmea_tcp::run(rx, addr)));
         }
+        if let Some(url) = cfg.outputs.mqtt.clone() {
+            let rx = bus.subscribe();
+            let topic = cfg.outputs.mqtt_topic.clone();
+            let station = cfg.station_ident.clone();
+            output_tasks.push(tokio::spawn(async move {
+                if let Err(e) = crate::outputs::mqtt::run(rx, url, topic, station).await {
+                    tracing::error!("mqtt output: {e}");
+                }
+                Ok(())
+            }));
+        }
         if let Some(url) = cfg.outputs.asf2_grpc.clone() {
             let rx = bus.subscribe();
             let (id, ident) = (station.id.to_string(), station.ident.clone());
@@ -423,6 +463,7 @@ pub fn run_session(mut source: Box<dyn IqSource>, cfg: SessionConfig) -> anyhow:
                         stop,
                         Some((live, capture_center, sample_rate)),
                         Some(&mut reasm),
+                        cfg.label_filter,
                     )
                 }
             }
@@ -457,6 +498,7 @@ pub(crate) fn decode_loop(
     stop: Arc<AtomicBool>,
     live: Option<(Arc<LiveState>, u64, f64)>,
     mut reasm: Option<&mut (xng_acars::reasm::Reassembler, xng_acars::miam::FileReassembler)>,
+    label_filter: LabelFilter,
 ) -> anyhow::Result<Vec<(u64, u64, u64)>> {
     use std::sync::atomic::Ordering as AtomOrd;
     let mut spectrum_fft: Option<std::sync::Arc<dyn rustfft::Fft<f32>>> = None;
@@ -538,6 +580,9 @@ pub(crate) fn decode_loop(
                 }
                 if let Some((r, files)) = reasm.as_deref_mut() {
                     apply_reassembly(&mut msg, r, files);
+                }
+                if !label_filter.allows(&msg) {
+                    continue;
                 }
                 bus.publish(msg);
             }
@@ -661,4 +706,48 @@ pub(crate) fn build_decoders(
         decoders.push((freq, dec));
     }
     Ok(decoders)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn acars_msg(label: &str) -> Message {
+        Message {
+            mode: Mode::AcarsPoa,
+            timestamp: chrono::Utc::now(),
+            frequency_hz: 131_550_000,
+            signal: Default::default(),
+            decode: Default::default(),
+            body: xng_types::MessageBody::Acars(xng_types::AcarsCore {
+                label: label.into(),
+                ..Default::default()
+            }),
+            raw: None,
+            source: Provenance {
+                station: StationIdentity::new("XX-TEST"),
+                app: AppInfo::xng(),
+                sdr: None,
+                channel: None,
+            },
+        }
+    }
+
+    #[test]
+    fn label_filter_include_exclude() {
+        let empty = LabelFilter::default();
+        assert!(empty.allows(&acars_msg("H1")));
+
+        let only_h1 = LabelFilter { include: vec!["H1".into()], exclude: vec![] };
+        assert!(only_h1.allows(&acars_msg("H1")));
+        assert!(!only_h1.allows(&acars_msg("Q0")));
+
+        let no_q0 = LabelFilter { include: vec![], exclude: vec!["Q0".into()] };
+        assert!(no_q0.allows(&acars_msg("H1")));
+        assert!(!no_q0.allows(&acars_msg("Q0")));
+
+        // exclude wins over include
+        let both = LabelFilter { include: vec!["Q0".into()], exclude: vec!["Q0".into()] };
+        assert!(!both.allows(&acars_msg("Q0")));
+    }
 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -48,6 +48,7 @@ pub fn run(mut source: Box<dyn IqSource>, cfg: SessionConfig) -> anyhow::Result<
         let stop = stop.clone();
         let live = live.clone();
         let sdr = cfg.sdr.clone();
+        let label_filter = cfg.label_filter.clone();
         move || {
             let mut reasm = (
                 xng_acars::reasm::Reassembler::new(300.0),
@@ -62,6 +63,7 @@ pub fn run(mut source: Box<dyn IqSource>, cfg: SessionConfig) -> anyhow::Result<
                 stop,
                 Some((live, capture_center, sample_rate)),
                 Some(&mut reasm),
+                label_filter,
             )
         }
     });


### PR DESCRIPTION
## What

The last two output-side gaps vs acarsdec/dumpvdl2/dumphfdl:

- **`--mqtt mqtt://[user:pass@]host[:port]`** — publish every normalized message as JSON to `<prefix>/<mode>` (e.g. `xng/vdl2`), prefix set by `--mqtt-topic` (default `xng`). rumqttc client with credential support and auto-reconnect (5 s backoff).
- **`--filter-labels H1,Q0` / `--exclude-labels SQ`** — ACARS label filtering applied at the bus publish point, so every output (console, JSONL, UDP, asf-2.0, MQTT, …) sees the same filtered stream. Non-ACARS messages always pass; exclude wins over include.

Also documents `--nmea-tcp`, `--gs-file`, and the new flags in the README outputs section.

## Testing
- `url_forms`: MQTT URL parsing (defaults, port, credentials, bad scheme)
- `label_filter_include_exclude`: include/exclude/precedence semantics
- Full workspace green; flags verified on `xng listen --help`

🤖 Generated with [Claude Code](https://claude.com/claude-code)