### PR TITLE
VDL2: channel-selectivity receive filter + pulse-shaped loopback (+2.5–3 dB)

### DIFF
--- a/crates/xng-mode-vdl2/examples/sensitivity.rs
+++ b/crates/xng-mode-vdl2/examples/sensitivity.rs
@@ -1,0 +1,58 @@
+//! Sensitivity A/B: shaped burst at swept noise, decode rate with and
+//! without the channel-selectivity lowpass. Long trailing noise lets
+//! phantom header locks fail and rewind, as in a live stream.
+use num_complex::Complex;
+use xng_mode_vdl2::avlc::{self, encode_address, AddressType};
+use xng_mode_vdl2::modulate::burst_iq_shaped;
+use xng_mode_vdl2::{demod::Vdl2Demod, interleave};
+
+fn main() {
+    let mut f = Vec::new();
+    f.extend(encode_address(AddressType::GroundIcao, 0x10A234, false, false));
+    f.extend(encode_address(AddressType::Aircraft, 0x800F5C, true, true));
+    f.push(0x01);
+    let frames = vec![f];
+    let truth = avlc::build(&frames);
+    let rate = 50_000.0;
+    let burst = burst_iq_shaped(&frames, rate, 0.0, 0.5);
+    let sig_pow: f32 =
+        burst.iter().map(|c| c.norm_sqr()).sum::<f32>() / burst.len() as f32;
+    let rs = interleave::vdl2_rs();
+    let taps = xng_dsp::fir::lowpass_taps(10_500.0 / rate, 101);
+
+    println!("amp    snr_dB   plain  filt   (of 40 trials)");
+    for amp in [0.02f32, 0.05, 0.08, 0.11, 0.14, 0.17, 0.20, 0.25] {
+        let noise_pow = 2.0 * amp * amp / 3.0;
+        let snr = 10.0 * (sig_pow / noise_pow).log10();
+        let mut ok = [0u32; 2];
+        for trial in 0..40u64 {
+            let mut iq = vec![Complex::new(0.0f32, 0.0); 2000];
+            iq.extend(burst.iter().copied());
+            iq.extend(vec![Complex::new(0.0f32, 0.0); 30_000]);
+            let mut seed = 0x9e37_79b9_7f4a_7c15u64.wrapping_mul(trial + 1) | 1;
+            let mut noise = move || {
+                seed ^= seed << 13;
+                seed ^= seed >> 7;
+                seed ^= seed << 17;
+                (seed as f32 / u64::MAX as f32) * 2.0 - 1.0
+            };
+            for s in &mut iq {
+                *s += Complex::new(noise() * amp, noise() * amp);
+            }
+            let mut filt = Vec::new();
+            let mut fir = xng_dsp::fir::Fir::new(taps.clone());
+            fir.process(&iq, &mut filt);
+            for (i, sig) in [&iq, &filt].into_iter().enumerate() {
+                let mut demod = Vdl2Demod::new(rate);
+                let good = demod
+                    .process(sig, &rs)
+                    .iter()
+                    .any(|b| b.bits == truth);
+                if good {
+                    ok[i] += 1;
+                }
+            }
+        }
+        println!("{amp:<6} {snr:>5.1}    {:>3}    {:>3}", ok[0], ok[1]);
+    }
+}

