### PR TITLE
VDL2: forensics round 5 — pseudo-truth retraction, 105k native, oracle diff

### DIFF
--- a/crates/xng-mode-vdl2/examples/bitdiff.rs
+++ b/crates/xng-mode-vdl2/examples/bitdiff.rs
@@ -1,0 +1,41 @@
+//! Error-position forensics: expected TX bits (ground-truth data
+//! through RS+interleave) vs dumped received bits.
+use xng_mode_vdl2::interleave;
+
+fn main() {
+    let truth_path = std::env::args().nth(1).expect("truth file");
+    let rx_path = std::env::args().nth(2).expect("rx file");
+    let truth = std::fs::read(&truth_path).expect("truth");
+    let rx = std::fs::read(&rx_path).expect("rx");
+    let rs = interleave::vdl2_rs();
+    let tx = interleave::interleave(&truth, &rs);
+    let n = tx.len().min(rx.len());
+    eprintln!("tx {} bits, rx {} bits", tx.len(), rx.len());
+    let mut errs = Vec::new();
+    for i in 0..n {
+        if tx[i] != rx[i] {
+            errs.push(i);
+        }
+    }
+    eprintln!("{} bit errors of {}", errs.len(), n);
+    // Map to symbols (3 bits each) and report position + bit-in-symbol.
+    let mut last = -10i64;
+    for &e in &errs {
+        let sym = e / 3;
+        let bit = e % 3;
+        let gap = e as i64 - last;
+        eprintln!("  bit {e:5} sym {sym:4}.{bit} (gap {gap})");
+        last = e as i64;
+    }
+    // Check-octet comparison: the transmitted tail past the data bits.
+    let data_bits = truth.len().div_ceil(8) * 8; // octet-aligned
+    let to_octets = |bits: &[u8]| -> Vec<u8> {
+        bits.chunks(8)
+            .map(|c| c.iter().enumerate().fold(0u8, |b, (i, &v)| b | (v << (7 - i))))
+            .collect()
+    };
+    let our_checks = to_octets(&tx[data_bits..]);
+    let rx_checks = to_octets(&rx[data_bits..n]);
+    eprintln!("our checks: {our_checks:02x?}");
+    eprintln!("rx  checks: {rx_checks:02x?}");
+}

--- a/crates/xng-mode-vdl2/examples/rscheck.rs
+++ b/crates/xng-mode-vdl2/examples/rscheck.rs
@@ -1,0 +1,28 @@
+//! Validate a dumped RX burst row directly against our RS math.
+use xng_mode_vdl2::interleave;
+
+fn main() {
+    let rx_path = std::env::args().nth(1).expect("rx file");
+    let tl: usize = std::env::args().nth(2).expect("tl").parse().unwrap();
+    let rx = std::fs::read(&rx_path).expect("rx");
+    let to_octets = |bits: &[u8]| -> Vec<u8> {
+        bits.chunks(8)
+            .map(|c| c.iter().enumerate().fold(0u8, |b, (i, &v)| b | (v << (7 - i))))
+            .collect()
+    };
+    let octets = to_octets(&rx);
+    let data_octets = tl.div_ceil(8);
+    eprintln!("rx {} bits -> {} octets ({} data + {} checks)",
+        rx.len(), octets.len(), data_octets, octets.len() - data_octets);
+    let rs = interleave::vdl2_rs();
+    // Build the padded 255-octet codeword like deinterleave does.
+    let mut cw = vec![0u8; 255];
+    cw[..data_octets].copy_from_slice(&octets[..data_octets]);
+    let k = octets.len() - data_octets;
+    cw[249..249 + k].copy_from_slice(&octets[data_octets..]);
+    let erasures: Vec<usize> = (249 + k..255).collect();
+    match rs.correct(&mut cw, &erasures) {
+        Ok(fixed) => eprintln!("RS VALID with {fixed} corrections"),
+        Err(()) => eprintln!("RS INVALID under our convention"),
+    }
+}

--- a/crates/xng-mode-vdl2/examples/truthcheck.rs
+++ b/crates/xng-mode-vdl2/examples/truthcheck.rs
@@ -1,0 +1,11 @@
+use xng_mode_vdl2::avlc;
+fn main() {
+    for p in std::env::args().skip(1) {
+        let bits = std::fs::read(&p).unwrap();
+        let frames = avlc::scan(&bits);
+        println!("{p}: {} AVLC FCS-valid frames", frames.len());
+        for f in &frames {
+            println!("  {:?} -> {:?} len {}", f.src.addr, f.dst.addr, f.raw.len());
+        }
+    }
+}

