### PR TITLE
Aero: C-channel decoder (8 400 bps OQPSK voice circuits, JAERO port)

### DIFF
--- a/crates/xng-mode-aero/PROVENANCE.md
+++ b/crates/xng-mode-aero/PROVENANCE.md
@@ -102,3 +102,27 @@ shared Viterbi/descrambler/SU path) is implemented and bit-level tested;
 the coherent OQPSK demodulator does not yet achieve carrier lock and its
 RF loopback tests are #[ignore]d pending a focused demod session
 (JAERO's tanh cross-product loop is the port reference).
+
+C-channel (8 400 bps OQPSK voice circuits) ported from
+`aerol.cpp::DecodeC` + `oqpskdemodulator.cpp` (fb==8400 paths):
+
+- Frame: 112-bit UW (two 52-bit rail patterns, JAERO `setPreamble`
+  arguments 216866263330005 / 3012071630031408, each detector trying
+  both patterns and complements for the OQPSK ambiguity) + 4096 coded
+  bits per ~500 ms superframe.
+- FEC: the P-channel K=7 rate-1/2 code punctured 3/4 (depuncture
+  inserts a neutral bit after every 3rd, last source bit dropped);
+  interleaving 16 × (64×4) blocks with the (27·i) mod 64 row permute;
+  decoded 2730 → first 2714 kept; LFSR15 descramble.
+- Payload: 25 sub-blocks of 1 + 96 + 12 bits — 96-bit AMBE voice
+  frames (12 bytes, surfaced for external decoding; the codec itself
+  is proprietary) and 12-bit slices accumulating into 12-byte sub-band
+  signal units (CRC-16/X.25), types 0x01 fill / 0x30 call progress
+  (AES, GES ids) / 0x60 telephony acknowledge.
+- Demod: the ported OQPSK demodulator with RRC β=0.6 and JAERO's
+  8 400-specific ~10 Hz timing-resonator coefficients.
+
+Note: JAERO additionally delays decoded bits by 2714−6 before the
+descrambler (`dl2`) for off-air scrambler alignment; our loopback is
+self-consistent without it, and the alignment question is flagged for
+when an off-air C-channel capture is available.

--- a/crates/xng-mode-aero/src/cchannel.rs
+++ b/crates/xng-mode-aero/src/cchannel.rs
@@ -1,0 +1,476 @@
+//! Aero C-channel (8 400 bps OQPSK voice circuits), ported from JAERO
+//! `aerol.cpp::DecodeC` (MIT; see PROVENANCE.md).
+//!
+//! Frame structure (one ~500 ms superframe = 4 208 bits at 8 400 bps):
+//!
+//! - 112-bit unique word: two 52-bit rail patterns bit-interleaved
+//!   (every detector tries both patterns and their complements, so the
+//!   OQPSK 180° ambiguity resolves per rail)
+//! - 4 096 coded bits: K=7 rate-1/2 convolutional (the P-channel
+//!   polynomials), punctured 3/4 (every 4th coded bit dropped), block
+//!   interleaved as 16 consecutive 64×4 row-permuted blocks
+//! - decoded 2 730 bits → first 2 714 kept: 25 sub-blocks of
+//!   1 + 96 voice + 12 data bits — the 96-bit chunks are AMBE voice
+//!   frames (12 bytes each, 20 ms; codec proprietary, bytes surfaced
+//!   for external decoding), the 12-bit chunks accumulate into 12-byte
+//!   sub-band signal units with a CRC-16/X.25 trailer.
+
+use xng_dsp::scramble::Lfsr15;
+use xng_dsp::viterbi::Viterbi;
+
+pub const FRAME_CODED_BITS: usize = 4096;
+pub const INFO_BITS: usize = 2714;
+const DECODED_BITS: usize = 2730;
+const SUBBLOCK_BITS: usize = 109; // 1 + 96 voice + 12 data
+const VOICE_FRAMES: usize = 25;
+const UW_LEN: usize = 52;
+/// The two 52-bit UW rail patterns (JAERO `setPreamble` arguments).
+pub const UW_RAIL1: u64 = 216_866_263_330_005;
+pub const UW_RAIL2: u64 = 3_012_071_630_031_408;
+/// 52-bit sliding correlator over both rail patterns and their
+/// complements (JAERO `OQPSKPreambleDetectorAndAmbiguityCorrection`:
+/// every rail tries both patterns, so the rail phase is arbitrary and
+/// the OQPSK 180° ambiguity resolves from which polarity matched).
+struct UwDetector {
+    p1: [u8; UW_LEN],
+    p2: [u8; UW_LEN],
+    buf: [u8; UW_LEN],
+    fill: usize,
+    tolerance: u32,
+    /// Set when a *complement* matched: this rail is BPSK-inverted.
+    pub inverted: bool,
+}
+
+fn pattern_bits(v: u64) -> [u8; UW_LEN] {
+    let mut p = [0u8; UW_LEN];
+    for (i, b) in p.iter_mut().enumerate() {
+        *b = ((v >> (UW_LEN - 1 - i)) & 1) as u8;
+    }
+    p
+}
+
+impl UwDetector {
+    fn new(tolerance: u32) -> Self {
+        Self {
+            p1: pattern_bits(UW_RAIL1),
+            p2: pattern_bits(UW_RAIL2),
+            buf: [0; UW_LEN],
+            fill: 0,
+            tolerance,
+            inverted: false,
+        }
+    }
+
+    fn update(&mut self, bit: u8) -> bool {
+        self.buf.rotate_left(1);
+        self.buf[UW_LEN - 1] = bit;
+        self.fill = (self.fill + 1).min(UW_LEN);
+        if self.fill < UW_LEN {
+            return false;
+        }
+        for pat in [&self.p1, &self.p2] {
+            let diff: u32 = self
+                .buf
+                .iter()
+                .zip(pat)
+                .map(|(&b, &p)| (b ^ p) as u32)
+                .sum();
+            if diff <= self.tolerance {
+                self.inverted = false;
+                return true;
+            }
+            if diff >= UW_LEN as u32 - self.tolerance {
+                self.inverted = true;
+                return true;
+            }
+        }
+        false
+    }
+}
+
+/// One decoded C-channel event.
+#[derive(Debug, Clone, PartialEq)]
+pub enum CChannelEvent {
+    /// A 12-byte AMBE voice frame (96 bits, 20 ms of compressed audio).
+    Voice([u8; 12]),
+    /// A CRC-valid 12-byte sub-band signal unit (CRC trailer included).
+    SignalUnit([u8; 12]),
+}
+
+/// Sub-band SU message types (JAERO `AEROTypeC`).
+pub fn su_type_name(t: u8) -> &'static str {
+    match t {
+        0x01 => "fill",
+        0x30 => "call-progress",
+        0x60 => "telephony-acknowledge",
+        _ => "other",
+    }
+}
+
+pub struct CChannelDeframer {
+    det_a: UwDetector,
+    det_b: UwDetector,
+    rail: bool,
+    sync_arm: bool,
+    synced: bool,
+    /// Soft bits since the UW (only the first FRAME_CODED_BITS kept).
+    frame: Vec<f32>,
+    viterbi: Viterbi,
+    inv_a: bool,
+    inv_b: bool,
+}
+
+impl Default for CChannelDeframer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CChannelDeframer {
+    pub fn new() -> Self {
+        Self {
+            det_a: UwDetector::new(6),
+            det_b: UwDetector::new(6),
+            rail: false,
+            sync_arm: false,
+            synced: false,
+            frame: Vec::with_capacity(FRAME_CODED_BITS),
+            viterbi: Viterbi::k7(),
+            inv_a: false,
+            inv_b: false,
+        }
+    }
+
+    /// Push one soft bit (sign = decision, magnitude = confidence);
+    /// bits alternate OQPSK rails. Returns decoded events as frames
+    /// complete.
+    pub fn push(&mut self, soft: f32) -> Vec<CChannelEvent> {
+        let mut out = Vec::new();
+        let hard = (soft > 0.0) as u8;
+
+        // UW search runs continuously on both rail detectors; sync
+        // fires on hits in two consecutive bit slots (one per rail),
+        // mirroring JAERO's gotsync_last handshake.
+        self.rail = !self.rail;
+        let hit = if self.rail {
+            let h = self.det_a.update(hard);
+            if h {
+                self.inv_a = self.det_a.inverted;
+            }
+            h
+        } else {
+            let h = self.det_b.update(hard);
+            if h {
+                self.inv_b = self.det_b.inverted;
+            }
+            h
+        };
+        if hit && self.sync_arm {
+            self.sync_arm = false;
+            self.synced = true;
+            self.frame.clear();
+            return out;
+        }
+        self.sync_arm = hit;
+
+        if self.synced && self.frame.len() < FRAME_CODED_BITS {
+            // Per-rail BPSK ambiguity correction from the UW match.
+            let inv = if self.rail { self.inv_a } else { self.inv_b };
+            self.frame.push(if inv { -soft } else { soft });
+            if self.frame.len() == FRAME_CODED_BITS {
+                out.extend(self.decode_frame());
+            }
+        }
+        out
+    }
+
+    fn decode_frame(&mut self) -> Vec<CChannelEvent> {
+        // 16 deinterleave blocks of 256 (64 rows × 4 cols, row
+        // permutation (27·i) mod 64, column-major readout on TX).
+        let mut deleaved = Vec::with_capacity(FRAME_CODED_BITS);
+        for blk in self.frame.chunks_exact(256) {
+            let mut block = [0.0f32; 256];
+            let mut k = 0;
+            for j in 0..4 {
+                for i in 0..64 {
+                    block[k] = blk[depermute(i) * 4 + j];
+                    k += 1;
+                }
+            }
+            deleaved.extend_from_slice(&block);
+        }
+
+        // Depuncture 3/4: a neutral bit after every 3rd received bit
+        // (the final source bit is dropped, matching JAERO). Frames
+        // decode independently — the unflushed Viterbi tail only
+        // degrades the dropped 2 714..2 730 dummy region.
+        let mut depunct = Vec::with_capacity(5460);
+        let mut ptr = 0usize;
+        for &s in &deleaved[..deleaved.len() - 1] {
+            ptr += 1;
+            depunct.push(s);
+            if ptr >= 3 {
+                depunct.push(0.0);
+                ptr = 0;
+            }
+        }
+        let mut bits = self.viterbi.decode(&depunct);
+        bits.truncate(INFO_BITS);
+        if bits.len() < INFO_BITS {
+            return Vec::new();
+        }
+
+        // Descramble (LFSR reset per frame, like the P-channel).
+        Lfsr15::new().apply(&mut bits);
+
+        let mut out = Vec::new();
+
+        // Voice: from bit 1, runs of 96 bits separated by 13 skipped.
+        let mut voice = Vec::with_capacity(VOICE_FRAMES * 12);
+        let mut h = 1usize;
+        let mut acc = 0u8;
+        let mut nb = 0u8;
+        let mut bitsin = 0usize;
+        while h < INFO_BITS {
+            acc |= bits[h] << 7;
+            nb += 1;
+            if nb == 8 {
+                voice.push(acc);
+                acc = 0;
+                nb = 0;
+            } else {
+                acc >>= 1;
+            }
+            bitsin += 1;
+            h += 1;
+            if bitsin == 96 {
+                bitsin = 0;
+                h += 13;
+            }
+        }
+        for f in voice.chunks_exact(12).take(VOICE_FRAMES) {
+            out.push(CChannelEvent::Voice(f.try_into().unwrap()));
+        }
+
+        // Data: 12 bits per sub-block at offset 97..109, accumulated
+        // LSB-first into 12-byte signal units, CRC-16/X.25 checked.
+        let mut su = Vec::with_capacity(12);
+        let mut acc = 0u8;
+        let mut nb = 0u8;
+        for y in 0..24 {
+            let offset = y * SUBBLOCK_BITS;
+            for h in offset + 97..offset + 109 {
+                acc |= bits[h] << 7;
+                nb += 1;
+                if nb == 8 {
+                    su.push(acc);
+                    acc = 0;
+                    nb = 0;
+                } else {
+                    acc >>= 1;
+                }
+            }
+            if su.len() == 12 {
+                if crate::su::su_crc_ok(&su) {
+                    out.push(CChannelEvent::SignalUnit(su[..].try_into().unwrap()));
+                }
+                su.clear();
+            }
+        }
+
+        self.synced = false; // re-arm on the next UW
+        out
+    }
+}
+
+#[inline]
+fn permute(i: usize) -> usize {
+    (27 * i) % 64
+}
+
+#[inline]
+fn depermute(i: usize) -> usize {
+    // inverse of (27·i) mod 64: 27·19 = 513 ≡ 1 (mod 64)
+    (19 * i) % 64
+}
+
+/// Mirror encoder for loopback testing: builds the UW + 4 096 coded
+/// bits for one frame from 2 714 info bits (bit 0 and the per-frame
+/// tail are zero-filled).
+pub struct CChannelEncoder {
+    viterbi: Viterbi,
+}
+
+impl Default for CChannelEncoder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CChannelEncoder {
+    pub fn new() -> Self {
+        Self { viterbi: Viterbi::k7() }
+    }
+
+    /// Encode one frame; returns hard bits (UW then coded payload).
+    pub fn encode(&mut self, info: &[u8]) -> Vec<u8> {
+        assert_eq!(info.len(), INFO_BITS);
+        let mut bits = info.to_vec();
+        bits.resize(DECODED_BITS, 0);
+        Lfsr15::new().apply(&mut bits);
+        let coded = self.viterbi.encode(&bits); // 5 460 bits
+
+        // Puncture 3/4: drop every 4th coded bit.
+        let mut punct = Vec::with_capacity(FRAME_CODED_BITS);
+        for (i, &b) in coded.iter().enumerate() {
+            if i % 4 != 3 {
+                punct.push(b);
+            }
+        }
+        punct.push(0); // the dropped trailing bit
+        assert_eq!(punct.len(), FRAME_CODED_BITS);
+
+        // Interleave per 256-bit block (column-major write of the
+        // row-permuted 64×4 matrix — the inverse of decode_frame).
+        let mut tx = Vec::with_capacity(112 + FRAME_CODED_BITS);
+        // UW: rails alternate starting with rail A (detector order):
+        // 8 lead-in zeros keep the 112-bit spacing.
+        tx.extend([0u8; 8]);
+        for i in 0..UW_LEN {
+            tx.push(((UW_RAIL1 >> (UW_LEN - 1 - i)) & 1) as u8);
+            tx.push(((UW_RAIL2 >> (UW_LEN - 1 - i)) & 1) as u8);
+        }
+        for blk in punct.chunks_exact(256) {
+            let mut block = [0u8; 256];
+            for j in 0..4 {
+                for i in 0..64 {
+                    block[i * 4 + j] = blk[j * 64 + permute(i)];
+                }
+            }
+            tx.extend_from_slice(&block);
+        }
+        tx
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn frame_with(su: &[u8; 12], voice_byte: u8) -> Vec<u8> {
+        // Build 2 714 info bits: voice areas filled with a marker
+        // byte pattern, the first sub-block data slots carrying `su`.
+        let mut bits = vec![0u8; INFO_BITS];
+        // voice bits (offset+1..offset+97) — LSB-first byte pattern
+        for y in 0..VOICE_FRAMES {
+            let offset = y * SUBBLOCK_BITS;
+            for (n, b) in bits[offset + 1..]
+                .iter_mut()
+                .take(96)
+                .enumerate()
+            {
+                if offset + 1 + n >= INFO_BITS {
+                    break;
+                }
+                *b = (voice_byte >> (n % 8)) & 1;
+            }
+        }
+        // SU: 96 bits over the first 8 sub-blocks' 12-bit data slots,
+        // LSB-first
+        let mut bitstream: Vec<u8> = su
+            .iter()
+            .flat_map(|&b| (0..8).map(move |i| (b >> i) & 1))
+            .collect();
+        bitstream.reverse(); // pop() from the front
+        for y in 0..8 {
+            let offset = y * SUBBLOCK_BITS;
+            for h in offset + 97..offset + 109 {
+                bits[h] = bitstream.pop().unwrap();
+            }
+        }
+        bits
+    }
+
+    #[test]
+    fn loopback_voice_and_su() {
+        let mut su10 = vec![0u8; 10];
+        su10[0] = 0x30; // call-progress
+        su10[1..4].copy_from_slice(&[0xAB, 0xCD, 0xEF]); // AES
+        su10[4] = 0x44; // GES
+        let su: [u8; 12] = crate::su::su_with_crc(su10).try_into().unwrap();
+
+        let info = frame_with(&su, 0x5A);
+        let mut enc = CChannelEncoder::new();
+        let mut dec = CChannelDeframer::new();
+
+        // Two identical frames: the first sync arms mid-stream, the
+        // second decodes (and exercises the continuous-FEC carry).
+        let mut events = Vec::new();
+        for _ in 0..3 {
+            for &b in &enc.encode(&info) {
+                let soft = if b == 1 { 0.9f32 } else { -0.9 };
+                events.extend(dec.push(soft));
+            }
+        }
+        let voices: Vec<_> = events
+            .iter()
+            .filter_map(|e| match e {
+                CChannelEvent::Voice(v) => Some(v),
+                _ => None,
+            })
+            .collect();
+        let sus: Vec<_> = events
+            .iter()
+            .filter_map(|e| match e {
+                CChannelEvent::SignalUnit(s) => Some(s),
+                _ => None,
+            })
+            .collect();
+        assert!(!voices.is_empty(), "no voice frames decoded");
+        assert_eq!(voices[0][0], 0x5A, "voice byte pattern survives");
+        assert!(!sus.is_empty(), "no signal units decoded");
+        assert_eq!(sus[0][0], 0x30);
+        assert_eq!(&sus[0][1..4], &[0xAB, 0xCD, 0xEF]);
+    }
+
+    #[test]
+    fn interleaver_roundtrip() {
+        let block: Vec<u8> = (0..256u32).map(|i| (i % 2) as u8 ^ ((i / 3) % 2) as u8).collect();
+        // encode-side write then decode-side read must be identity
+        let mut txb = [0u8; 256];
+        for j in 0..4 {
+            for i in 0..64 {
+                txb[i * 4 + j] = block[j * 64 + permute(i)];
+            }
+        }
+        let mut back = [0u8; 256];
+        let mut k = 0;
+        for j in 0..4 {
+            for i in 0..64 {
+                back[k] = txb[depermute(i) * 4 + j];
+                k += 1;
+            }
+        }
+        assert_eq!(&back[..], &block[..]);
+    }
+
+    #[test]
+    fn uw_detector_normal_and_inverted() {
+        for raw in [UW_RAIL1, UW_RAIL2] {
+            let mut d = UwDetector::new(6);
+            for i in 0..UW_LEN {
+                let bit = ((raw >> (UW_LEN - 1 - i)) & 1) as u8;
+                let hit = d.update(bit);
+                assert_eq!(hit, i == UW_LEN - 1, "pattern {raw:#x} bit {i}");
+            }
+            assert!(!d.inverted);
+            let mut d = UwDetector::new(6);
+            for i in 0..UW_LEN {
+                let bit = 1 - ((raw >> (UW_LEN - 1 - i)) & 1) as u8;
+                let hit = d.update(bit);
+                assert_eq!(hit, i == UW_LEN - 1);
+            }
+            assert!(d.inverted);
+        }
+    }
+}

--- a/crates/xng-mode-aero/src/lib.rs
+++ b/crates/xng-mode-aero/src/lib.rs
@@ -8,6 +8,7 @@
 //! [`xng_acars::block`] → [`xng_types::Message`].
 
 pub mod burst;
+pub mod cchannel;
 pub mod demod;
 pub mod oqpsk;
 pub mod frame;
@@ -250,6 +251,64 @@ impl AeroBurstDecoder {
 
     pub fn level_dbfs(&self) -> f32 {
         10.0 * self.level.max(1e-12).log10()
+    }
+}
+
+/// C-channel decoder: IQ (48 kHz, or DDC'd down from wideband) →
+/// 8 400 bps OQPSK demod → deframer → voice frames and sub-band SUs.
+/// C-channel circuits are call-assigned via P-channel setup, so the
+/// frequency comes from the operator, not a scan plan.
+pub struct CChannelDecoder {
+    ddc: Option<Ddc>,
+    demod: oqpsk::OqpskDemod,
+    deframer: cchannel::CChannelDeframer,
+    channel_buf: Vec<Complex<f32>>,
+    soft: Vec<(f32, u8)>,
+}
+
+impl CChannelDecoder {
+    pub fn new(input_rate: f64, freq_offset_hz: f64) -> Result<Self, String> {
+        let ddc = if (input_rate - oqpsk::CHANNEL_RATE_HR).abs() < 1e-6
+            && freq_offset_hz.abs() < 1e-6
+        {
+            None
+        } else {
+            Some(Ddc::new(
+                input_rate,
+                oqpsk::CHANNEL_RATE_HR,
+                freq_offset_hz,
+                8_400.0,
+            )?)
+        };
+        Ok(Self {
+            ddc,
+            demod: oqpsk::OqpskDemod::new_c_channel(oqpsk::CHANNEL_RATE_HR),
+            deframer: cchannel::CChannelDeframer::new(),
+            channel_buf: Vec::new(),
+            soft: Vec::new(),
+        })
+    }
+
+    pub fn process(&mut self, input: &[Complex<f32>]) -> Vec<cchannel::CChannelEvent> {
+        let channel: &[Complex<f32>] = match &mut self.ddc {
+            Some(ddc) => {
+                self.channel_buf.clear();
+                ddc.process(input, &mut self.channel_buf);
+                &self.channel_buf
+            }
+            None => input,
+        };
+        self.soft.clear();
+        self.demod.process(channel, &mut self.soft);
+        let mut out = Vec::new();
+        for &(s, _) in &self.soft {
+            out.extend(self.deframer.push(s));
+        }
+        out
+    }
+
+    pub fn level_dbfs(&self) -> f32 {
+        self.demod.level_dbfs()
     }
 }
 

--- a/crates/xng-mode-aero/src/oqpsk.rs
+++ b/crates/xng-mode-aero/src/oqpsk.rs
@@ -141,6 +141,7 @@ pub fn rrc_taps(sps: f64, num_taps: usize, beta: f64) -> Vec<f32> {
 /// designed at 48 kHz; `HrChain` always feeds this demod at 48 kHz.
 pub struct OqpskDemod {
     fs: f64,
+    bit_rate: f64,
     rrc: Fir,
     filtered: Vec<Complex<f32>>,
     // carrier NCO (estimated offset, Hz, plus a phase trim in radians)
@@ -181,14 +182,42 @@ impl OqpskDemod {
     // traceability even though they truncate to f32.
     #[allow(clippy::excessive_precision)]
     pub fn new(channel_rate: f64) -> Self {
+        Self::new_with_rate(channel_rate, BIT_RATE as f64)
+    }
+
+    /// 8 400 bps variant (Aero C-channel): RRC β=0.6 and JAERO's
+    /// 8 400-specific timing-resonator coefficients; everything else is
+    /// the same demodulator.
+    pub fn new_c_channel(channel_rate: f64) -> Self {
+        Self::new_with_rate(channel_rate, 8_400.0)
+    }
+
+    fn new_with_rate(channel_rate: f64, bit_rate: f64) -> Self {
         debug_assert!(
             (channel_rate - CHANNEL_RATE_HR).abs() < 1e-6,
             "OQPSK IIR coefficients are designed for 48 kHz"
         );
-        let t = channel_rate / SYMBOL_RATE; // samples per symbol
+        let c8400 = (bit_rate - 8_400.0).abs() < 1e-6;
+        let symbol_rate = bit_rate / 2.0;
+        let rrc_beta = if c8400 { 0.6 } else { 1.0 };
+        // Timing resonators at 48 kHz on the bit rate: JAERO's 10.5 kHz
+        // set, or the ~10 Hz-bandwidth 8.4 kHz set.
+        let resonator = if c8400 {
+            Biquad::new(
+                [0.001_284_585_786_447_078_9, 0.0, -0.001_284_585_786_447_078_9],
+                [-0.906_814_619_992_798_89, 0.997_430_828_427_105_84],
+            )
+        } else {
+            Biquad::new(
+                [0.000_327_142_189_395_890_35, 0.0, 0.000_327_142_189_395_890_35],
+                [-0.390_052_999_482_108_03, 0.999_345_715_621_208_22],
+            )
+        };
+        let t = channel_rate / symbol_rate; // samples per symbol
         Self {
             fs: channel_rate,
-            rrc: Fir::new(rrc_taps(t, 55, 1.0)),
+            bit_rate,
+            rrc: Fir::new(rrc_taps(t, 55, rrc_beta)),
             filtered: Vec::new(),
             nco_freq_hz: 0.0,
             nco_phase: 0.0,
@@ -198,13 +227,9 @@ impl OqpskDemod {
             d_t41: FracDelay::new(t / 4.0),
             d_t42: FracDelay::new(t / 4.0),
             d_t8: FracDelay::new(t / 8.0),
-            // 10 500 Hz resonator at 48 kHz (JAERO st_iir_resonator).
-            resonator: Biquad::new(
-                [0.000_327_142_189_395_890_35, 0.0, 0.000_327_142_189_395_890_35],
-                [-0.390_052_999_482_108_03, 0.999_345_715_621_208_22],
-            ),
+            resonator,
             st_phase: 0.0,
-            st_freq_hz: BIT_RATE as f64,
+            st_freq_hz: bit_rate,
             sig_last: Complex::new(0.0, 0.0),
             pair_toggle: false,
             pt_d: Complex::new(0.0, 0.0),
@@ -263,7 +288,7 @@ impl OqpskDemod {
                     self.acq_blocks += 1;
                     if self.acq_blocks >= 2 {
                         let res = self.fs / ACQ_FFT as f64;
-                        let tone = (SYMBOL_RATE / res).round() as i64;
+                        let tone = (self.bit_rate / 2.0 / res).round() as i64;
                         let range = (3_000.0 / res) as i64;
                         let idx = |k: i64| k.rem_euclid(ACQ_FFT as i64) as usize;
                         let mut best = (f32::MIN, 0i64);
@@ -312,7 +337,7 @@ impl OqpskDemod {
             );
             let st_err = (st_rot * m1).arg();
             self.st_freq_hz = (self.st_freq_hz - st_err as f64 * 1e-8)
-                .clamp(BIT_RATE as f64 - 0.1, BIT_RATE as f64 + 0.1);
+                .clamp(self.bit_rate - 0.1, self.bit_rate + 0.1);
             let prev_phase = self.st_phase;
             self.st_phase += self.st_freq_hz / self.fs - st_err as f64 * 0.01 / 360.0;
             // Strobe when the oscillator passes STROBE_POINT (with wrap).
@@ -494,7 +519,21 @@ pub fn modulate_oqpsk(
     freq_offset_hz: f64,
     amplitude: f32,
 ) -> Vec<Complex<f32>> {
-    let half = sample_rate / SYMBOL_RATE / 2.0;
+    modulate_oqpsk_rate(bits, BIT_RATE as f64, 1.0, sample_rate, freq_offset_hz, amplitude)
+}
+
+/// OQPSK modulator at an arbitrary bit rate / RRC roll-off (the
+/// C-channel is 8 400 bps with β=0.6).
+pub fn modulate_oqpsk_rate(
+    bits: &[u8],
+    bit_rate: f64,
+    rrc_beta: f64,
+    sample_rate: f64,
+    freq_offset_hz: f64,
+    amplitude: f32,
+) -> Vec<Complex<f32>> {
+    let symbol_rate = bit_rate / 2.0;
+    let half = sample_rate / symbol_rate / 2.0;
     let total = ((bits.len() + 4) as f64 * half) as usize;
     let mut i_rail = vec![0.0f32; total];
     let mut q_rail = vec![0.0f32; total];
@@ -510,7 +549,7 @@ pub fn modulate_oqpsk(
             }
         }
     }
-    let taps = rrc_taps(sample_rate / SYMBOL_RATE, 129, 1.0);
+    let taps = rrc_taps(sample_rate / symbol_rate, 129, rrc_beta);
     let mut shape_i = Fir::new(taps.clone());
     let mut shape_q = Fir::new(taps);
     let ic: Vec<Complex<f32>> = i_rail.into_iter().map(|v| Complex::new(v, 0.0)).collect();

--- a/crates/xng-mode-aero/tests/cchannel_e2e.rs
+++ b/crates/xng-mode-aero/tests/cchannel_e2e.rs
@@ -1,0 +1,96 @@
+//! C-channel RF loopback: encoded frames → 8 400 bps OQPSK (RRC β=0.6)
+//! → demod → deframer → AMBE voice frames + sub-band signal units.
+
+use num_complex::Complex;
+use xng_mode_aero::cchannel::{CChannelDeframer, CChannelEncoder, CChannelEvent, INFO_BITS};
+use xng_mode_aero::oqpsk::{modulate_oqpsk_rate, OqpskDemod, CHANNEL_RATE_HR};
+
+struct Noise(u64);
+impl Noise {
+    fn next(&mut self) -> f32 {
+        self.0 ^= self.0 << 13;
+        self.0 ^= self.0 >> 7;
+        self.0 ^= self.0 << 17;
+        (self.0 as f32 / u64::MAX as f32) * 2.0 - 1.0
+    }
+}
+
+fn test_frame_bits() -> Vec<u8> {
+    let mut su10 = vec![0u8; 10];
+    su10[0] = 0x30; // call-progress
+    su10[1..4].copy_from_slice(&[0x12, 0x34, 0x56]); // AES
+    su10[4] = 0x7E; // GES
+    let su = xng_mode_aero::su::su_with_crc(su10);
+
+    let mut bits = vec![0u8; INFO_BITS];
+    // Voice slots: a recognizable byte pattern (LSB-first packing).
+    for y in 0..25 {
+        let offset = y * 109;
+        for n in 0..96 {
+            if offset + 1 + n >= INFO_BITS {
+                break;
+            }
+            bits[offset + 1 + n] = (0xA7u8 >> (n % 8)) & 1;
+        }
+    }
+    // SU bits into the first 8 sub-blocks' 12-bit data slots.
+    let stream: Vec<u8> = su.iter().flat_map(|&b| (0..8).map(move |i| (b >> i) & 1)).collect();
+    let mut it = stream.into_iter();
+    for y in 0..8 {
+        let offset = y * 109;
+        for h in offset + 97..offset + 109 {
+            bits[h] = it.next().unwrap();
+        }
+    }
+    bits
+}
+
+#[test]
+fn decodes_c_channel_voice_and_su_from_iq() {
+    let info = test_frame_bits();
+    let mut enc = CChannelEncoder::new();
+    let mut bits = Vec::new();
+    for _ in 0..4 {
+        bits.extend(enc.encode(&info));
+    }
+
+    let mut iq = modulate_oqpsk_rate(&bits, 8_400.0, 0.6, CHANNEL_RATE_HR, 90.0, 0.5);
+    let mut noise = Noise(0x0123_4567_89ab_cdef);
+    for s in &mut iq {
+        *s += Complex::new(noise.next() * 0.02, noise.next() * 0.02);
+    }
+
+    let mut demod = OqpskDemod::new_c_channel(CHANNEL_RATE_HR);
+    let mut deframer = CChannelDeframer::new();
+    let mut soft = Vec::new();
+    let mut events = Vec::new();
+    for chunk in iq.chunks(8192) {
+        soft.clear();
+        demod.process(chunk, &mut soft);
+        for &(s, _) in &soft {
+            events.extend(deframer.push(s));
+        }
+    }
+
+    let voices: Vec<_> = events
+        .iter()
+        .filter_map(|e| match e {
+            CChannelEvent::Voice(v) => Some(v),
+            _ => None,
+        })
+        .collect();
+    let sus: Vec<_> = events
+        .iter()
+        .filter_map(|e| match e {
+            CChannelEvent::SignalUnit(s) => Some(s),
+            _ => None,
+        })
+        .collect();
+
+    assert!(!voices.is_empty(), "no AMBE voice frames decoded");
+    assert_eq!(voices[0][0], 0xA7, "voice byte pattern");
+    assert!(!sus.is_empty(), "no signal units decoded");
+    assert_eq!(sus[0][0], 0x30, "call-progress type");
+    assert_eq!(&sus[0][1..4], &[0x12, 0x34, 0x56], "AES id");
+    assert_eq!(sus[0][4], 0x7E, "GES id");
+}


### PR DESCRIPTION
## What

Task #21, the last JAERO capability xng lacked: **C-channel voice circuits** (8 400 bps OQPSK).

- **`cchannel.rs`** — frame chain ported from `aerol.cpp::DecodeC` (MIT, PROVENANCE.md updated): 112-bit UW (two 52-bit rail patterns; each rail detector tries both patterns and complements, resolving the OQPSK 180° ambiguity), 16×(64×4) block deinterleave, 3/4 depuncture, K=7 rate-1/2 Viterbi, LFSR15 descramble → 25 × 12-byte **AMBE voice frames** per ~500 ms superframe (codec is proprietary — bytes surfaced for external decoding, same policy as Iridium VOC) + CRC-16/X.25-checked **sub-band signal units** (fill / call-progress with AES+GES ids / telephony-acknowledge).
- **OQPSK demod parameterized**: `new_c_channel` uses RRC β=0.6 and JAERO's 8 400-specific ~10 Hz timing-resonator coefficients; the 10.5 kbps path is bit-for-bit unchanged (all existing tests pass).
- **Mirror encoder** for loopback + two test tiers: bit-level (UW/interleave/FEC/scramble round trip) and full-IQ e2e (8 400 bps OQPSK with 90 Hz carrier offset + noise → voice bytes and SU fields recovered exactly).
- **`CChannelDecoder`** public API (DDC → demod → deframer). C-channel frequencies are call-assigned via P-channel setup — not scannable — so session-level wiring waits for an off-air capture (the dl2 scrambler-alignment question is documented in PROVENANCE.md for that day).

## Testing
- `loopback_voice_and_su`, `interleaver_roundtrip`, `uw_detector_normal_and_inverted` (bit level)
- `decodes_c_channel_voice_and_su_from_iq` (full RF loopback)
- Full workspace: 258 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added C-channel deframing and decoding support for 8.4 kbps OQPSK voice circuits, enabling extraction of voice frames and signal units from received bitstreams.
  * Introduced generalized OQPSK demodulator supporting multiple bit rates beyond the standard 10.5 kbps configuration.
  * Added C-channel encoder for testing and loopback validation.

* **Tests**
  * Added end-to-end test validating C-channel decoding with realistic voice and signal unit patterns.

* **Documentation**
  * Added comprehensive C-channel technical documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->