### PR TITLE
ADS-B: ⅛-sample grid, syndrome repair, near-floor gates (145 → 161 unique)

### DIFF
--- a/bench/baselines.json
+++ b/bench/baselines.json
@@ -1,5 +1,5 @@
 {
   "_comment": "Minimum decode counts per fixture. Raise these when a demod improvement lands (they are the new floor); never lower without a documented tradeoff. Calibration history in docs/notes/BENCHMARKS.md.",
-  "adsb_modes1": 270,
+  "adsb_modes1": 310,
   "ais_offair": 36
 }

--- a/crates/xng-mode-adsb/src/demod.rs
+++ b/crates/xng-mode-adsb/src/demod.rs
@@ -21,7 +21,7 @@ const PREAMBLE_PULSES: [usize; 4] = [0, 2, 7, 9];
 const PREAMBLE_QUIET: [usize; 6] = [1, 3, 5, 11, 13, 15];
 /// Candidate gate: mean pulse energy must exceed this multiple of the
 /// worst quiet slot.
-const PULSE_QUIET_RATIO: f32 = 1.0;
+const PULSE_QUIET_RATIO: f32 = 0.5;
 /// Long frame length in bits (DF >= 16).
 const LONG_BITS: usize = 112;
 const SHORT_BITS: usize = 56;
@@ -31,19 +31,19 @@ const NOISE_ALPHA: f32 = 1e-4;
 pub struct PpmDemod {
     /// Samples per half µs.
     half: usize,
-    /// Second timing phase active (2 MS/s input): a pulse landing
+    /// Fractional timing phases active (2 MS/s input): a pulse landing
     /// between samples splits its energy across two half-µs slots and
     /// weak frames decide wrong. The original grid is scanned exactly
-    /// as before; a midpoint-interpolated half-shifted grid is scanned
-    /// independently and its *additional* frames merged in — never
+    /// as before; quarter-sample-shifted interpolated grids are scanned
+    /// independently and their *additional* frames merged in — never
     /// replacing an on-grid decode (interpolation blurs pulse/quiet
     /// contrast, measured −35 frames when used alone).
     two_phase: bool,
     last_sample: Complex<f32>,
     /// Power (|x|²) carry buffer across process() calls.
     power: Vec<f32>,
-    /// Half-shifted power buffer (midpoint complex interpolation).
-    power_mid: Vec<f32>,
+    /// Fractionally shifted power buffers (⅛-sample offset grid).
+    power_frac: [Vec<f32>; 7],
     validator: FrameValidator,
     noise: f32,
 }
@@ -63,7 +63,7 @@ impl PpmDemod {
             two_phase,
             last_sample: Complex::new(0.0, 0.0),
             power: Vec::new(),
-            power_mid: Vec::new(),
+            power_frac: std::array::from_fn(|_| Vec::new()),
             validator: FrameValidator::new(),
             noise: 1e-6,
         })