--- a/crates/xng-mode-vdl2/src/demod.rs
+++ b/crates/xng-mode-vdl2/src/demod.rs
@@ -407,6 +407,18 @@ impl Vdl2Demod {
                                 if std::env::var("VDL2_DEBUG").is_ok() {
                                     eprintln!("RSFAIL tl_bits={tl_bits} syms={}", n / 3);
                                 }
+                                if let Ok(dir) = std::env::var("VDL2_DUMP_BITS") {
+                                    use std::sync::atomic::AtomicU32;
+                                    static N: AtomicU32 = AtomicU32::new(0);
+                                    let k = N.fetch_add(1, AOrd::Relaxed);
+                                    let _ = std::fs::write(
+                                        format!(
+                                            "{dir}/rx_tl{tl_bits}_{k}_at{}.bits",
+                                            c.uw_start as u64
+                                        ),
+                                        &c.bits[HEADER_BITS..n],
+                                    );
+                                }
                                 STAT_RS_FAIL.fetch_add(1, AOrd::Relaxed);
                                 self.last_rs_fail = c.uw_start;
                                 // A false UW lock (e.g. on a burst edge) can

--- a/crates/xng-mode-vdl2/src/lib.rs
+++ b/crates/xng-mode-vdl2/src/lib.rs
@@ -61,7 +61,16 @@ impl Vdl2ChannelDecoder {
     pub fn new(input_rate: f64, freq_offset_hz: f64) -> Result<Self, String> {
         // Prefer the high channel rate when the capture divides into it;
         // 50 kS/s remains the floor (and the vendored-fixture rate).
-        let channel_rate = if input_rate >= CHANNEL_RATE_HI
+        // Prefer 105 kS/s (an exact 10 samples/symbol) when the input
+        // divides into it: at 100 kS/s every symbol center falls at a
+        // fractional sample position and the linear interpolator's
+        // error acts as decision noise; integer sps removes it.
+        const CHANNEL_RATE_NATIVE: f64 = 105_000.0;
+        let channel_rate = if input_rate >= CHANNEL_RATE_NATIVE
+            && (input_rate / CHANNEL_RATE_NATIVE).fract().abs() < 1e-9
+        {
+            CHANNEL_RATE_NATIVE
+        } else if input_rate >= CHANNEL_RATE_HI
             && (input_rate / CHANNEL_RATE_HI).fract().abs() < 1e-9
         {
             CHANNEL_RATE_HI

--- a/docs/notes/VDL2-DEMOD-V2.md
+++ b/docs/notes/VDL2-DEMOD-V2.md
@@ -338,3 +338,32 @@ derived filter, bit-level ground truth, off-air last.
 
 HFDL's no-DDC path has the same missing-selectivity structure and its
 own falsified-sensitivity backlog — worth the same experiment there.
+
+## Round 5 (2026-06-11): forensics reset — the pseudo-truth retraction
+
+Two corrections and a sharpened target list:
+
+1. **The `/tmp/vdl2_bits/burst_tl*.bits` files were never ground
+   truth.** They contain zero FCS-valid AVLC frames — they are our own
+   failed post-RS bits from an earlier round. Any conclusion drawn by
+   comparing against them (including this round's first "check-octet
+   convention" hypothesis) is invalid. Verification rule going
+   forward: a claimed truth file must pass `avlc::scan` before it is
+   used as a reference.
+2. **105 kS/s native channel support added** (exact 10 samples/symbol)
+   to falsify the fractional-interpolation hypothesis: 19 frames at
+   105 k, identical to 100 k. Linear-interpolation error is NOT the
+   gap. (Kept anyway: integer sps for free when the input divides.)
+
+Real oracle diff (dumpvdl2 built from source, JSON output, same
+capture): oracle 41 = 12 x25 + 10 acars + 9 RR + 8 xid + 2 other; we
+decode 19, including RRs from every conversation. Missing entirely:
+**all six GSIF broadcast XIDs** (2D4917/2D4918 → FFFFFF), 8 of 10
+ACARS, and roughly half of the 47806D→10981A x25 exchange. The
+stations are audible (their RRs decode); the mid-size frames fail.
+
+RS-failure positions are now dumpable (`VDL2_DUMP_BITS=<dir>`, files
+carry the burst sample offset); three GSIF burst IQ segments are
+extracted to /tmp/vdl2_lab/ for single-burst lab work. Next: bit-true
+single-burst study against dumpvdl2's decode of the same burst —
+obtained from dumpvdl2 itself, not from stale files.


### PR DESCRIPTION
## What

Round 5 of the VDL2 campaign (the 41/41 push), mostly epistemics:

- **Retraction**: the `burst_tl*.bits` files treated as dumpvdl2 ground truth in earlier rounds contain **zero FCS-valid frames** — they were our own failed post-RS bits. A same-day hypothesis built on them (check-octet convention mismatch) died with them. New rule in the notes: truth files must pass `avlc::scan` before use.
- **105 kS/s native channel** (exact 10 samples/symbol): falsifies the fractional-interpolation hypothesis — 19 frames, identical to 100 k. Kept anyway (integer sps when the input divides).
- **Real oracle diff** (dumpvdl2 built from source, JSON): the missing 22 are *all six GSIF broadcast XIDs*, 8 of 10 ACARS frames, and ~half of one X.25 exchange — while the RRs of every conversation decode. The stations are audible; the mid-size frames fail.
- Tooling: `VDL2_DUMP_BITS` dumps RS-failing bursts with sample offsets; `bitdiff`/`rscheck`/`truthcheck` examples; three GSIF burst IQ segments extracted for single-burst lab work.
- Also restores the ADS-B round-2 BENCHMARKS.md paragraph lost to a silent patch failure in #93's chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added native 105 kS/s channel rate support for improved demodulation flexibility.
  * Enabled optional payload bit dumping during RS decoding failures for advanced diagnostics.

* **Chores**
  * Added example programs for bit analysis, validation, and frame detection.

* **Documentation**
  * Updated validation methodology with ground truth verification requirements and testing procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->