### PR TITLE
Web dashboard: live map + message stream + per-mode counters (--http)

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,16 @@ A full example config and a hardened systemd unit live in
 [`contrib/`](contrib/). Sessions can also replay IQ files (`file =`
 instead of `sdr =`) — useful for regression runs over recorded nights.
 
+### Web dashboard
+
+`--http 0.0.0.0:8080` (any command, or `http =` in the station config)
+serves a built-in live dashboard: a dark map of decoded **aircraft**
+(Mode S positions, callsigns, altitude/speed) and **vessels** (AIS),
+a streaming message panel, and per-mode counters — the tar1090 /
+AIS-catcher-viewer experience, for every mode at once, with zero extra
+software. The page is embedded in the binary (CDN assets are
+SRI-pinned; RF-sourced strings are HTML-escaped).
+
 ### Feeding and outputs
 
 Every mode and every command shares the same output options:

--- a/contrib/station.example.toml
+++ b/contrib/station.example.toml
@@ -6,6 +6,7 @@ station-id = "XX-KSEA-1"
 feed-airframes = true
 jsonl = "/var/log/xng/messages.jsonl"
 metrics = "0.0.0.0:9090"
+http = "0.0.0.0:8080"          # live web dashboard (map + messages)
 # mqtt = "mqtt://user:pass@broker:1883"
 # sbs = "0.0.0.0:30003"        # Mode S BaseStation TCP
 # beast = "0.0.0.0:30005"      # Mode S Beast TCP (mlat-client compatible)

--- a/src/commands/scan.rs
+++ b/src/commands/scan.rs
@@ -385,6 +385,7 @@ pub(crate) fn scan_group(
             sbs: None,
             beast: None,
             nmea_tcp: None,
+            http: None,
             mqtt: None,
             mqtt_topic: "xng".into(),
         },

