### PR TITLE
v0.12.0: decode-depth round 3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3643,7 +3643,7 @@ dependencies = [
 
 [[package]]
 name = "xng"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3683,7 +3683,7 @@ dependencies = [
 
 [[package]]
 name = "xng-acars"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "base64",
  "crc",
@@ -3695,7 +3695,7 @@ dependencies = [
 
 [[package]]
 name = "xng-dsp"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "crc",
  "num-complex",
@@ -3704,7 +3704,7 @@ dependencies = [
 
 [[package]]
 name = "xng-mode-acars"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "chrono",
  "num-complex",
@@ -3716,7 +3716,7 @@ dependencies = [
 
 [[package]]
 name = "xng-mode-adsb"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "chrono",
  "num-complex",
@@ -3727,7 +3727,7 @@ dependencies = [
 
 [[package]]
 name = "xng-mode-aero"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "chrono",
  "num-complex",
@@ -3741,7 +3741,7 @@ dependencies = [
 
 [[package]]
 name = "xng-mode-ais"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "chrono",
  "num-complex",
@@ -3752,7 +3752,7 @@ dependencies = [
 
 [[package]]
 name = "xng-mode-hfdl"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "chrono",
  "num-complex",
@@ -3765,7 +3765,7 @@ dependencies = [
 
 [[package]]
 name = "xng-mode-iridium"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "chrono",
  "crc",
@@ -3780,7 +3780,7 @@ dependencies = [
 
 [[package]]
 name = "xng-mode-stdc"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "chrono",
  "num-complex",
@@ -3793,7 +3793,7 @@ dependencies = [
 
 [[package]]
 name = "xng-mode-vdl2"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "chrono",
  "num-complex",
@@ -3806,7 +3806,7 @@ dependencies = [
 
 [[package]]
 name = "xng-proto"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "chrono",
  "prost",
@@ -3817,7 +3817,7 @@ dependencies = [
 
 [[package]]
 name = "xng-sdr"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "num-complex",
  "pkg-config",
@@ -3828,7 +3828,7 @@ dependencies = [
 
 [[package]]
 name = "xng-types"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "chrono",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["legacy"]
 resolver = "2"
 
 [workspace.package]
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/airframesio/xng"


### PR DESCRIPTION
Version bump for the round-3 campaign (PRs #77–#82):

- **HFDL**: channel-selectivity filter in the no-DDC path — **+4.5–5 dB** measured sensitivity
- **Iridium**: IIP/IIQ/IIR frame parsing on the IP channel and VDA (toolkit-oracle validated)
- **Aero**: C-channel assignment SUs (circuit frequencies from P-channel call setup) + new `MessageBody::Aero` structured body
- **VDL2**: IDRP UPDATE path attributes, NLRI, ERROR codes
- **AIS**: field decode for types 17/20/22/23 (pyais-exact)
- **Deps**: rumqttc 0.25 without TLS features — root-lockfile Dependabot alerts now zero

Tag v0.12.0 follows the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)