### PR TITLE
AIS: fractional-sample timing at the coherent anchor (24 → 26 unique)

### DIFF
--- a/bench/baselines.json
+++ b/bench/baselines.json
@@ -1,5 +1,5 @@
 {
   "_comment": "Minimum decode counts per fixture. Raise these when a demod improvement lands (they are the new floor); never lower without a documented tradeoff. Calibration history in docs/notes/BENCHMARKS.md.",
   "adsb_modes1": 270,
-  "ais_offair": 32
+  "ais_offair": 36
 }

--- a/crates/xng-mode-ais/src/coherent.rs
+++ b/crates/xng-mode-ais/src/coherent.rs
@@ -27,6 +27,17 @@ const GATE_FACTOR: f32 = 2.0;
 const CORR_THRESHOLD: f32 = 0.72;
 const NOISE_ALPHA: f32 = 5e-4;
 
+/// Linearly interpolated sample at fractional position `pos`.
+#[inline]
+fn sample_frac(w: &[Complex<f32>], pos: f32) -> Complex<f32> {
+    let i = pos.floor().max(0.0) as usize;
+    if i + 1 >= w.len() {
+        return *w.last().unwrap_or(&Complex::new(0.0, 0.0));
+    }
+    let f = pos - i as f32;
+    w[i] * (1.0 - f) + w[i + 1] * f
+}
+
 /// NRZI level sequence (±1) for a bit pattern, starting from +1.
 fn nrzi_levels(bits: &[u8]) -> Vec<f32> {
     let mut level = 1.0f32;
@@ -217,6 +228,31 @@ impl CoherentDemod {
             cfo += CFO_STEP_HZ;
         }
         let (_, cfo, _) = best?;
+        // Fractional timing: the anchor is integer-sample, but at 5
+        // samples/bit a ±0.5-sample offset already skews every bit
+        // correlation by ±10 % of a bit. Evaluate the template at
+        // sub-sample offsets (linear interpolation) and keep the best;
+        // the whole window is then resampled at that offset.
+        let mut best_frac = (0.0f32, 0.0f32); // (|corr|, frac)
+        for k in -2i32..=2 {
+            let frac = k as f32 * 0.25;
+            let mut corr = Complex::new(0.0f32, 0.0);
+            for (i, &t) in self.template.iter().enumerate() {
+                let x = sample_frac(window, i as f32 + frac);
+                corr += x * t.conj();
+            }
+            if corr.norm() > best_frac.0 {
+                best_frac = (corr.norm(), frac);
+            }
+        }
+        let window: Vec<Complex<f32>> = if best_frac.1 != 0.0 {
+            (0..window.len())
+                .map(|i| sample_frac(window, i as f32 + best_frac.1))
+                .collect()
+        } else {
+            window.to_vec()
+        };
+        let window = &window[..];
         // Fine CFO: phase slope between the two template halves at the
         // grid winner (the coarse grid leaves up to ±75 Hz, which would
         // integrate to radians of drift across a 26 ms burst).

--- a/docs/notes/BENCHMARKS.md
+++ b/docs/notes/BENCHMARKS.md
@@ -77,9 +77,11 @@ Viterbi with decision-directed phase tracking) raised the synthetic
 sensitivity by **+11–12 dB** (discriminator dies at ~12 dB SNR;
 coherent path runs 40/40 at 6.2 dB and 30/40 at 0.9 dB) and the
 off-air capture from 6 to **24 unique payloads** (45 % of
-AIS-catcher, still a clean subset). The remaining gap is timing
-refinement (the anchor is integer-sample), GMSK-pulse-exact branch
-metrics, and multi-hypothesis decoding of colliding bursts.
+AIS-catcher, still a clean subset). **Fractional-timing refinement** (sub-sample template offsets,
+window resampled at the winner) followed: 24 → 26 unique payloads
+(49 % of AIS-catcher), bench fixture 36 → 39 frames. The remaining
+gap is GMSK-pulse-exact branch metrics and multi-hypothesis decoding
+of colliding bursts.
 
 Hard-won implementation notes: the template-correlation anchor MUST
 reject peaks near the search-window edge (the rising shoulder of a


### PR DESCRIPTION
Follow-up to #87, the first documented remaining lever: the coherent anchor was integer-sample, skewing every Viterbi bit correlation by up to 10 % of a bit at 5 samples/bit. The template now scores sub-sample offsets on a quarter-sample grid (linear interpolation) and the burst window is resampled at the winner.

**Measured**: off-air fixture 36 → 39 frames, 24 → 26 unique payloads (49 % of AIS-catcher, still a clean subset). Bench floor raised 32 → 36. Remaining levers (BENCHMARKS.md): GMSK-pulse-exact branch metrics, colliding-burst multi-hypothesis decode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)