--- a/crates/xng-mode-vdl2/src/lib.rs
+++ b/crates/xng-mode-vdl2/src/lib.rs
@@ -42,6 +42,13 @@ pub struct Vdl2Frame {
 
 pub struct Vdl2ChannelDecoder {
     ddc: Option<Ddc>,
+    /// Channel-selectivity lowpass for the no-DDC path. The RC(α=0.6)
+    /// TX pulse occupies ±(1+α)·Rs/2 = ±8.4 kHz; a flat lowpass there
+    /// keeps the signal spectrum (and its Nyquist zero-ISI property)
+    /// untouched while removing all out-of-band noise. When a DDC runs
+    /// its decimation filter already provides this.
+    selectivity: Option<xng_dsp::fir::Fir>,
+    select_buf: Vec<Complex<f32>>,
     demod: demod::Vdl2Demod,
     rs: ReedSolomon,
     channel_buf: Vec<Complex<f32>>,
@@ -66,8 +73,19 @@ impl Vdl2ChannelDecoder {
         } else {
             Some(Ddc::new(input_rate, channel_rate, freq_offset_hz, CHANNEL_PASSBAND_HZ)?)
         };
+        let selectivity = if ddc.is_none() {
+            // -6 dB point at the symbol rate so the filter is flat
+            // through the RC band edge (8.4 kHz) and the windowed-sinc
+            // transition lives entirely in the noise-only region.
+            let taps = xng_dsp::fir::lowpass_taps(demod::SYMBOL_RATE / channel_rate, 101);
+            Some(xng_dsp::fir::Fir::new(taps))
+        } else {
+            None
+        };
         Ok(Self {
             ddc,
+            selectivity,
+            select_buf: Vec::new(),
             demod: demod::Vdl2Demod::new(channel_rate),
             rs: interleave::vdl2_rs(),
             channel_buf: Vec::new(),
@@ -86,7 +104,14 @@ impl Vdl2ChannelDecoder {
                 ddc.process(input, &mut self.channel_buf);
                 &self.channel_buf
             }
-            None => input,
+            None => match &mut self.selectivity {
+                Some(fir) => {
+                    self.select_buf.clear();
+                    fir.process(input, &mut self.select_buf);
+                    &self.select_buf
+                }
+                None => input,
+            },
         };
         let mut out = Vec::new();
         for burst in self.demod.process(channel, &self.rs) {

--- a/crates/xng-mode-vdl2/src/modulate.rs
+++ b/crates/xng-mode-vdl2/src/modulate.rs
@@ -25,6 +25,82 @@ pub fn burst_iq(
     burst_iq_with(frames, &rs, sample_rate, freq_offset_hz, amplitude)
 }
 
+/// Like `burst_iq`, but with the Annex 10 pulse shaping: each D8PSK
+/// symbol point is carried on a full raised-cosine pulse (α = 0.6),
+/// i.e. linear modulation s(t) = Σ e^{jφ_k}·h(t−kT). RC is a Nyquist
+/// pulse, so symbol-center samples are ISI-free — but inter-symbol
+/// samples follow the real off-air trajectory, unlike the rectangular
+/// test modulator. Use this for any receive-filter experiment.
+pub fn burst_iq_shaped(
+    frames: &[Vec<u8>],
+    sample_rate: f64,
+    freq_offset_hz: f64,
+    amplitude: f32,
+) -> Vec<Complex<f32>> {
+    let rs = interleave::vdl2_rs();
+    let phases = burst_phases(frames, &rs);
+    let sps = sample_rate / SYMBOL_RATE;
+    const ALPHA: f64 = 0.6;
+    const SPAN: f64 = 6.0; // pulse support in symbols, each side
+
+    // Raised-cosine pulse h(t/T): 1 at 0, zeros at nonzero integers.
+    let rc = |t: f64| -> f64 {
+        let denom = 1.0 - (2.0 * ALPHA * t) * (2.0 * ALPHA * t);
+        let sinc = if t.abs() < 1e-12 { 1.0 } else { (PI * t).sin() / (PI * t) };
+        if denom.abs() < 1e-9 {
+            // t = ±T/(2α): limit α/2·sinc(1/(2α))·π/... use l'Hôpital form
+            ALPHA / 2.0 * (PI / (2.0 * ALPHA)).sin()
+        } else {
+            sinc * (PI * ALPHA * t).cos() / denom
+        }
+    };
+
+    let nsamples = ((phases.len() as f64 + 2.0 * SPAN) * sps).ceil() as usize;
+    (0..nsamples)
+        .map(|n| {
+            let t_sym = n as f64 / sps - SPAN; // time in symbols
+            let lo = ((t_sym - SPAN).ceil().max(0.0)) as usize;
+            let hi = ((t_sym + SPAN).floor()).min(phases.len() as f64 - 1.0) as usize;
+            let mut acc = Complex::new(0.0f64, 0.0);
+            for (k, &phk) in phases.iter().enumerate().take(hi + 1).skip(lo) {
+                let w = rc(t_sym - k as f64);
+                acc += Complex::new(phk.cos(), phk.sin()) * w;
+            }
+            let rot = TAU * freq_offset_hz * n as f64 / sample_rate;
+            let r = Complex::new(rot.cos(), rot.sin());
+            let v = acc * r;
+            Complex::new(v.re as f32, v.im as f32) * amplitude
+        })
+        .collect()
+}
+
+/// Cumulative D8PSK phase per symbol (ramp-up + UW + scrambled data).
+fn burst_phases(frames: &[Vec<u8>], rs: &ReedSolomon) -> Vec<f64> {
+    let avlc_bits = crate::avlc::build(frames);
+    let tl = avlc_bits.len() as u32;
+    let tx = interleave::interleave(&avlc_bits, rs);
+
+    let mut bits: Vec<u8> = header::encode(tl).to_vec();
+    bits.extend(tx);
+    Scrambler::new().apply(&mut bits);
+    while bits.len() % 3 != 0 {
+        bits.push(0);
+    }
+    let mut deltas: Vec<u8> = vec![0; 5];
+    deltas.extend(UW_DELTAS);
+    for t in bits.chunks_exact(3) {
+        let idx = (t[0] | (t[1] << 1) | (t[2] << 2)) as usize;
+        deltas.push(GRAY_FWD[idx]);
+    }
+    let mut phases = Vec::with_capacity(deltas.len());
+    let mut ph = 0.0f64;
+    for &d in &deltas {
+        ph += d as f64 * PI / 4.0;
+        phases.push(ph);
+    }
+    phases
+}
+
 pub fn burst_iq_with(
     frames: &[Vec<u8>],
     rs: &ReedSolomon,

--- a/crates/xng-mode-vdl2/tests/end_to_end.rs
+++ b/crates/xng-mode-vdl2/tests/end_to_end.rs
@@ -50,7 +50,10 @@ fn decodes_burst_at_channel_rate() {
     let iq_burst = burst_iq(&[aoa_frame(), rr_frame()], 50_000.0, 0.0, 0.5);
     let mut iq = vec![Complex::new(0.0, 0.0); 800];
     iq.extend(iq_burst);
-    iq.extend(vec![Complex::new(0.0, 0.0); 800]);
+    // Generous trailing noise: a phantom UW lock in the lead-in whose
+    // garbage header passes the thin 25-bit FEC needs enough stream to
+    // starve, fail RS, and rewind — live SDR streams never end.
+    iq.extend(vec![Complex::new(0.0, 0.0); 30_000]);
     let mut noise = Noise(0xabcd_ef01_2345_6789);
     for s in &mut iq {
         *s += Complex::new(noise.next() * 0.01, noise.next() * 0.01);
@@ -103,4 +106,31 @@ fn decodes_from_wideband_capture_with_cfo() {
     let acars = frames[0].acars.as_ref().unwrap();
     assert!(acars.crc_ok);
     assert_eq!(acars.core.text.len(), 79);
+}
+
+/// The pulse-shaped (RC α=0.6) modulator is the realistic loopback: RC
+/// is Nyquist, so the existing symbol-center demod must decode it
+/// cleanly at both channel rates and survive moderate noise.
+#[test]
+fn decodes_pulse_shaped_burst() {
+    use xng_mode_vdl2::modulate::burst_iq_shaped;
+    for rate in [50_000.0, 100_000.0] {
+        let iq_burst = burst_iq_shaped(&[aoa_frame(), rr_frame()], rate, 0.0, 0.5);
+        let pad = (rate / 50.0) as usize;
+        let mut iq = vec![Complex::new(0.0, 0.0); pad];
+        iq.extend(iq_burst);
+        iq.extend(vec![Complex::new(0.0, 0.0); 30_000]);
+        let mut noise = Noise(0x1357_9bdf_2468_ace0);
+        for s in &mut iq {
+            *s += Complex::new(noise.next() * 0.02, noise.next() * 0.02);
+        }
+
+        let mut dec = Vdl2ChannelDecoder::new(rate, 0.0).unwrap();
+        let mut frames = Vec::new();
+        for chunk in iq.chunks(4096) {
+            frames.extend(dec.process(chunk));
+        }
+        assert_eq!(frames.len(), 2, "rate {rate}");
+        assert!(frames[0].acars.is_some(), "rate {rate}: AOA frame decodes");
+    }
 }

--- a/docs/notes/VDL2-DEMOD-V2.md
+++ b/docs/notes/VDL2-DEMOD-V2.md
@@ -286,3 +286,55 @@ mid-size bursts, and the next credible lever is a properly-derived
 receive filter (matched to the actual RC pulse, ISI-compensated or
 zero-forcing at symbol instants) — a half-day design task with the
 harness and funnel already in place.
+
+## Round 4 (2026-06): the receive filter, done properly
+
+Protocol followed as planned: pulse-shaped test modulator first, then a
+derived filter, bit-level ground truth, off-air last.
+
+1. **Pulse-shaped modulator** (`burst_iq_shaped`): linear D8PSK with the
+   Annex 10 full raised-cosine pulse (α=0.6, ±6T support). RC is
+   Nyquist, so the existing symbol-center demod decodes it unchanged —
+   loopback now covers the realistic waveform at both channel rates.
+
+2. **The derived filter is not a matched filter.** For an RC-shaped TX
+   pulse the zero-ISI receive filter family is F(ω) with H·F Nyquist;
+   the noise-optimal member that adds no ISI is **flat across the
+   signal band, zero outside**: a plain lowpass covering ±8.4 kHz.
+   Critically its -6 dB point must sit *beyond* the RC band edge
+   (we use Rs = 10.5 kHz, 101 taps) — an early experiment with the
+   cutoff at 8.5 kHz ate the outer RC rolloff, broke the Nyquist
+   property, and failed loopback exactly as theory predicts.
+
+3. **Where it goes**: the DDC's decimation filter already provides
+   channel selectivity (8.5 kHz passband), but the no-DDC path
+   (input rate == channel rate, zero offset — all fixture and off-air
+   harness runs) had NO filtering at all: the demod saw the full
+   input Nyquist band of noise. The selectivity FIR now fills that
+   path only.
+
+4. **Measured sensitivity** (shaped burst, 40 trials/point, 50 kS/s):
+   ~2.5-3 dB. At 13.5 dB SNR: 32/40 plain vs 40/40 filtered; at
+   11.4 dB: 12 vs 34; at 9.7 dB: 1 vs 19. Matches the expected
+   noise-bandwidth reduction (25 kHz → ~10.5 kHz equivalent).
+   `examples/sensitivity.rs` reproduces the table.
+
+5. **Off-air: 19 frames before, 19 after** (funnel slightly cleaner:
+   rs_fail 17→16, hdr_fail 204→199). The sigidwiki capture is
+   24-30 dB SNR — out-of-band noise was never its binding constraint.
+   **The receive-filter hypothesis for the 19→41 gap is falsified.**
+   The remaining gap stays where round 3 left it: in-band raw
+   symbol-decision quality on mid-size bursts (good residuals, wrong
+   bits), where the falsified-equalizer list already covers the cheap
+   in-band levers.
+
+6. **Harness hazard found**: a phantom UW lock in lead-in noise whose
+   garbage header passes the thin 25-bit FEC starves collection when
+   the test stream simply ends (no hdr_fail, no rs_fail, zero output —
+   a silent swallow). Live streams always provide the trailing samples
+   that let it fail RS and rewind. Loopback tests now pad 30k trailing
+   samples; remember this when a synthetic test inexplicably returns
+   zero bursts.
+
+HFDL's no-DDC path has the same missing-selectivity structure and its
+own falsified-sensitivity backlog — worth the same experiment there.


### PR DESCRIPTION
## What

Task: the VDL2 receive filter, done properly (round 4 of the demod campaign, per the protocol in docs/notes/VDL2-DEMOD-V2.md).

- **Pulse-shaped test modulator** (`burst_iq_shaped`): linear D8PSK on the Annex 10 full raised-cosine pulse (α=0.6). Loopback now covers the realistic waveform at both channel rates — the rectangular modulator's blindness was the documented matched-filter trap.
- **Derived receive filter**: for an RC TX pulse the noise-optimal zero-ISI receive filter is *flat across the signal band, zero outside* — a lowpass with its −6 dB point beyond the RC band edge (Rs = 10.5 kHz, 101 taps). It fills the **no-DDC path**, which previously fed the demod the full input Nyquist band of noise (the DDC path always had selectivity from its decimation filter).
- **Measured**: +2.5–3 dB sensitivity on shaped bursts (40 trials/point; at 11.4 dB SNR: 34/40 filtered vs 12/40 plain). `examples/sensitivity.rs` reproduces the table.
- **Off-air regression**: 19 frames before and after on the sigidwiki capture — no regression, and the receive-filter hypothesis for the 19→41 oracle gap is **falsified** (capture is 24–30 dB SNR; out-of-band noise was never its constraint). Notes updated.
- **Harness hazard documented**: phantom UW locks whose garbage headers pass the thin 25-bit FEC silently swallow test bursts when the synthetic stream ends; loopback tests now pad 30k trailing samples so they starve and rewind as in a live stream.

## Testing
- New `decodes_pulse_shaped_burst` loopback at 50k and 100k
- Full workspace: 254 passed, 0 failed
- Off-air harness: 19/19 frames (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)