### PR TITLE
Collision decode: AIS SIC + ADS-B findings (sighting-based ICAO clock)

### DIFF
--- a/crates/xng-mode-adsb/src/demod.rs
+++ b/crates/xng-mode-adsb/src/demod.rs
@@ -164,7 +164,7 @@ impl PpmDemod {
         }
         let end = self.power.len() - frame_samples;
 
-        let mut found = Self::scan(
+        let raw_found = Self::scan(
             &self.power,
             self.half,
             end,
@@ -172,6 +172,16 @@ impl PpmDemod {
             &mut self.validator,
             true,
         );
+        let mut found: Vec<(usize, AdsbFrame)> = Vec::new();
+        for (pos, f) in raw_found {
+            let dup = found.iter().any(|(p, g)| {
+                g.bytes == f.bytes
+                    && (*p as i64 - pos as i64).unsigned_abs() < frame_samples as u64
+            });
+            if !dup {
+                found.push((pos, f));
+            }
+        }
         if self.two_phase {
             for grid in &self.power_frac {
                 let frames = Self::scan(

--- a/crates/xng-mode-adsb/src/frame.rs
+++ b/crates/xng-mode-adsb/src/frame.rs
@@ -88,7 +88,6 @@ impl FrameValidator {
     /// Validate a demodulated candidate; returns a frame when parity
     /// checks out.
     pub fn validate(&mut self, bytes: &[u8], level_dbfs: f32) -> Option<AdsbFrame> {
-        self.counter += 1;
         let df = bytes[0] >> 3;
         // Syndrome = expected parity over the data bits XOR the received
         // parity field: 0 for clean parity, the overlaid address otherwise.
@@ -179,6 +178,11 @@ impl FrameValidator {
     }
 
     fn learn(&mut self, icao: u32) {
+        // The staleness clock ticks on sightings, not candidate
+        // attempts: near-floor gates plus in-frame collision scanning
+        // make attempt counts explode, and an attempt-based clock
+        // thrashes the cache (measured: −7 unique frames).
+        self.counter += 1;
         if self.icao_cache.len() >= ICAO_CACHE_MAX {
             // Drop the stalest half (rare; cheap enough).
             let cutoff = self.counter.saturating_sub((ICAO_CACHE_MAX / 2) as u64);

--- a/crates/xng-mode-ais/src/coherent.rs
+++ b/crates/xng-mode-ais/src/coherent.rs
@@ -156,6 +156,24 @@ fn gmsk_waveform(levels: &[f32]) -> Vec<Complex<f32>> {
     out
 }
 
+/// First FCS-valid candidate: returns (bits consumed incl. closing
+/// flag, the raw stuffed payload bits actually transmitted).
+fn first_valid(candidates: &[Vec<u8>]) -> Option<(usize, Vec<u8>)> {
+    for bits in candidates {
+        let mut df = crate::frame::HdlcDeframer::new();
+        for &b in &[0u8, 1, 1, 1, 1, 1, 1, 0] {
+            df.push_bit(b);
+        }
+        for (k, &b) in bits.iter().enumerate() {
+            if df.push_bit(b).is_some() {
+                // k is the index of the closing flag's final 0.
+                return Some((k + 1, bits[..k + 1].to_vec()));
+            }
+        }
+    }
+    None
+}
+
 pub struct CoherentDemod {
     buf: VecDeque<Complex<f32>>,
     /// Absolute index of buf[0] in the stream.
@@ -213,6 +231,41 @@ impl CoherentDemod {
                 if std::env::var("AIS_DEBUG").is_ok() {
                     eprintln!("try_decode at {}: {} candidate(s)", start, decoded.len());
                 }
+                // Successive interference cancellation: if a candidate
+                // is FCS-valid, reconstruct its exact burst (bits are
+                // known, the synthesis is the modulator's) and subtract;
+                // a colliding weaker burst then gets its own pass.
+                if let Some((_bits_used, frame_bits)) = first_valid(&decoded) {
+                    if let Some(residual) = self.subtract_burst(&window, &frame_bits) {
+                        // The colliding burst's template can sit anywhere
+                        // in the residual: scan for the best anchor.
+                        let tmpl_len = self.template.len();
+                        let mut best = (0.0f32, 0usize);
+                        let mut off = 0usize;
+                        while off + tmpl_len + SPB < residual.len() {
+                            let m = Self::template_metric(
+                                &self.template,
+                                &residual[off..off + tmpl_len],
+                            );
+                            if m > best.0 {
+                                best = (m, off);
+                            }
+                            off += 1;
+                        }
+                        if best.0 > CORR_THRESHOLD {
+                            let rescued = self.try_decode(&residual[best.1..]);
+                            if std::env::var("AIS_DEBUG").is_ok() {
+                                eprintln!(
+                                    "  SIC anchor m={:.3} at {}: {} candidate(s)",
+                                    best.0,
+                                    best.1,
+                                    rescued.len()
+                                );
+                            }
+                            out.extend(rescued);
+                        }
+                    }
+                }
                 out.extend(decoded);
                 self.pending = None;
                 self.cursor = start + tmpl_len as u64; // resume past the template
@@ -254,8 +307,86 @@ impl CoherentDemod {
         out
     }
 
+    /// Reconstruct a confirmed burst (template + raw payload bits) and
+    /// subtract it from the window; returns the residual for a second
+    /// decode pass, or None when the fit is implausible.
+    fn subtract_burst(
+        &self,
+        window: &[Complex<f32>],
+        payload_bits: &[u8],
+    ) -> Option<Vec<Complex<f32>>> {
+        // Synthesize the full transmitted waveform: template bits then
+        // the raw payload bits, NRZI → levels → GMSK.
+        let mut bits = Vec::with_capacity(TMPL_BITS + payload_bits.len());
+        for k in 0..16 {
+            bits.push((k % 2) as u8);
+        }
+        bits.extend([0, 1, 1, 1, 1, 1, 1, 0]);
+        bits.extend_from_slice(payload_bits);
+        let wave = gmsk_waveform(&nrzi_levels(&bits));
+        let n = wave.len().min(window.len());
+
+        // CFO estimate over the whole known waveform (phase slope of
+        // halves), then complex least-squares amplitude.
+        let mut c1 = Complex::new(0.0f32, 0.0);
+        let mut c2 = Complex::new(0.0f32, 0.0);
+        for k in 0..n {
+            let v = window[k] * wave[k].conj();
+            if k < n / 2 {
+                c1 += v;
+            } else {
+                c2 += v;
+            }
+        }
+        let dphi = (c2 * c1.conj()).arg();
+        let cfo_step = Complex::from_polar(1.0, dphi / (n as f32 / 2.0));
+        let mut rot = Complex::new(1.0f32, 0.0);
+        let mut num = Complex::new(0.0f32, 0.0);
+        let mut den = 0.0f32;
+        for k in 0..n {
+            let w = wave[k] * rot;
+            num += window[k] * w.conj();
+            den += w.norm_sqr();
+            rot *= cfo_step;
+        }
+        let scale = num / den.max(1e-12);
+        // Sanity: the fit must explain a meaningful share of the
+        // window energy, else subtraction just injects the template.
+        let fit_energy = scale.norm_sqr() * den;
+        let win_energy: f32 = window[..n].iter().map(|c| c.norm_sqr()).sum();
+        if fit_energy < 0.25 * win_energy {
+            return None;
+        }
+        let mut residual = window.to_vec();
+        let mut rot = Complex::new(1.0f32, 0.0);
+        for k in 0..n {
+            residual[k] -= scale * wave[k] * rot;
+            rot *= cfo_step;
+        }
+        Some(residual)
+    }
+
     /// Correlate the template over a short window after `rel`; returns
     /// the offset of an accepted anchor.
+    /// Differential-coherent template metric at one position (CFO-
+    /// immune: the four partial sums' magnitudes are rotation-
+    /// invariant).
+    fn template_metric(template: &[Complex<f32>], w: &[Complex<f32>]) -> f32 {
+        let tmpl_len = template.len();
+        let mut acc = [Complex::new(0.0f32, 0.0); 4];
+        let mut energy = 0.0f32;
+        for (k, &t) in template.iter().enumerate() {
+            let r = w[k];
+            acc[k * 4 / tmpl_len] += r * t.conj();
+            energy += r.norm_sqr();
+        }
+        if energy < 1e-12 {
+            return 0.0;
+        }
+        (acc[0].norm() + acc[1].norm() + acc[2].norm() + acc[3].norm())
+            / (energy * tmpl_len as f32).sqrt()
+    }
+
     fn hunt_template(&self, rel: usize) -> Option<usize> {
         let tmpl_len = self.template.len();
         let span = SPB * 64; // search ~64 bits ahead of the gate
@@ -265,24 +396,9 @@ impl CoherentDemod {
             if s0 + tmpl_len >= self.buf.len() {
                 break;
             }
-            // Differential-coherent metric is CFO-immune enough for the
-            // anchor: corr of (r·conj(template)) self-consistency via
-            // per-quarter-template phase agreement.
-            let mut acc = [Complex::new(0.0f32, 0.0); 4];
-            let mut energy = 0.0f32;
-            for (k, &t) in self.template.iter().enumerate() {
-                let r = self.buf[s0 + k];
-                acc[k * 4 / tmpl_len] += r * t.conj();
-                energy += r.norm_sqr();
-            }
-            if energy < 1e-12 {
-                continue;
-            }
-            // CFO rotates the four partial sums by a constant step;
-            // the magnitude of the differential combination is
-            // rotation-invariant.
-            let m = (acc[0].norm() + acc[1].norm() + acc[2].norm() + acc[3].norm())
-                / (energy * tmpl_len as f32).sqrt();
+            let w: Vec<Complex<f32>> =
+                self.buf.iter().skip(s0).take(tmpl_len).copied().collect();
+            let m = Self::template_metric(&self.template, &w);
             if m > best.0 {
                 best = (m, off);
             }

--- a/docs/notes/BENCHMARKS.md
+++ b/docs/notes/BENCHMARKS.md
@@ -95,9 +95,19 @@ unanchored. Process lesson re-learned at cost: `cargo build -p <crate>`
 does NOT rebuild the workspace binary — three off-air "regressions"
 were a stale `target/release/xng`.
 
-Remaining 17 AC-only payloads: colliding bursts and the weakest tail —
-multi-hypothesis collision decode is the shared next lever with ADS-B's
-last 8.
+**Collision decode (same day)**: AIS successive interference
+cancellation shipped — a confirmed FCS-valid burst is reconstructed
+exactly (the bits are known; the synthesis is the modulator's),
+least-squares scaled with its own CFO estimate, subtracted, and the
+residual re-hunted for a colliding burst. **No gain on this fixture**
+(the missing 17 never anchor at any threshold — they are the genuinely
+weakest tail, not collisions), but the machinery is in place for dense
+traffic. ADS-B in-frame collision scanning was tried and **falsified**
+on modes1 (−7 unique: mid-frame false DF11 candidates pollute the ICAO
+cache; the cache clock was moved from attempts to sightings as a
+lasting fix). The remaining gaps — AIS 17, ADS-B 8 — are deep-weak
+sensitivity and need either better front-end SNR or per-burst
+iterative refinement, not collision handling.
 
 Hard-won implementation notes: the template-correlation anchor MUST
 reject peaks near the search-window edge (the rising shoulder of a


### PR DESCRIPTION
## What

The collision-decode round, honestly reported:

- **AIS successive interference cancellation**: a confirmed FCS-valid burst is reconstructed exactly — the bits are known and the synthesis is the modulator's own GMSK waveform — least-squares scaled with its own CFO estimate, subtracted from the window, and the residual re-hunted and decoded for a colliding burst. **No gain on the bench fixture**: the missing 17 payloads never anchor at any threshold (0.72 → 0.55 changes nothing) — they're the genuinely weakest tail of distant base stations, not collisions. The machinery is in place for dense coastal traffic where slot collisions are routine.
- **ADS-B in-frame collision scanning: falsified** on modes1 (−7 unique). Scanning inside decoded frame spans produces mid-frame false DF11 candidates that pollute the ICAO cache. Reverted, documented.
- **Lasting fix from the experiment**: the ICAO cache staleness clock ticks on *sightings* rather than candidate attempts — attempt-based aging thrashes under near-floor gates.

## Gates
All green at current floors (ADS-B 323 ≥ 310, AIS 51 ≥ 48, VDL2 44 ≥ 42); full workspace passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)