### PR TITLE
v0.14.0: the oracle-parity release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3643,7 +3643,7 @@ dependencies = [
 
 [[package]]
 name = "xng"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3683,7 +3683,7 @@ dependencies = [
 
 [[package]]
 name = "xng-acars"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "base64",
  "crc",
@@ -3695,7 +3695,7 @@ dependencies = [
 
 [[package]]
 name = "xng-dsp"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "crc",
  "num-complex",
@@ -3704,7 +3704,7 @@ dependencies = [
 
 [[package]]
 name = "xng-mode-acars"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "chrono",
  "num-complex",
@@ -3716,7 +3716,7 @@ dependencies = [
 
 [[package]]
 name = "xng-mode-adsb"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "chrono",
  "num-complex",
@@ -3727,7 +3727,7 @@ dependencies = [
 
 [[package]]
 name = "xng-mode-aero"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "chrono",
  "num-complex",
@@ -3741,7 +3741,7 @@ dependencies = [
 
 [[package]]
 name = "xng-mode-ais"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "chrono",
  "num-complex",
@@ -3752,7 +3752,7 @@ dependencies = [
 
 [[package]]
 name = "xng-mode-hfdl"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "chrono",
  "num-complex",
@@ -3765,7 +3765,7 @@ dependencies = [
 
 [[package]]
 name = "xng-mode-iridium"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "chrono",
  "crc",
@@ -3780,7 +3780,7 @@ dependencies = [
 
 [[package]]
 name = "xng-mode-stdc"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "chrono",
  "num-complex",
@@ -3793,7 +3793,7 @@ dependencies = [
 
 [[package]]
 name = "xng-mode-vdl2"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "chrono",
  "num-complex",
@@ -3806,7 +3806,7 @@ dependencies = [
 
 [[package]]
 name = "xng-proto"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "chrono",
  "prost",
@@ -3817,7 +3817,7 @@ dependencies = [
 
 [[package]]
 name = "xng-sdr"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "num-complex",
  "pkg-config",
@@ -3828,7 +3828,7 @@ dependencies = [
 
 [[package]]
 name = "xng-types"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "chrono",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["legacy"]
 resolver = "2"
 
 [workspace.package]
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/airframesio/xng"

--- a/README.md
+++ b/README.md
@@ -276,6 +276,12 @@ drops the listed ones. Non-ACARS messages always pass. VDL2 console
 lines can name ground stations via `--gs-file stations.json` (a JSON
 object mapping hex AVLC addresses to names).
 
+Decode performance is benchmarked against the strongest open decoders
+on off-air captures — **VDL2: 44 frames vs dumpvdl2's 41; ADS-B: 161
+unique vs dump1090-fa's 162 (plus 7 it misses); AIS: 68 % of
+AIS-catcher and closing** — with every result fenced by a CI
+regression gate ([bench/](bench/), [docs/notes/BENCHMARKS.md](docs/notes/BENCHMARKS.md)).
+
 **asf-2.0** ([docs/ASF2.md](docs/ASF2.md)) is xng's multiplexed feeding
 protocol: one protobuf schema carrying every channel/SDR/mode over a
 single gRPC or QUIC connection, with reconnect and backpressure handling.


### PR DESCRIPTION
Version bump for the demod campaign (PRs #93–#97):

| mode | oracle | xng v0.14.0 |
|---|---|---|
| **VDL2** | dumpvdl2: 41 | **44** — the RS bit-order fix that closed a multi-session investigation |
| **ADS-B** | dump1090-fa: 162 | **161** unique + 7 it misses — ⅛-sample grids, syndrome repair, near-floor gates |
| **AIS** | AIS-catcher: 53 | **36** unique (was 6 this morning) — coherent burst path, GMSK-exact MLSE, dual pulse hypotheses, SIC |

Every number is fenced by the decode-count regression gate (`bench/`) on every PR. Tag v0.14.0 follows the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)