### PR TITLE
Aero: C-channel assignment SUs (P-channel call setup)

### DIFF
--- a/crates/xng-mode-aero/src/lib.rs
+++ b/crates/xng-mode-aero/src/lib.rs
@@ -29,6 +29,8 @@ pub struct AeroEvent {
     pub user: su::AeroUserData,
     pub acars: Option<xng_acars::block::AcarsBlock>,
     pub bit_rate: u32,
+    /// Set when this event is a C-channel assignment SU.
+    pub assignment: Option<serde_json::Value>,
 }
 
 /// One demod + framing chain at a fixed bit rate.
@@ -46,6 +48,8 @@ struct Framer {
     /// When collecting: soft bits gathered after the UW (header + coded).
     collecting: Option<Vec<f32>>,
     reasm: su::Reassembler,
+    /// C-channel assignment SUs decoded this push (drained per chunk).
+    assignments: Vec<serde_json::Value>,
 }
 
 impl Framer {
@@ -55,6 +59,7 @@ impl Framer {
             shift: 0,
             collecting: None,
             reasm: su::Reassembler::new(),
+            assignments: Vec::new(),
         }
     }
 
@@ -66,6 +71,9 @@ impl Framer {
                 let bytes = self.decoder.decode(coded);
                 for su_bytes in bytes.chunks_exact(su::SU_LEN) {
                     if su::su_crc_ok(su_bytes) {
+                        if let Some(a) = su::parse_c_assignment(su_bytes) {
+                            self.assignments.push(a);
+                        }
                         if let Some(u) = self.reasm.push(su_bytes) {
                             out.push(u);
                         }
@@ -164,7 +172,10 @@ impl AeroChannelDecoder {
             }
             for user in users {
                 let acars = su::parse_acars(&user.data);
-                out.push(AeroEvent { user, acars, bit_rate: chain.rate });
+                out.push(AeroEvent { user, acars, bit_rate: chain.rate, assignment: None });
+            }
+            for a in chain.framer.assignments.drain(..) {
+                out.push(assignment_event(a, chain.rate));
             }
         }
 
@@ -186,7 +197,10 @@ impl AeroChannelDecoder {
             }
             for user in hr_users {
                 let acars = su::parse_acars(&user.data);
-                out.push(AeroEvent { user, acars, bit_rate: oqpsk::BIT_RATE });
+                out.push(AeroEvent { user, acars, bit_rate: oqpsk::BIT_RATE, assignment: None });
+            }
+            for a in hr.framer.assignments.drain(..) {
+                out.push(assignment_event(a, oqpsk::BIT_RATE));
             }
         }
         out
@@ -240,7 +254,7 @@ impl AeroBurstDecoder {
                 if let Some(result) = self.packetizers[i].process(&bits) {
                     for user in result.users {
                         let acars = su::parse_acars(&user.data);
-                        out.push(AeroEvent { user, acars, bit_rate: rate });
+                        out.push(AeroEvent { user, acars, bit_rate: rate, assignment: None });
                     }
                     break; // one rate decoded this burst
                 }
@@ -312,11 +326,27 @@ impl CChannelDecoder {
     }
 }
 
+fn assignment_event(a: serde_json::Value, bit_rate: u32) -> AeroEvent {
+    let user = su::AeroUserData {
+        aes_id: a["aes_id"].as_str().unwrap_or("").to_owned(),
+        ges_id: a["ges_id"].as_u64().unwrap_or(0) as u8,
+        qno: 0,
+        refno: 0,
+        data: Vec::new(),
+    };
+    AeroEvent { user, acars: None, bit_rate, assignment: Some(a) }
+}
+
 /// Convert a decoded event into the normalized message model.
 pub fn to_message(e: &AeroEvent, frequency_hz: u64, level_dbfs: f32, source: Provenance) -> Message {
-    let (body, crc_ok, errors) = match &e.acars {
-        Some(b) => (MessageBody::Acars(b.core.clone()), b.crc_ok, Some(b.parity_errors)),
-        None => (MessageBody::Undecoded, true, None),
+    let (body, crc_ok, errors) = match (&e.acars, &e.assignment) {
+        (Some(b), _) => (MessageBody::Acars(b.core.clone()), b.crc_ok, Some(b.parity_errors)),
+        (None, Some(a)) => (
+            MessageBody::Aero { kind: "c-channel-assignment".to_owned(), details: a.clone() },
+            true,
+            None,
+        ),
+        (None, None) => (MessageBody::Undecoded, true, None),
     };
     Message {
         mode: Mode::AeroL,

--- a/crates/xng-mode-aero/src/oqpsk.rs
+++ b/crates/xng-mode-aero/src/oqpsk.rs
@@ -424,6 +424,8 @@ pub struct HrFramer {
     /// When collecting: (soft bits after UW, rail inversion masks).
     collecting: Option<(Vec<f32>, [f32; 2])>,
     pub reasm: su::Reassembler,
+    /// C-channel assignment SUs decoded this push (drained per chunk).
+    pub assignments: Vec<serde_json::Value>,
 }
 
 /// Check a 64-bit window: even-position bits = one rail's 32-bit UW,
@@ -455,6 +457,7 @@ impl HrFramer {
             shift: 0,
             collecting: None,
             reasm: su::Reassembler::new(),
+            assignments: Vec::new(),
         }
     }
 
@@ -467,6 +470,9 @@ impl HrFramer {
                 let bytes = self.decoder.decode(coded);
                 for su_bytes in bytes.chunks_exact(su::SU_LEN) {
                     if su::su_crc_ok(su_bytes) {
+                        if let Some(a) = su::parse_c_assignment(su_bytes) {
+                            self.assignments.push(a);
+                        }
                         if let Some(u) = self.reasm.push(su_bytes) {
                             out.push(u);
                         }

--- a/crates/xng-mode-aero/src/su.rs
+++ b/crates/xng-mode-aero/src/su.rs
@@ -322,6 +322,35 @@ pub fn build_r_sus(aes_id: u32, ges_id: u8, qno: u8, refno: u8, data: &[u8]) -> 
 }
 
 /// Fill-in SU (type 0x01) used to pad frames.
+/// Parse a C-channel assignment SU (P-channel types 0x31–0x34): the
+/// ground station tells an aircraft which voice-circuit frequency pair
+/// to use. Channel numbers step 2.5 kHz from 1510.0 (receive) and
+/// 1611.5 MHz (transmit); bit 7 of each high byte flags a spot beam.
+/// (JAERO `CreateCAssignmentItem`.)
+pub fn parse_c_assignment(su: &[u8]) -> Option<serde_json::Value> {
+    if su.len() < 10 || !(0x31..=0x34).contains(&su[0]) {
+        return None;
+    }
+    let service = match su[0] {
+        0x31 => "distress",
+        0x32 => "flight-safety",
+        0x33 => "other-safety",
+        _ => "non-safety",
+    };
+    let rx_chan = (((su[6] & 0x7F) as u32) << 8) | su[7] as u32;
+    let tx_chan = (((su[8] & 0x7F) as u32) << 8) | su[9] as u32;
+    Some(serde_json::json!({
+        "su_type": "c-channel-assignment",
+        "service": service,
+        "aes_id": format!("{:06X}", u32::from_be_bytes([0, su[1], su[2], su[3]])),
+        "ges_id": su[4],
+        "receive_mhz": rx_chan as f64 * 0.0025 + 1510.0,
+        "transmit_mhz": tx_chan as f64 * 0.0025 + 1611.5,
+        "receive_spotbeam": su[6] & 0x80 != 0,
+        "transmit_spotbeam": su[8] & 0x80 != 0,
+    }))
+}
+
 pub fn fill_su() -> Vec<u8> {
     su_with_crc(vec![0x01, 0, 0, 0, 0, 0, 0, 0, 0, 0])
 }
@@ -329,6 +358,31 @@ pub fn fill_su() -> Vec<u8> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn c_assignment_parses_frequencies() {
+        // type 0x32 flight-safety, AES ABCDEF, GES 0x44,
+        // rx channel 4000 (spot beam), tx channel 2000.
+        let mut su10 = vec![0u8; 10];
+        su10[0] = 0x32;
+        su10[1..4].copy_from_slice(&[0xAB, 0xCD, 0xEF]);
+        su10[4] = 0x44;
+        su10[6] = 0x80 | ((4000u16 >> 8) as u8);
+        su10[7] = (4000u16 & 0xFF) as u8;
+        su10[8] = (2000u16 >> 8) as u8;
+        su10[9] = (2000u16 & 0xFF) as u8;
+        let su = su_with_crc(su10);
+        let a = parse_c_assignment(&su).unwrap();
+        assert_eq!(a["service"], "flight-safety");
+        assert_eq!(a["aes_id"], "ABCDEF");
+        assert_eq!(a["ges_id"], 0x44);
+        assert_eq!(a["receive_mhz"], 1520.0);
+        assert_eq!(a["transmit_mhz"], 1616.5);
+        assert_eq!(a["receive_spotbeam"], true);
+        assert_eq!(a["transmit_spotbeam"], false);
+        // non-assignment types pass through
+        assert!(parse_c_assignment(&[0x71; 12]).is_none());
+    }
 
     #[test]
     fn isu_chain_reassembles() {

--- a/crates/xng-proto/src/lib.rs
+++ b/crates/xng-proto/src/lib.rs
@@ -113,6 +113,12 @@ impl From<&Message> for asf2::DecodedMessage {
                     details_json: details.to_string(),
                 }))
             }
+            MessageBody::Aero { kind, details } => {
+                Some(asf2::decoded_message::Body::Aero(asf2::AeroBody {
+                    kind: kind.clone(),
+                    details_json: details.to_string(),
+                }))
+            }
             MessageBody::Hfdl { kind, details } => {
                 Some(asf2::decoded_message::Body::Hfdl(asf2::HfdlBody {
                     kind: kind.clone(),

--- a/crates/xng-types/src/message.rs
+++ b/crates/xng-types/src/message.rs
@@ -142,6 +142,11 @@ pub enum MessageBody {
     },
     /// A frame decoded at link layer but with no (or not-yet-implemented)
     /// application-layer interpretation.
+    /// Inmarsat Aero non-ACARS structures (C-channel assignments, ...).
+    Aero {
+        kind: String,
+        details: serde_json::Value,
+    },
     Undecoded,
 }
 

--- a/proto/asf2.proto
+++ b/proto/asf2.proto
@@ -85,6 +85,13 @@ message HfdlBody {
   string details_json = 2;
 }
 
+message AeroBody {
+  // Structure kind, e.g. "c-channel-assignment".
+  string kind = 1;
+  // Decoded fields as JSON.
+  string details_json = 2;
+}
+
 message Vdl2Body {
   string kind = 1;          // xid | avlc-rr | avlc-i | avlc-ua | ...
   string details_json = 2;  // addresses, control, decoded parameters
@@ -136,6 +143,7 @@ message DecodedMessage {
     HfdlBody hfdl = 15;
     IridiumBody iridium = 16;
     Vdl2Body vdl2 = 17;
+    AeroBody aero = 18;
   }
 }
 

--- a/src/outputs/console.rs
+++ b/src/outputs/console.rs
@@ -185,6 +185,25 @@ pub fn format_message(msg: &Message, fmt: ConsoleFormat) -> String {
                     }
                     s
                 }
+                MessageBody::Aero { kind, details } => {
+                    let mut s = format!("AERO {kind}");
+                    if let Some(svc) = details.get("service").and_then(|v| v.as_str()) {
+                        s.push_str(&format!(" {svc}"));
+                    }
+                    if let (Some(aes), Some(ges)) = (
+                        details.get("aes_id").and_then(|v| v.as_str()),
+                        details.get("ges_id").and_then(|v| v.as_u64()),
+                    ) {
+                        s.push_str(&format!(" AES:{aes} GES:{ges}"));
+                    }
+                    if let (Some(rx), Some(tx)) = (
+                        details.get("receive_mhz").and_then(|v| v.as_f64()),
+                        details.get("transmit_mhz").and_then(|v| v.as_f64()),
+                    ) {
+                        s.push_str(&format!(" rx:{rx:.4} tx:{tx:.4} MHz"));
+                    }
+                    s
+                }
                 MessageBody::Vdl2 { kind, details } => {
                     let addr = |k: &str| {
                         details


### PR DESCRIPTION
## What

Task #26, completing the C-channel story from PR #75: the P-channel **assignment SUs** (types 0x31–0x34) that tell an aircraft which voice-circuit frequency pair to use are now parsed on both P-channel chains (600/1200 bps and 10.5 kbps):

- service class (distress / flight-safety / other-safety / non-safety)
- AES + GES ids
- receive/transmit frequencies (2.5 kHz channel steps from 1510.0 / 1611.5 MHz) + spot-beam flags

per JAERO's `CreateCAssignmentItem`. This is the missing link for tuning the PR #75 C-channel decoder onto live circuits.

New **`MessageBody::Aero { kind, details }`** structured body (proto `AeroBody = 18`, console rendering with AES/GES and rx/tx MHz) so assignments surface end to end instead of vanishing as non-ISU SUs.

## Testing
- `c_assignment_parses_frequencies` (field-exact: channel 4000 → 1520.0 MHz rx, 2000 → 1616.5 MHz tx, spot-beam flags)
- Full workspace green

🤖 Generated with [Claude Code](https://claude.com/claude-code)