### PR TITLE
Station mode: whole receive site in one process

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2327,6 +2327,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2742,6 +2751,47 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap 2.14.0",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tonic"
@@ -3548,6 +3598,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3661,6 +3720,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-stream",
+ "toml",
  "tonic",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,7 @@ airspyhf = ["xng-sdr/airspyhf"]
 [dependencies]
 anyhow.workspace = true
 rumqttc.workspace = true
+toml = "0.8"
 chrono.workspace = true
 clap = { version = "4", features = ["derive"] }
 num-complex.workspace = true

--- a/README.md
+++ b/README.md
@@ -259,6 +259,40 @@ xng tui --sdr driver=rtlsdr -r 2400000 -c 131.500M --channels 131.550,131.125
 xng tui --file capture.cf32 -r 2400000 -c 131.500M --channels 131.550
 ```
 
+### Whole-station mode
+
+One process can run the entire receive site — several modes on several
+SDRs, sharing one feed, one output set, and one metrics endpoint
+(something no single-mode decoder can do):
+
+```bash
+xng station station.toml
+```
+
+```toml
+station-id = "XX-KSEA-1"
+
+[outputs]
+feed-airframes = true
+metrics = "0.0.0.0:9090"
+
+[[session]]
+sdr = "driver=rtlsdr,serial=00000001"
+gain = 48
+mode = "acars"
+sample-rate = 2400000
+center = "131.000M"
+channels = ["130.025", "131.550", "131.725"]
+
+[[session]]
+sdr = "driver=airspy"   # rate/center/channels derive from the plan
+mode = "vdl2"
+```
+
+A full example config and a hardened systemd unit live in
+[`contrib/`](contrib/). Sessions can also replay IQ files (`file =`
+instead of `sdr =`) — useful for regression runs over recorded nights.
+
 ### Feeding and outputs
 
 Every mode and every command shares the same output options:

--- a/contrib/station.example.toml
+++ b/contrib/station.example.toml
@@ -1,0 +1,32 @@
+# xng station configuration — the whole receive site in one process.
+#   xng station station.toml
+station-id = "XX-KSEA-1"
+
+[outputs]
+feed-airframes = true
+jsonl = "/var/log/xng/messages.jsonl"
+metrics = "0.0.0.0:9090"
+# mqtt = "mqtt://user:pass@broker:1883"
+# sbs = "0.0.0.0:30003"        # Mode S BaseStation TCP
+# beast = "0.0.0.0:30005"      # Mode S Beast TCP (mlat-client compatible)
+# nmea-tcp = "0.0.0.0:10110"   # AIS NMEA TCP
+
+[[session]]
+sdr = "driver=rtlsdr,serial=00000001"
+gain = 48
+mode = "acars"
+sample-rate = 2400000
+center = "131.000M"
+channels = ["130.025", "131.125", "131.550", "131.725"]
+
+[[session]]
+sdr = "driver=airspy"          # rate/center/channels derive from the
+mode = "vdl2"                  # mode's built-in plan when omitted
+
+[[session]]
+sdr = "driver=rtlsdr,serial=00000002"
+mode = "adsb"
+sample-rate = 2000000
+center = "1090M"
+channels = ["1090"]
+receiver-pos = "47.62,-122.35" # enables surface-position decode

--- a/contrib/xng-station.service
+++ b/contrib/xng-station.service
@@ -1,0 +1,23 @@
+# systemd unit for an xng station.
+#   sudo cp xng-station.service /etc/systemd/system/
+#   sudo systemctl enable --now xng-station
+[Unit]
+Description=xng multi-mode SDR station
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+ExecStart=/usr/local/bin/xng station /etc/xng/station.toml
+Restart=on-failure
+RestartSec=10
+# SDR USB access typically wants the plugdev group:
+User=xng
+Group=plugdev
+# Hardening
+NoNewPrivileges=true
+ProtectSystem=strict
+ReadWritePaths=/var/log/xng
+PrivateTmp=true
+
+[Install]
+WantedBy=multi-user.target

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -4,4 +4,5 @@ pub mod ingest;
 pub mod iq_info;
 pub mod scan;
 pub mod selftest;
+pub mod station;
 pub mod survey;

--- a/src/commands/station.rs
+++ b/src/commands/station.rs
@@ -1,0 +1,135 @@
+//! Station config file: several decode sessions (mode + SDR/file +
+//! channels) plus one shared output set, run as a single process.
+//!
+//! ```toml
+//! station-id = "XX-KSEA-1"
+//!
+//! [outputs]
+//! feed-airframes = true
+//! jsonl = "/var/log/xng/messages.jsonl"
+//! metrics = "0.0.0.0:9090"
+//!
+//! [[session]]
+//! sdr = "driver=rtlsdr,serial=00000001"
+//! gain = 48
+//! mode = "acars"
+//! sample-rate = 2400000
+//! center = "131.000M"
+//! channels = ["130.025", "131.550", "131.725"]
+//!
+//! [[session]]
+//! sdr = "driver=airspy"
+//! mode = "vdl2"          # rate/center/channels from the mode's plan
+//! ```
+
+use serde::Deserialize;
+use std::path::{Path, PathBuf};
+
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub struct StationFile {
+    pub station_id: String,
+    #[serde(default)]
+    pub outputs: OutputsToml,
+    #[serde(rename = "session")]
+    pub sessions: Vec<SessionToml>,
+}
+
+#[derive(Deserialize, Debug, Default)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub struct OutputsToml {
+    #[serde(default)]
+    pub feed_airframes: bool,
+    pub jsonl: Option<PathBuf>,
+    pub metrics: Option<String>,
+    #[serde(default)]
+    pub udp: Vec<String>,
+    pub sbs: Option<String>,
+    pub beast: Option<String>,
+    pub nmea_tcp: Option<String>,
+    pub mqtt: Option<String>,
+    pub mqtt_topic: Option<String>,
+    pub asf2_grpc: Option<String>,
+    pub asf2_quic: Option<String>,
+    #[serde(default)]
+    pub json: bool,
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub struct SessionToml {
+    /// SDR selector (`driver=rtlsdr,serial=…`); mutually exclusive
+    /// with `file`.
+    pub sdr: Option<String>,
+    /// IQ file replay instead of live hardware.
+    pub file: Option<PathBuf>,
+    /// Sample format for `file` (cf32/cs16/cs8/cu8); guessed from the
+    /// extension when omitted.
+    pub format: Option<String>,
+    pub gain: Option<f64>,
+    pub mode: String,
+    pub sample_rate: Option<f64>,
+    pub center: Option<String>,
+    #[serde(default)]
+    pub channels: Vec<String>,
+    pub receiver_pos: Option<String>,
+    pub demod_effort: Option<String>,
+}
+
+pub fn load(path: &Path) -> anyhow::Result<StationFile> {
+    let text = std::fs::read_to_string(path)
+        .map_err(|e| anyhow::anyhow!("read {}: {e}", path.display()))?;
+    let f: StationFile = toml::from_str(&text)
+        .map_err(|e| anyhow::anyhow!("parse {}: {e}", path.display()))?;
+    anyhow::ensure!(!f.sessions.is_empty(), "{}: no [[session]] entries", path.display());
+    for (i, sess) in f.sessions.iter().enumerate() {
+        anyhow::ensure!(
+            sess.sdr.is_some() ^ sess.file.is_some(),
+            "session {}: exactly one of `sdr` or `file` is required",
+            i + 1
+        );
+    }
+    Ok(f)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_example_config() {
+        let f: StationFile =
+            toml::from_str(include_str!("../../contrib/station.example.toml")).unwrap();
+        assert_eq!(f.station_id, "XX-KSEA-1");
+        assert_eq!(f.sessions.len(), 3);
+        assert!(f.outputs.feed_airframes);
+        assert_eq!(f.sessions[1].mode, "vdl2");
+        assert!(f.sessions[1].channels.is_empty()); // plan-derived
+    }
+
+    #[test]
+    fn rejects_sdr_and_file_together() {
+        let toml = r#"
+station-id = "X"
+[[session]]
+sdr = "driver=rtlsdr"
+file = "x.cf32"
+mode = "acars"
+"#;
+        let f: StationFile = toml::from_str(toml).unwrap();
+        // load() enforces the exclusivity; emulate via the same check
+        assert!(!(f.sessions[0].sdr.is_some() ^ f.sessions[0].file.is_some()));
+    }
+
+    #[test]
+    fn rejects_unknown_fields() {
+        let toml = r#"
+station-id = "X"
+typo-field = 1
+[[session]]
+sdr = "driver=rtlsdr"
+mode = "acars"
+"#;
+        assert!(toml::from_str::<StationFile>(toml).is_err());
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -219,6 +219,12 @@ enum Command {
         #[command(flatten)]
         output: OutputOpts,
     },
+    /// Run a whole station from a config file: several decode
+    /// sessions (modes + SDRs) in one process with shared outputs
+    Station {
+        /// Path to the station TOML config
+        config: PathBuf,
+    },
     /// Inspect a recorded IQ file: duration, power, spectral peaks
     IqInfo {
         /// Path to the IQ file
@@ -536,6 +542,7 @@ fn main() -> anyhow::Result<()> {
         Command::Listen { sdr, gain, tune, output } => {
             listen(&sdr, gain, &tune, &output)
         }
+        Command::Station { config } => run_station_cmd(&config),
         Command::IqInfo { file, sample_rate, format, center_freq, fft_size } => {
             commands::iq_info::run(&file, sample_rate, format.as_deref(), center_freq, fft_size)
         }
@@ -652,6 +659,110 @@ fn main() -> anyhow::Result<()> {
 /// served it. `driver=airspy` / `driver=airspyhf` use the native backends
 /// when compiled in (falling through to SoapySDR otherwise, where a
 /// SoapyAirspy module may exist); `backend=soapy` forces the fallthrough.
+fn run_station_cmd(config: &std::path::Path) -> anyhow::Result<()> {
+    let st = commands::station::load(config)?;
+
+    // Shared outputs (the first session's SessionConfig carries them).
+    let mut udp = st.outputs.udp.clone();
+    if st.outputs.feed_airframes {
+        udp.push(AIRFRAMES_ACARS_UDP.to_owned());
+    }
+    let outputs = runtime::OutputConfig {
+        console: if st.outputs.json { ConsoleFormat::Json } else { ConsoleFormat::Pretty },
+        jsonl: st.outputs.jsonl.clone(),
+        udp,
+        asf2_grpc: st.outputs.asf2_grpc.clone(),
+        asf2_quic: st.outputs.asf2_quic.clone(),
+        asf2_quic_trust: outputs::asf2_quic::TrustMode::SystemRoots,
+        metrics: st.outputs.metrics.clone(),
+        sbs: st.outputs.sbs.clone(),
+        beast: st.outputs.beast.clone(),
+        nmea_tcp: st.outputs.nmea_tcp.clone(),
+        mqtt: st.outputs.mqtt.clone(),
+        mqtt_topic: st.outputs.mqtt_topic.clone().unwrap_or_else(|| "xng".into()),
+    };
+
+    let mut sessions = Vec::new();
+    for (i, sess) in st.sessions.iter().enumerate() {
+        let label = format!("session {} ({})", i + 1, sess.mode);
+        // Tuning: explicit values, or the mode plan via the same
+        // derivation the TUI uses.
+        let tune = TuneOpts {
+            mode: sess.mode.clone(),
+            sample_rate: sess.sample_rate,
+            center_freq: sess.center.clone(),
+            channels: sess.channels.clone(),
+            receiver_pos: sess.receiver_pos.clone(),
+            filter_labels: Vec::new(),
+            exclude_labels: Vec::new(),
+            demod_effort: sess
+                .demod_effort
+                .as_deref()
+                .map(str::parse)
+                .transpose()
+                .map_err(|e: String| anyhow::anyhow!("{label}: {e}"))?,
+        };
+        let (mode, rate, center_hz, channels) = if tune.sample_rate.is_some()
+            && tune.center_freq.is_some()
+            && !tune.channels.is_empty()
+        {
+            parse_tune(&tune)?
+        } else if let Some(sdr) = &sess.sdr {
+            resolve_tune_auto(&tune, sdr)?
+        } else {
+            anyhow::bail!("{label}: file sessions need sample-rate, center, and channels");
+        };
+
+        let (source, sdr_info): (Box<dyn xng_sdr::IqSource>, Option<xng_types::SdrInfo>) =
+            match (&sess.sdr, &sess.file) {
+                (Some(sdr), None) => {
+                    let (src, backend) = open_sdr(sdr, rate, center_hz, sess.gain)?;
+                    let info = xng_types::SdrInfo {
+                        id: sdr.clone(),
+                        driver: backend.to_string(),
+                        serial: None,
+                    };
+                    (src, Some(info))
+                }
+                (None, Some(path)) => {
+                    let fmt = match &sess.format {
+                        Some(f) => f
+                            .parse::<IqFormat>()
+                            .map_err(|e| anyhow::anyhow!("{label}: {e}"))?,
+                        None => IqFormat::from_extension(path)
+                            .ok_or_else(|| anyhow::anyhow!("{label}: pass `format`"))?,
+                    };
+                    let src = FileIqSource::open(path, fmt, rate, center_hz)?;
+                    (
+                        Box::new(src),
+                        Some(xng_types::SdrInfo {
+                            id: "file".into(),
+                            driver: "file".into(),
+                            serial: None,
+                        }),
+                    )
+                }
+                _ => unreachable!("validated in station::load"),
+            };
+
+        sessions.push((
+            source,
+            runtime::SessionConfig {
+                mode,
+                center_hz,
+                channels_hz: channels,
+                station_ident: st.station_id.clone(),
+                sdr: sdr_info,
+                outputs: outputs.clone(),
+                receiver_pos: parse_receiver_pos(&sess.receiver_pos)?,
+                label_filter: Default::default(),
+                demod_effort: tune.demod_effort.unwrap_or(runtime::DemodEffort::Live),
+            },
+        ));
+    }
+    runtime::run_station(sessions)
+}
+
 fn open_sdr(
     sdr: &str,
     sample_rate: f64,

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -20,6 +20,7 @@ use xng_mode_vdl2::Vdl2ChannelDecoder;
 use xng_sdr::{IqSource, SdrError};
 use xng_types::{AppInfo, ChannelInfo, Message, MessageBody, Mode, Provenance, SdrInfo, StationIdentity};
 
+#[derive(Clone)]
 pub struct OutputConfig {
     /// Console format (always on).
     pub console: ConsoleFormat,
@@ -357,6 +358,66 @@ impl ModeChannel {
     }
 }
 
+/// Spawn the configured output sinks on the current tokio runtime.
+fn spawn_outputs(
+    bus: &MessageBus,
+    outputs: &OutputConfig,
+    station: &StationIdentity,
+) -> Vec<tokio::task::JoinHandle<Result<(), std::io::Error>>> {
+    let mut output_tasks = Vec::new();
+    output_tasks.push(tokio::spawn({
+        let rx = bus.subscribe();
+        let fmt = outputs.console;
+        async move {
+            console::run(rx, fmt).await;
+            Ok::<(), std::io::Error>(())
+        }
+    }));
+    if let Some(path) = outputs.jsonl.clone() {
+        let rx = bus.subscribe();
+        output_tasks.push(tokio::spawn(async move { jsonl::run(rx, &path).await }));
+    }
+    for target in outputs.udp.clone() {
+        let rx = bus.subscribe();
+        output_tasks.push(tokio::spawn(acarsdec_json::run(rx, target)));
+    }
+    if let Some(addr) = outputs.sbs.clone() {
+        let rx = bus.subscribe();
+        output_tasks.push(tokio::spawn(crate::outputs::sbs::run(rx, addr)));
+    }
+    if let Some(addr) = outputs.beast.clone() {
+        let rx = bus.subscribe();
+        output_tasks.push(tokio::spawn(crate::outputs::beast::run(rx, addr)));
+    }
+    if let Some(addr) = outputs.nmea_tcp.clone() {
+        let rx = bus.subscribe();
+        output_tasks.push(tokio::spawn(crate::outputs::nmea_tcp::run(rx, addr)));
+    }
+    if let Some(url) = outputs.mqtt.clone() {
+        let rx = bus.subscribe();
+        let topic = outputs.mqtt_topic.clone();
+        let ident = station.ident.clone();
+        output_tasks.push(tokio::spawn(async move {
+            if let Err(e) = crate::outputs::mqtt::run(rx, url, topic, ident).await {
+                tracing::error!("mqtt output: {e}");
+            }
+            Ok(())
+        }));
+    }
+    if let Some(url) = outputs.asf2_grpc.clone() {
+        let rx = bus.subscribe();
+        let (id, ident) = (station.id.to_string(), station.ident.clone());
+        output_tasks.push(tokio::spawn(crate::outputs::asf2_grpc::run(rx, url, id, ident)));
+    }
+    if let Some(target) = outputs.asf2_quic.clone() {
+        let rx = bus.subscribe();
+        let trust = outputs.asf2_quic_trust.clone();
+        let (id, ident) = (station.id.to_string(), station.ident.clone());
+        output_tasks.push(tokio::spawn(crate::outputs::asf2_quic::run(rx, target, trust, id, ident)));
+    }
+    output_tasks
+}
+
 /// Run a decode session until the source ends or `stop` is set.
 pub fn run_session(mut source: Box<dyn IqSource>, cfg: SessionConfig) -> anyhow::Result<()> {
     let sample_rate = source.sample_rate();
@@ -405,57 +466,7 @@ pub fn run_session(mut source: Box<dyn IqSource>, cfg: SessionConfig) -> anyhow:
                 }
             });
         }
-        let mut output_tasks = Vec::new();
-        output_tasks.push(tokio::spawn({
-            let rx = bus.subscribe();
-            let fmt = cfg.outputs.console;
-            async move {
-                console::run(rx, fmt).await;
-                Ok::<(), std::io::Error>(())
-            }
-        }));
-        if let Some(path) = cfg.outputs.jsonl.clone() {
-            let rx = bus.subscribe();
-            output_tasks.push(tokio::spawn(async move { jsonl::run(rx, &path).await }));
-        }
-        for target in cfg.outputs.udp.clone() {
-            let rx = bus.subscribe();
-            output_tasks.push(tokio::spawn(acarsdec_json::run(rx, target)));
-        }
-        if let Some(addr) = cfg.outputs.sbs.clone() {
-            let rx = bus.subscribe();
-            output_tasks.push(tokio::spawn(crate::outputs::sbs::run(rx, addr)));
-        }
-        if let Some(addr) = cfg.outputs.beast.clone() {
-            let rx = bus.subscribe();
-            output_tasks.push(tokio::spawn(crate::outputs::beast::run(rx, addr)));
-        }
-        if let Some(addr) = cfg.outputs.nmea_tcp.clone() {
-            let rx = bus.subscribe();
-            output_tasks.push(tokio::spawn(crate::outputs::nmea_tcp::run(rx, addr)));
-        }
-        if let Some(url) = cfg.outputs.mqtt.clone() {
-            let rx = bus.subscribe();
-            let topic = cfg.outputs.mqtt_topic.clone();
-            let station = cfg.station_ident.clone();
-            output_tasks.push(tokio::spawn(async move {
-                if let Err(e) = crate::outputs::mqtt::run(rx, url, topic, station).await {
-                    tracing::error!("mqtt output: {e}");
-                }
-                Ok(())
-            }));
-        }
-        if let Some(url) = cfg.outputs.asf2_grpc.clone() {
-            let rx = bus.subscribe();
-            let (id, ident) = (station.id.to_string(), station.ident.clone());
-            output_tasks.push(tokio::spawn(crate::outputs::asf2_grpc::run(rx, url, id, ident)));
-        }
-        if let Some(target) = cfg.outputs.asf2_quic.clone() {
-            let rx = bus.subscribe();
-            let trust = cfg.outputs.asf2_quic_trust.clone();
-            let (id, ident) = (station.id.to_string(), station.ident.clone());
-            output_tasks.push(tokio::spawn(crate::outputs::asf2_quic::run(rx, target, trust, id, ident)));
-        }
+        let output_tasks = spawn_outputs(&bus, &cfg.outputs, &station);
 
         // Ctrl-C → graceful stop.
         tokio::spawn({
@@ -627,6 +638,136 @@ pub(crate) fn decode_loop(
         }
     }
     Ok(stats)
+}
+
+/// Run several decode sessions (different modes/SDRs) in one process,
+/// sharing one message bus and one set of outputs — the whole station
+/// as a single unit.
+pub fn run_station(sessions: Vec<(Box<dyn IqSource>, SessionConfig)>) -> anyhow::Result<()> {
+    anyhow::ensure!(!sessions.is_empty(), "station config has no sessions");
+
+    struct Prepared {
+        source: Box<dyn IqSource>,
+        decoders: Vec<(u64, ModeChannel)>,
+        cfg: SessionConfig,
+        capture_center: u64,
+    }
+    let mut prepared = Vec::new();
+    for (source, cfg) in sessions {
+        let sample_rate = source.sample_rate();
+        let capture_center =
+            if cfg.center_hz > 0 { cfg.center_hz } else { source.center_freq_hz() };
+        let mut decoders = Vec::new();
+        for &freq in &cfg.channels_hz {
+            let offset = freq as f64 - capture_center as f64;
+            if 2.0 * (offset.abs() + ModeChannel::passband_hz(cfg.mode)) > sample_rate {
+                anyhow::bail!(
+                    "[{}] channel {:.3} MHz is outside the capture (center {:.3} MHz, rate {} S/s)",
+                    cfg.mode,
+                    freq as f64 / 1e6,
+                    capture_center as f64 / 1e6,
+                    sample_rate
+                );
+            }
+            let mut dec =
+                ModeChannel::new(cfg.mode, sample_rate, offset, freq, cfg.demod_effort)
+                    .map_err(|e| anyhow::anyhow!("[{}] {:.3} MHz: {e}", cfg.mode, freq as f64 / 1e6))?;
+            if let (ModeChannel::Adsb(d), Some((lat, lon))) = (&mut dec, cfg.receiver_pos) {
+                d.set_receiver_position(lat, lon);
+            }
+            decoders.push((freq, dec));
+        }
+        tracing::info!(
+            "station session: {} with {} channel(s) at {:.0} S/s centered {:.3} MHz",
+            cfg.mode,
+            decoders.len(),
+            sample_rate,
+            capture_center as f64 / 1e6
+        );
+        prepared.push(Prepared { source, decoders, cfg, capture_center });
+    }
+
+    let station = StationIdentity::new(prepared[0].cfg.station_ident.clone());
+    let stop = Arc::new(AtomicBool::new(false));
+
+    let rt = tokio::runtime::Runtime::new()?;
+    rt.block_on(async {
+        let bus = MessageBus::new();
+        if let Some(addr) = prepared[0].cfg.outputs.metrics.clone() {
+            let live = LiveState::new();
+            tokio::spawn(async move {
+                if let Err(e) =
+                    crate::outputs::metrics::serve(addr, live, "station".to_string()).await
+                {
+                    tracing::warn!("metrics endpoint failed: {e}");
+                }
+            });
+        }
+        let output_tasks = spawn_outputs(&bus, &prepared[0].cfg.outputs, &station);
+
+        tokio::spawn({
+            let stop = stop.clone();
+            async move {
+                if tokio::signal::ctrl_c().await.is_ok() {
+                    tracing::info!("interrupt received, stopping station");
+                    stop.store(true, Ordering::Relaxed);
+                }
+            }
+        });
+
+        let mut decode_tasks = Vec::new();
+        for mut prep in prepared {
+            let bus = bus.clone();
+            let stop = stop.clone();
+            let station = station.clone();
+            decode_tasks.push(tokio::task::spawn_blocking(move || {
+                let reasm_timeout = match prep.cfg.mode {
+                    Mode::AcarsPoa | Mode::Vdl2 => 120.0,
+                    _ => 660.0,
+                };
+                let mut reasm = (
+                    xng_acars::reasm::Reassembler::new(reasm_timeout),
+                    xng_acars::miam::FileReassembler::new(),
+                );
+                let _ = prep.capture_center;
+                decode_loop(
+                    &mut *prep.source,
+                    std::mem::take(&mut prep.decoders),
+                    station,
+                    prep.cfg.sdr.clone(),
+                    bus,
+                    stop,
+                    None,
+                    Some(&mut reasm),
+                    prep.cfg.label_filter.clone(),
+                )
+            }));
+        }
+        for t in decode_tasks {
+            match t.await? {
+                Ok(stats) => {
+                    for (freq, seen, ok) in stats {
+                        tracing::info!(
+                            "channel {:.3} MHz: {} frame(s), {} with valid CRC",
+                            freq as f64 / 1e6,
+                            seen,
+                            ok
+                        );
+                    }
+                }
+                Err(e) => tracing::warn!("session ended with error: {e}"),
+            }
+        }
+
+        drop(bus);
+        for t in output_tasks {
+            if let Err(e) = t.await? {
+                tracing::warn!("output error: {e}");
+            }
+        }
+        Ok::<(), anyhow::Error>(())
+    })?;
+    Ok(())
 }
 
 /// Suppresses cross-channel duplicates: the same transmission decoded


### PR DESCRIPTION
## What

Task #39 — the platform feature no single-mode decoder has: `xng station station.toml` runs **several decode sessions (modes × SDRs/files) in one process**, sharing one message bus, one output set (one Airframes feed, one JSONL/MQTT/metrics endpoint).

- `runtime::run_station` + `spawn_outputs` extracted from `run_session` (no behavior change to existing commands)
- TOML config, kebab-case with `deny_unknown_fields` (typos fail loudly): `[outputs]` + `[[session]]` entries; `sdr =` for live hardware or `file =` for IQ replay; rate/center/channels derive from the mode's built-in plan when omitted (the TUI's derivation)
- `contrib/station.example.toml` + hardened systemd unit (`ProtectSystem=strict`, `NoNewPrivileges`)
- README section

## Tested

Integration: VDL2 (105 kS/s capture) + ADS-B (modes1) **concurrently in one process** → both hit their bench-gate counts (44 / 323) into a shared JSONL. Config parsing unit tests (example config, sdr/file exclusivity, unknown-field rejection). Full workspace + all four bench gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Whole-station mode" enabling a single process to manage multiple decode sessions (ACARS, VDL2, ADS-B, etc.) with shared outputs, feed configuration, and metrics endpoints via TOML configuration files.
  * Included example configuration and systemd service file for deployment support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->