@@ -94,7 +94,7 @@ impl PpmDemod {
 
             let pulses: f32 =
                 PREAMBLE_PULSES.iter().map(|&p| Self::slot(power, half, i, p)).sum::<f32>() / 4.0;
-            if pulses < *noise * half as f32 * 2.0 {
+            if pulses < *noise * half as f32 * 1.2 {
                 i += 1;
                 continue;
             }
@@ -140,9 +140,16 @@ impl PpmDemod {
         self.power.extend(input.iter().map(|x| x.norm_sqr()));
         if self.two_phase {
             let mut prev = self.last_sample;
-            self.power_mid.reserve(input.len());
+            for v in &mut self.power_frac {
+                v.reserve(input.len());
+            }
             for &x in input {
-                self.power_mid.push(((prev + x) * 0.5).norm_sqr());
+                for (j, frac) in
+                    [0.125f32, 0.25, 0.375, 0.5, 0.625, 0.75, 0.875].iter().enumerate()
+                {
+                    let interp = prev * (1.0 - frac) + x * *frac;
+                    self.power_frac[j].push(interp.norm_sqr());
+                }
                 prev = x;
             }
             if let Some(&last) = input.last() {
@@ -166,23 +173,26 @@ impl PpmDemod {
             true,
         );
         if self.two_phase {
-            let mid = Self::scan(
-                &self.power_mid,
-                self.half,
-                end.min(self.power_mid.len().saturating_sub(frame_samples)),
-                &mut self.noise,
-                &mut self.validator,
-                false,
-            );
-            // Merge: keep half-shifted decodes only when the on-grid scan
-            // didn't already produce the same bytes nearby (legitimate
-            // repeats of identical messages are many frame-lengths apart).
-            for (pos, f) in mid {
-                let dup = found.iter().any(|(p, g)| {
-                    g.bytes == f.bytes && (*p as i64 - pos as i64).unsigned_abs() < frame_samples as u64
-                });
-                if !dup {
-                    found.push((pos, f));
+            for grid in &self.power_frac {
+                let frames = Self::scan(
+                    grid,
+                    self.half,
+                    end.min(grid.len().saturating_sub(frame_samples)),
+                    &mut self.noise,
+                    &mut self.validator,
+                    false,
+                );
+                // Merge: keep shifted decodes only when no equal-bytes
+                // frame was already found nearby (legitimate repeats of
+                // identical messages are many frame-lengths apart).
+                for (pos, f) in frames {
+                    let dup = found.iter().any(|(p, g)| {
+                        g.bytes == f.bytes
+                            && (*p as i64 - pos as i64).unsigned_abs() < frame_samples as u64
+                    });
+                    if !dup {
+                        found.push((pos, f));
+                    }
                 }
             }
         }
@@ -192,8 +202,10 @@ impl PpmDemod {
         // Keep the unscanned tail for the next call.
         self.power.drain(..end.min(self.power.len()));
         if self.two_phase {
-            let n = end.min(self.power_mid.len());
-            self.power_mid.drain(..n);
+            for v in &mut self.power_frac {
+                let n = end.min(v.len());
+                v.drain(..n);
+            }
         }
         out
     }

--- a/crates/xng-mode-adsb/src/frame.rs
+++ b/crates/xng-mode-adsb/src/frame.rs
@@ -9,7 +9,36 @@
 
 use crate::decode::{self, Cpr, Velocity};
 use std::collections::HashMap;
+use std::sync::OnceLock;
 use xng_dsp::checksum::mode_s_crc;
+
+/// Syndrome → bit-position table for single-bit errors in 112-bit
+/// frames (the Mode S CRC is linear; bit i alone yields syndrome
+/// crc(e_i)). 56-bit frames reuse the table tail.
+fn single_bit_fix(syndrome: u32, nbytes: usize) -> Option<usize> {
+    static TABLE: OnceLock<std::collections::HashMap<u32, usize>> = OnceLock::new();
+    let table = TABLE.get_or_init(|| {
+        let mut map = std::collections::HashMap::new();
+        for bit in 0..112usize {
+            let mut msg = [0u8; 14];
+            msg[bit / 8] = 0x80 >> (bit % 8);
+            let syn = mode_s_crc(&msg[..11])
+                ^ u32::from_be_bytes([0, msg[11], msg[12], msg[13]]);
+            map.insert(syn, bit);
+        }
+        map
+    });
+    let bit = *table.get(&syndrome)?;
+    // For 56-bit frames the error must land within the short frame.
+    let total_bits = nbytes * 8;
+    if total_bits == 112 {
+        Some(bit)
+    } else {
+        // 56-bit short frame: its bit k corresponds to long-frame bit
+        // k + 56 in CRC terms (the polynomial acts on the tail).
+        bit.checked_sub(56).filter(|&b| b < total_bits)
+    }
+}
 
 /// Identification charset (TC 1–4): index 1–26 = A–Z, 32 = space,
 /// 48–57 = digits.
@@ -67,11 +96,27 @@ impl FrameValidator {
         let expected = mode_s_crc(&bytes[..n - 3]);
         let received = u32::from_be_bytes([0, bytes[n - 3], bytes[n - 2], bytes[n - 1]]);
         let syndrome = expected ^ received;
+        let mut bytes = bytes.to_vec();
+        let mut syndrome = syndrome;
         let icao = match df {
             // Extended squitter: clean parity; address in AA field.
+            // The CRC is linear, so a single bit error has a unique,
+            // precomputable syndrome — repair it (the parity then
+            // re-verifies clean) instead of dropping the frame.
             17 | 18 => {
                 if syndrome != 0 {
-                    return None;
+                    let Some(bit) = single_bit_fix(syndrome, bytes.len()) else {
+                        return None;
+                    };
+                    bytes[bit / 8] ^= 0x80 >> (bit % 8);
+                    let n = bytes.len();
+                    let expected = mode_s_crc(&bytes[..n - 3]);
+                    let received =
+                        u32::from_be_bytes([0, bytes[n - 3], bytes[n - 2], bytes[n - 1]]);
+                    syndrome = expected ^ received;
+                    if syndrome != 0 || bytes[0] >> 3 != df {
+                        return None;
+                    }
                 }
                 let icao = u32::from_be_bytes([0, bytes[1], bytes[2], bytes[3]]);
                 self.learn(icao);
@@ -100,7 +145,7 @@ impl FrameValidator {
         let mut f = AdsbFrame {
             df,
             icao,
-            bytes: bytes.to_vec(),
+            bytes: bytes.clone(),
             callsign: None,
             altitude_ft: None,
             squawk: None,
@@ -219,10 +264,18 @@ mod tests {
     }
 
     #[test]
-    fn rejects_corrupted_squitter() {
-        let mut bad = ID_FRAME;
-        bad[6] ^= 0x01;
-        assert!(FrameValidator::new().validate(&bad, -20.0).is_none());
+    fn repairs_single_bit_rejects_double() {
+        // One flipped bit: the syndrome identifies it and the frame
+        // repairs to the original.
+        let mut one = ID_FRAME;
+        one[6] ^= 0x01;
+        let f = FrameValidator::new().validate(&one, -20.0).expect("repaired");
+        assert_eq!(f.bytes, &ID_FRAME);
+        // Two flipped bits: not repairable, rejected.
+        let mut two = ID_FRAME;
+        two[6] ^= 0x01;
+        two[9] ^= 0x10;
+        assert!(FrameValidator::new().validate(&two, -20.0).is_none());
     }
 
     #[test]


### PR DESCRIPTION
## What

Task #34 (the 100 % push): three more ablation-attributed levers on `modes1.bin`:

1. **⅛-sample interpolated timing grid** — 8 independent phase scans merged by bytes + position
2. **Single-bit syndrome repair for DF17/18** — the Mode S CRC is linear, so a one-bit error has a unique precomputable syndrome; repaired frames must re-verify clean (a 2-bit corruption still rejects — test updated to assert both)
3. **Pre-gates near the floor** (`PULSE_QUIET_RATIO` 0.5, noise 1.2×) — with CRC + repair arbitrating, strict pre-gates only cost frames

## Measured (modes1, unique frames)

| | xng | dump1090-fa `--no-fix` |
|---|---|---|
| unique | **161** | 162 |
| common | 154 | — |
| exclusive | **7** | 8 |

**Count parity.** The 8 remaining FA-only frames plateau under every gate setting — suspected colliding bursts, which need multi-hypothesis decode (the same lever the AIS 100 % push needs; deliberately a follow-up). Bench floor raised 270 → 310 (actual 329).

## Testing
- Workspace green; `bench/run.sh` green with raised floor; this PR's bench job exercises it

🤖 Generated with [Claude Code](https://claude.com/claude-code)