### PR TITLE
Bench: install SoapySDR/protobuf deps in the workflow

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -12,6 +12,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+      - name: Install dependencies
+        run: sudo apt install -y libsoapysdr-dev protobuf-compiler
       - name: Build
         run: cargo build --release
       - name: Fetch AIS fixture (release asset)


### PR DESCRIPTION
PR #90's `decode-counts` check failed at `cargo build` — soapysdr-sys needs the system library, same as rust.yml installs. One-line fix; this PR's own bench run validates it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)