--- a/src/commands/station.rs
+++ b/src/commands/station.rs
@@ -47,6 +47,7 @@ pub struct OutputsToml {
     pub sbs: Option<String>,
     pub beast: Option<String>,
     pub nmea_tcp: Option<String>,
+    pub http: Option<String>,
     pub mqtt: Option<String>,
     pub mqtt_topic: Option<String>,
     pub asf2_grpc: Option<String>,

--- a/src/commands/survey.rs
+++ b/src/commands/survey.rs
@@ -426,6 +426,7 @@ fn dwell(
             sbs: None,
             beast: None,
             nmea_tcp: None,
+            http: None,
             mqtt: None,
             mqtt_topic: "xng".into(),
         },

--- a/src/main.rs
+++ b/src/main.rs
@@ -129,6 +129,10 @@ struct OutputOpts {
     /// (shown in console output)
     #[arg(long)]
     gs_file: Option<PathBuf>,
+    /// Serve the live web dashboard (map of decoded aircraft/vessels
+    /// + message stream) on this address (e.g. 0.0.0.0:8080)
+    #[arg(long)]
+    http: Option<String>,
     /// Publish messages as JSON to an MQTT broker
     /// (mqtt://[user:pass@]host[:port])
     #[arg(long)]
@@ -175,6 +179,7 @@ impl OutputOpts {
                 sbs: self.sbs.clone(),
                 beast: self.beast.clone(),
                 nmea_tcp: self.nmea_tcp.clone(),
+                http: self.http.clone(),
                 mqtt: self.mqtt.clone(),
                 mqtt_topic: self.mqtt_topic.clone(),
             },
@@ -642,6 +647,7 @@ fn main() -> anyhow::Result<()> {
                         sbs: None,
                         beast: None,
                         nmea_tcp: None,
+                        http: None,
                         mqtt: None,
                         mqtt_topic: "xng".into(),
                     },
@@ -678,6 +684,7 @@ fn run_station_cmd(config: &std::path::Path) -> anyhow::Result<()> {
         sbs: st.outputs.sbs.clone(),
         beast: st.outputs.beast.clone(),
         nmea_tcp: st.outputs.nmea_tcp.clone(),
+        http: st.outputs.http.clone(),
         mqtt: st.outputs.mqtt.clone(),
         mqtt_topic: st.outputs.mqtt_topic.clone().unwrap_or_else(|| "xng".into()),
     };

--- a/src/outputs/assets/dashboard.html
+++ b/src/outputs/assets/dashboard.html
@@ -1,0 +1,112 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>xng station</title>
+<link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="anonymous">
+<style>
+  :root { color-scheme: dark; }
+  * { box-sizing: border-box; }
+  body { margin: 0; display: flex; height: 100vh; font: 13px/1.4 ui-monospace, SFMono-Regular, Menlo, monospace; background: #0b0e14; color: #c8ccd4; }
+  #map { flex: 1; }
+  #side { width: 420px; display: flex; flex-direction: column; border-left: 1px solid #1c2230; }
+  #head { padding: 10px 12px; border-bottom: 1px solid #1c2230; display: flex; justify-content: space-between; align-items: baseline; }
+  #head b { color: #7aa2f7; font-size: 15px; }
+  #totals { padding: 8px 12px; border-bottom: 1px solid #1c2230; display: flex; flex-wrap: wrap; gap: 6px 14px; }
+  #totals span b { color: #9ece6a; }
+  #msgs { flex: 1; overflow-y: auto; padding: 6px 0; }
+  .msg { padding: 3px 12px; border-bottom: 1px solid #11141c; white-space: pre-wrap; word-break: break-word; }
+  .msg .meta { color: #565f89; }
+  .leaflet-container { background: #0b0e14; }
+  .lbl { background: #16161e; border: 1px solid #2a2f41; border-radius: 3px; color: #c8ccd4; padding: 1px 4px; font: 11px ui-monospace, monospace; white-space: nowrap; }
+</style>
+</head>
+<body>
+<div id="map"></div>
+<div id="side">
+  <div id="head"><b>xng station</b><span id="counts"></span></div>
+  <div id="totals"></div>
+  <div id="msgs"></div>
+</div>
+<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin="anonymous"></script>
+<script>
+const map = L.map('map', { zoomControl: true }).setView([40, -95], 4);
+L.tileLayer('https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png', {
+  attribution: '&copy; OpenStreetMap, &copy; CARTO', maxZoom: 18,
+}).addTo(map);
+
+const planeIcon = trk => L.divIcon({ className: '', html:
+  `<div style="transform:rotate(${trk||0}deg);font-size:18px;color:#7aa2f7">&#9650;</div>`,
+  iconSize: [18, 18], iconAnchor: [9, 9] });
+const shipIcon = cog => L.divIcon({ className: '', html:
+  `<div style="transform:rotate(${cog||0}deg);font-size:14px;color:#9ece6a">&#11041;</div>`,
+  iconSize: [14, 14], iconAnchor: [7, 7] });
+
+const markers = new Map(); // key -> {marker, label}
+let fitted = false;
+
+function upsert(key, lat, lon, icon, label, popup) {
+  if (lat == null || lon == null) return null;
+  let e = markers.get(key);
+  if (!e) {
+    e = { marker: L.marker([lat, lon], { icon }).addTo(map) };
+    e.marker.bindTooltip(label, { permanent: true, direction: 'right', offset: [10, 0], className: 'lbl' });
+    e.marker.bindPopup(popup);
+    markers.set(key, e);
+  } else {
+    e.marker.setLatLng([lat, lon]);
+    e.marker.setIcon(icon);
+    e.marker.setTooltipContent(label);
+    e.marker.setPopupContent(popup);
+  }
+  e.alive = true;
+  return [lat, lon];
+}
+
+async function tick() {
+  try {
+    const r = await fetch('/api/state');
+    const s = await r.json();
+    markers.forEach(e => e.alive = false);
+    const pts = [];
+
+    for (const a of s.aircraft) {
+      // Callsigns arrive over RF: escape before any HTML context.
+      const label = escapeHtml(a.callsign || a.icao);
+      const popup = `<b>${label}</b><br>icao ${escapeHtml(a.icao)}` +
+        (a.alt != null ? `<br>${a.alt} ft` : '') +
+        (a.spd != null ? `<br>${a.spd} kt` : '') +
+        (a.squawk ? `<br>squawk ${a.squawk}` : '') + `<br>${a.msgs} msgs`;
+      const p = upsert('a' + a.icao, a.lat, a.lon, planeIcon(a.trk), label, popup);
+      if (p) pts.push(p);
+    }
+    for (const v of s.vessels) {
+      const label = escapeHtml((v.name || String(v.mmsi)).trim());
+      const popup = `<b>${label}</b><br>mmsi ${v.mmsi}` +
+        (v.sog != null ? `<br>${v.sog} kt` : '');
+      const p = upsert('v' + v.mmsi, v.lat, v.lon, shipIcon(v.cog), label, popup);
+      if (p) pts.push(p);
+    }
+    markers.forEach((e, k) => { if (!e.alive) { map.removeLayer(e.marker); markers.delete(k); } });
+    if (!fitted && pts.length) { map.fitBounds(pts, { maxZoom: 9, padding: [40, 40] }); fitted = true; }
+
+    document.getElementById('counts').textContent =
+      `${s.aircraft.length} aircraft · ${s.vessels.length} vessels`;
+    document.getElementById('totals').innerHTML = Object.entries(s.totals)
+      .sort()
+      .map(([m, n]) => `<span>${m} <b>${n}</b></span>`)
+      .join('');
+    document.getElementById('msgs').innerHTML = s.messages
+      .map(m => `<div class="msg"><span class="meta">${m.t.slice(11, 19)} ${(m.freq / 1e6).toFixed(3)}</span> ${escapeHtml(m.text)}</div>`)
+      .join('');
+  } catch (e) { /* server restarting; retry */ }
+}
+function escapeHtml(s) {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+tick();
+setInterval(tick, 2000);
+</script>
+</body>
+</html>

--- a/src/outputs/http.rs
+++ b/src/outputs/http.rs
@@ -1,0 +1,162 @@
+//! Embedded web dashboard: a live map of decoded aircraft (Mode S CPR)
+//! and vessels (AIS) plus a message stream and per-mode counters —
+//! the in-browser view single-mode decoders get from tar1090 or the
+//! AIS-catcher viewer, here for every mode at once.
+//!
+//! One hand-rolled HTTP endpoint (same pattern as the Prometheus
+//! exporter): `GET /` serves the embedded page, `GET /api/state`
+//! serves the JSON snapshot the page polls.
+
+use serde_json::{json, Value};
+use std::collections::{HashMap, VecDeque};
+use std::sync::{Arc, Mutex};
+use std::time::{SystemTime, UNIX_EPOCH};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::sync::broadcast;
+use xng_types::{Message, MessageBody};
+
+const PAGE: &str = include_str!("assets/dashboard.html");
+const RECENT_CAP: usize = 200;
+/// Drop map entities not heard from in this many seconds.
+const EXPIRE_S: u64 = 300;
+
+#[derive(Default)]
+struct Dash {
+    aircraft: HashMap<String, Value>,
+    vessels: HashMap<u32, Value>,
+    recent: VecDeque<Value>,
+    totals: HashMap<String, u64>,
+}
+
+fn now_s() -> u64 {
+    SystemTime::now().duration_since(UNIX_EPOCH).map(|d| d.as_secs()).unwrap_or(0)
+}
+
+fn update(d: &mut Dash, m: &Message) {
+    let mode = m.mode.as_str().to_string();
+    *d.totals.entry(mode.clone()).or_insert(0) += 1;
+
+    match &m.body {
+        MessageBody::ModeS {
+            icao: Some(icao),
+            callsign,
+            altitude_ft,
+            lat,
+            lon,
+            speed_kt,
+            track_deg,
+            squawk,
+            ..
+        } => {
+            let e = d.aircraft.entry(icao.clone()).or_insert_with(|| json!({}));
+            let o = e.as_object_mut().unwrap();
+            o.insert("icao".into(), json!(icao));
+            o.insert("seen".into(), json!(now_s()));
+            let msgs = o.get("msgs").and_then(Value::as_u64).unwrap_or(0);
+            o.insert("msgs".into(), json!(msgs + 1));
+            for (k, v) in [
+                ("callsign", callsign.as_ref().map(|c| json!(c.trim()))),
+                ("alt", altitude_ft.map(|v| json!(v))),
+                ("lat", lat.map(|v| json!(v))),
+                ("lon", lon.map(|v| json!(v))),
+                ("spd", speed_kt.map(|v| json!(v.round()))),
+                ("trk", track_deg.map(|v| json!(v.round()))),
+                ("squawk", squawk.as_ref().map(|v| json!(v))),
+            ] {
+                if let Some(v) = v {
+                    o.insert(k.into(), v);
+                }
+            }
+        }
+        MessageBody::Ais { mmsi: Some(mmsi), details: Some(det), msg_type, .. } => {
+            let e = d.vessels.entry(*mmsi).or_insert_with(|| json!({}));
+            let o = e.as_object_mut().unwrap();
+            o.insert("mmsi".into(), json!(mmsi));
+            o.insert("seen".into(), json!(now_s()));
+            if let Some(t) = msg_type {
+                o.insert("type".into(), json!(t));
+            }
+            for (k, src) in
+                [("lat", "lat"), ("lon", "lon"), ("sog", "sog_kt"), ("cog", "cog_deg"), ("name", "name")]
+            {
+                if let Some(v) = det.get(src) {
+                    o.insert(k.into(), v.clone());
+                }
+            }
+        }
+        _ => {}
+    }
+
+    // Message stream entry: a one-line summary plus the body.
+    let line = crate::outputs::console::format_message(m, crate::outputs::console::ConsoleFormat::Pretty);
+    d.recent.push_back(json!({
+        "t": m.timestamp.to_rfc3339(),
+        "mode": mode,
+        "freq": m.frequency_hz,
+        "text": line,
+    }));
+    while d.recent.len() > RECENT_CAP {
+        d.recent.pop_front();
+    }
+}
+
+fn snapshot(d: &mut Dash) -> String {
+    let cutoff = now_s().saturating_sub(EXPIRE_S);
+    d.aircraft.retain(|_, v| v["seen"].as_u64().unwrap_or(0) >= cutoff);
+    d.vessels.retain(|_, v| v["seen"].as_u64().unwrap_or(0) >= cutoff);
+    json!({
+        "aircraft": d.aircraft.values().collect::<Vec<_>>(),
+        "vessels": d.vessels.values().collect::<Vec<_>>(),
+        "messages": d.recent.iter().rev().take(60).collect::<Vec<_>>(),
+        "totals": d.totals,
+        "now": now_s(),
+    })
+    .to_string()
+}
+
+pub async fn run(
+    mut rx: broadcast::Receiver<Arc<Message>>,
+    addr: String,
+) -> std::io::Result<()> {
+    let state = Arc::new(Mutex::new(Dash::default()));
+
+    // HTTP listener.
+    let listener = tokio::net::TcpListener::bind(&addr).await?;
+    tracing::info!("dashboard on http://{addr}/");
+    let http_state = state.clone();
+    tokio::spawn(async move {
+        loop {
+            let Ok((mut sock, _)) = listener.accept().await else { break };
+            let state = http_state.clone();
+            tokio::spawn(async move {
+                let mut buf = [0u8; 2048];
+                let n = sock.read(&mut buf).await.unwrap_or(0);
+                let req = String::from_utf8_lossy(&buf[..n]);
+                let path = req.split_whitespace().nth(1).unwrap_or("/");
+                let (ctype, body) = if path.starts_with("/api/state") {
+                    ("application/json", snapshot(&mut state.lock().unwrap()))
+                } else {
+                    ("text/html; charset=utf-8", PAGE.to_string())
+                };
+                let resp = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: {ctype}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    body.len(),
+                    body
+                );
+                let _ = sock.write_all(resp.as_bytes()).await;
+            });
+        }
+    });
+
+    // Bus consumer.
+    loop {
+        match rx.recv().await {
+            Ok(msg) => update(&mut state.lock().unwrap(), &msg),
+            Err(broadcast::error::RecvError::Lagged(n)) => {
+                tracing::warn!("dashboard lagged, dropped {n} messages");
+            }
+            Err(broadcast::error::RecvError::Closed) => break,
+        }
+    }
+    Ok(())
+}

--- a/src/outputs/mod.rs
+++ b/src/outputs/mod.rs
@@ -7,6 +7,7 @@ pub mod beast;
 pub mod asf2_grpc;
 pub mod asf2_quic;
 pub mod console;
+pub mod http;
 pub mod jsonl;
 pub mod metrics;
 pub mod mqtt;

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -41,6 +41,8 @@ pub struct OutputConfig {
     pub beast: Option<String>,
     /// NMEA (AIVDM) TCP server address.
     pub nmea_tcp: Option<String>,
+    /// Web dashboard listen address (live map + message stream).
+    pub http: Option<String>,
     /// MQTT broker URL (mqtt://[user:pass@]host[:port]).
     pub mqtt: Option<String>,
     /// MQTT topic prefix (messages publish to `<prefix>/<mode>`).
@@ -392,6 +394,10 @@ fn spawn_outputs(
     if let Some(addr) = outputs.nmea_tcp.clone() {
         let rx = bus.subscribe();
         output_tasks.push(tokio::spawn(crate::outputs::nmea_tcp::run(rx, addr)));
+    }
+    if let Some(addr) = outputs.http.clone() {
+        let rx = bus.subscribe();
+        output_tasks.push(tokio::spawn(crate::outputs::http::run(rx, addr)));
     }
     if let Some(url) = outputs.mqtt.clone() {
         let rx = bus.subscribe();


### PR DESCRIPTION
## What

Task #40 — the second half of the platform pair: `--http 0.0.0.0:8080` (any command, or `http =` in the station config) serves a **built-in live dashboard**:

- dark Leaflet map of decoded **aircraft** (Mode S positions, callsign, alt/speed/squawk, heading-rotated markers) and **vessels** (AIS, COG-rotated)
- streaming message panel + per-mode counters
- page embedded in the binary; one hand-rolled endpoint pair (`/`, `/api/state`) following the Prometheus-exporter pattern — no web framework dependency

Security: CDN assets are SRI-pinned (hashes verified against unpkg at build time of this PR); RF-sourced strings (callsigns, vessel names — attacker-controllable over the air) are HTML-escaped before any DOM context.

## Tested

Station-mode integration: ADS-B + AIS file replay → `/api/state` serves the real aircraft (AMC421, full kinematics) and Sacramento AIS base stations with positions; HTML page serves. Full workspace + bench gates green.

Pairs with #102 for the v0.15.0 platform release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)