### PR TITLE
README: dashboard v2 features

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,8 +297,11 @@ instead of `sdr =`) — useful for regression runs over recorded nights.
 
 `--http 0.0.0.0:8080` (any command, or `http =` in the station config)
 serves a built-in live dashboard: a dark map of decoded **aircraft**
-(Mode S positions, callsigns, altitude/speed) and **vessels** (AIS),
-a streaming message panel, and per-mode counters — the tar1090 /
+(Mode S positions, callsigns, altitude/speed) and **vessels** (AIS)
+with **position trails**, a click-to-focus **entity table**, countries
+from the ICAO/MID allocation tables, registrations/types from an
+optional `--aircraft-db` CSV (tar1090/Mictronics format), a streaming
+message panel, and per-mode counters — the tar1090 /
 AIS-catcher-viewer experience, for every mode at once, with zero extra
 software. The page is embedded in the binary (CDN assets are
 SRI-pinned; RF-sourced strings are HTML-escaped).


### PR DESCRIPTION
The #106 chain's README patch failed its anchor assert and the chain continued without it — this is that paragraph (trails, entity table, enrichment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)