### PR TITLE
Dashboard: escape squawk in popup HTML

### DIFF
--- a/src/outputs/assets/dashboard.html
+++ b/src/outputs/assets/dashboard.html
@@ -77,7 +77,7 @@ async function tick() {
       const popup = `<b>${label}</b><br>icao ${escapeHtml(a.icao)}` +
         (a.alt != null ? `<br>${a.alt} ft` : '') +
         (a.spd != null ? `<br>${a.spd} kt` : '') +
-        (a.squawk ? `<br>squawk ${a.squawk}` : '') + `<br>${a.msgs} msgs`;
+        (a.squawk ? `<br>squawk ${escapeHtml(String(a.squawk))}` : '') + `<br>${a.msgs} msgs`;
       const p = upsert('a' + a.icao, a.lat, a.lon, planeIcon(a.trk), label, popup);
       if (p) pts.push(p);
     }


### PR DESCRIPTION
Security-review follow-up to #103: `a.squawk` interpolated into popup HTML unescaped. Our decoder constrains squawk to four digits today, so it isn't currently exploitable — but every RF-derived field goes through `escapeHtml` on principle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)