### PR TITLE
HFDL: channel-selectivity filter in the no-DDC path (+4.5–5 dB)

### DIFF
--- a/crates/xng-mode-hfdl/examples/sensitivity.rs
+++ b/crates/xng-mode-hfdl/examples/sensitivity.rs
@@ -1,0 +1,73 @@
+//! Sensitivity A/B: HFDL burst at swept noise, decode rate with and
+//! without the no-DDC channel-selectivity lowpass. The modulator is
+//! rectangular-phase; the LMS equalizer absorbs the filter's static
+//! ISI exactly as it does off-air, so the comparison is fair.
+use num_complex::Complex;
+use xng_mode_hfdl::modulate::{burst_symbols, modulate};
+use xng_mode_hfdl::{fec::SETTINGS, pdu, HfdlChannelDecoder, CHANNEL_RATE};
+
+fn main() {
+    let spdu = pdu::build_spdu(7, 1234, 52);
+    let s = &SETTINGS[2]; // 1200 bps — the workhorse squitter rate
+    let syms = burst_symbols(&spdu, s);
+    let burst = modulate(&syms, CHANNEL_RATE, 1440.0, 0.5);
+    let sig_pow: f32 =
+        burst.iter().map(|c| c.norm_sqr()).sum::<f32>() / burst.len() as f32;
+
+    println!("amp    snr_dB   plain  filt   (of 40 trials)");
+    for amp in [0.3f32, 0.4, 0.5, 0.6, 0.7, 0.85, 1.0, 1.2] {
+        let noise_pow = 2.0 * amp * amp / 3.0;
+        let snr = 10.0 * (sig_pow / noise_pow).log10();
+        let mut ok = [0u32; 2];
+        for trial in 0..40u64 {
+            let mut iq = vec![Complex::new(0.0f32, 0.0); 3000];
+            iq.extend(burst.iter().copied());
+            iq.extend(vec![Complex::new(0.0f32, 0.0); 3000]);
+            let mut seed = 0x517c_c1b7_2722_0a95u64.wrapping_mul(trial + 1) | 1;
+            let mut noise = move || {
+                seed ^= seed << 13;
+                seed ^= seed >> 7;
+                seed ^= seed << 17;
+                (seed as f32 / u64::MAX as f32) * 2.0 - 1.0
+            };
+            for x in &mut iq {
+                *x += Complex::new(noise() * amp, noise() * amp);
+            }
+            // Filtered = the shipped decoder; plain = demod + parser
+            // directly, skipping the selectivity filter.
+            let mut dec = HfdlChannelDecoder::new(CHANNEL_RATE, 0.0).unwrap();
+            let mut got = false;
+            for chunk in iq.chunks(8192) {
+                if dec
+                    .process(chunk)
+                    .iter()
+                    .any(|e| e.kind == "squitter" && e.details["frame_index"] == 1234)
+                {
+                    got = true;
+                }
+            }
+            if got {
+                ok[1] += 1;
+            }
+            // Plain: demod + parser directly, no selectivity filter.
+            let mut demod = xng_mode_hfdl::demod::HfdlDemod::new(CHANNEL_RATE);
+            let mut parser = pdu::PduParser::new();
+            let mut got = false;
+            for chunk in iq.chunks(8192) {
+                for b in demod.process(chunk) {
+                    if parser
+                        .parse(&b.payload, b.bps)
+                        .iter()
+                        .any(|e| e.kind == "squitter" && e.details["frame_index"] == 1234)
+                    {
+                        got = true;
+                    }
+                }
+            }
+            if got {
+                ok[0] += 1;
+            }
+        }
+        println!("{amp:<6} {snr:>5.1}    {:>3}    {:>3}", ok[0], ok[1]);
+    }
+}

--- a/crates/xng-mode-hfdl/src/lib.rs
+++ b/crates/xng-mode-hfdl/src/lib.rs
@@ -21,6 +21,14 @@ pub const SUBCARRIER_OFFSET_HZ: f64 = 1_440.0;
 
 pub struct HfdlChannelDecoder {
     ddc: Option<Ddc>,
+    /// Channel-selectivity lowpass for the no-DDC path: the same
+    /// ±1.5 kHz passband the DDC's decimation filter applies (off-air
+    /// validated through that path). Without it a 12 kS/s direct input
+    /// feeds the demod the full ±6 kHz of noise. The LMS equalizer
+    /// downstream absorbs the filter's static in-band ISI, as it does
+    /// on the DDC path.
+    selectivity: Option<xng_dsp::Fir>,
+    select_buf: Vec<Complex<f32>>,
     demod: demod::HfdlDemod,
     parser: pdu::PduParser,
     channel_buf: Vec<Complex<f32>>,
@@ -37,8 +45,17 @@ impl HfdlChannelDecoder {
         } else {
             Some(Ddc::new(input_rate, CHANNEL_RATE, sub, CHANNEL_PASSBAND_HZ)?)
         };
+        let selectivity = if ddc.is_none() {
+            let taps =
+                xng_dsp::lowpass_taps(CHANNEL_PASSBAND_HZ / CHANNEL_RATE, 101);
+            Some(xng_dsp::Fir::new(taps))
+        } else {
+            None
+        };
         Ok(Self {
             ddc,
+            selectivity,
+            select_buf: Vec::new(),
             demod: demod::HfdlDemod::new(CHANNEL_RATE),
             parser: pdu::PduParser::new(),
             channel_buf: Vec::new(),
@@ -52,7 +69,14 @@ impl HfdlChannelDecoder {
                 ddc.process(input, &mut self.channel_buf);
                 &self.channel_buf
             }
-            None => input,
+            None => match &mut self.selectivity {
+                Some(fir) => {
+                    self.select_buf.clear();
+                    fir.process(input, &mut self.select_buf);
+                    &self.select_buf
+                }
+                None => input,
+            },
         };
         let mut out = Vec::new();
         for burst in self.demod.process(channel) {


### PR DESCRIPTION
## What

The same structural hole VDL2 round 4 found and fixed (PR #74), now in HFDL: a 12 kS/s direct input (`ddc = None`) fed the demod the full ±6 kHz of noise, while wideband inputs always got the DDC's ±1.5 kHz decimation filter. The no-DDC path now applies the identical lowpass design. The LMS equalizer absorbs the filter's static in-band ISI, exactly as it already does on the off-air-validated DDC path.

## Measured

Synthetic 1200 bps squitter, 40 trials/point:

| SNR | plain | filtered |
|---|---|---|
| 3.7 dB | 39/40 | 40/40 |
| 1.8 dB | 9/40 | 40/40 |
| 0.2 dB | 0/40 | 40/40 |
| −1.2 dB | 0/40 | 40/40 |
| −2.8 dB | 0/40 | 8/40 |

≈ **+4.5–5 dB**, consistent with the 6 dB theoretical noise-bandwidth ratio. `examples/sensitivity.rs` reproduces the table.

## Regression
- Off-air sigidwiki capture: 33 events before and after, at both 12 kHz (no-DDC) and 48 kHz (DDC)
- Full workspace green

🤖 Generated with [Claude Code](https://claude.com/claude-code)