### PR TITLE
v0.15.0: the platform release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3702,7 +3702,7 @@ dependencies = [
 
 [[package]]
 name = "xng"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3743,7 +3743,7 @@ dependencies = [
 
 [[package]]
 name = "xng-acars"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "base64",
  "crc",
@@ -3755,7 +3755,7 @@ dependencies = [
 
 [[package]]
 name = "xng-dsp"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "crc",
  "num-complex",
@@ -3764,7 +3764,7 @@ dependencies = [
 
 [[package]]
 name = "xng-mode-acars"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "chrono",
  "num-complex",
@@ -3776,7 +3776,7 @@ dependencies = [
 
 [[package]]
 name = "xng-mode-adsb"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "chrono",
  "num-complex",
@@ -3787,7 +3787,7 @@ dependencies = [
 
 [[package]]
 name = "xng-mode-aero"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "chrono",
  "num-complex",
@@ -3801,7 +3801,7 @@ dependencies = [
 
 [[package]]
 name = "xng-mode-ais"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "chrono",
  "num-complex",
@@ -3812,7 +3812,7 @@ dependencies = [
 
 [[package]]
 name = "xng-mode-hfdl"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "chrono",
  "num-complex",
@@ -3825,7 +3825,7 @@ dependencies = [
 
 [[package]]
 name = "xng-mode-iridium"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "chrono",
  "crc",
@@ -3840,7 +3840,7 @@ dependencies = [
 
 [[package]]
 name = "xng-mode-stdc"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "chrono",
  "num-complex",
@@ -3853,7 +3853,7 @@ dependencies = [
 
 [[package]]
 name = "xng-mode-vdl2"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "chrono",
  "num-complex",
@@ -3866,7 +3866,7 @@ dependencies = [
 
 [[package]]
 name = "xng-proto"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "chrono",
  "prost",
@@ -3877,7 +3877,7 @@ dependencies = [
 
 [[package]]
 name = "xng-sdr"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "num-complex",
  "pkg-config",
@@ -3888,7 +3888,7 @@ dependencies = [
 
 [[package]]
 name = "xng-types"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "chrono",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["legacy"]
 resolver = "2"
 
 [workspace.package]
-version = "0.14.0"
+version = "0.15.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/airframesio/xng"


### PR DESCRIPTION
Version bump for the platform round (PRs #100–#103):

- **Station mode** — the whole receive site in one process: several modes across several SDRs (or IQ replays), one shared Airframes feed/outputs/metrics. `xng station config.toml`, example config + hardened systemd unit in `contrib/`. No single-mode decoder can do this.
- **Web dashboard** — `--http`: built-in live map of decoded aircraft (Mode S) and vessels (AIS), streaming message panel, per-mode counters. SRI-pinned CDN assets, RF-sourced strings escaped.
- **HFDL forensic round** — emission parity with dumphfdl's LPDU envelopes, 33/37 (89 %) with the gap characterized as deep-weak; fourth CI-fenced mode.
- **CPU benchmarks + `--demod-effort`** — every mode now real-time on Pi-class hardware (AIS 3.0× → 8.6×; ADS-B live effort 16.6× at 97 % recall).

Tag v0.15.0 follows the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)