### PR TITLE
ADS-B: native 2.4 MS/s (fractional path) + readsb benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,8 +205,9 @@ xng listen --sdr driver=rtlsdr --mode iridium -r 2000000 -c 1626.250M \
 xng listen --sdr driver=rtlsdr --mode ais -r 2400000 -c 162.000M \
     --channels 161.975,162.025
 
-# Mode S / ADS-B (consumes the whole capture)
-xng listen --sdr driver=rtlsdr --mode adsb -r 2000000 -c 1090.000M --channels 1090
+# Mode S / ADS-B (consumes the whole capture; 2.4 MS/s — the
+# RTL-SDR's best rate — decodes natively via the fractional path)
+xng listen --sdr driver=rtlsdr --mode adsb -r 2400000 -c 1090.000M --channels 1090
 ```
 
 ### Site survey / soak test

--- a/crates/xng-mode-adsb/src/demod.rs
+++ b/crates/xng-mode-adsb/src/demod.rs
@@ -29,8 +29,10 @@ const SHORT_BITS: usize = 56;
 const NOISE_ALPHA: f32 = 1e-4;
 
 pub struct PpmDemod {
-    /// Samples per half µs.
+    /// Samples per half µs (integer path).
     half: usize,
+    /// Samples per half µs when fractional (prefix-sum slot path).
+    half_f: Option<f64>,
     /// Fractional timing phases active (2 MS/s input): a pulse landing
     /// between samples splits its energy across two half-µs slots and
     /// weak frames decide wrong. The original grid is scanned exactly
@@ -61,15 +63,19 @@ impl PpmDemod {
     /// cost; `&[0.5]` is the live/embedded compromise.
     pub fn with_phases(input_rate: f64, fracs: &[f32]) -> Result<Self, String> {
         let spu = input_rate / 1e6;
-        if (spu - spu.round()).abs() > 1e-9 || (spu.round() as usize) % 2 != 0 || spu < 2.0 {
+        if spu < 2.0 {
             return Err(format!(
-                "Mode S needs an even integer number of samples per µs; \
-                 {input_rate} S/s gives {spu} (use e.g. 2000000)"
+                "Mode S needs at least 2 samples per µs; {input_rate} S/s gives {spu}"
             ));
         }
-        let two_phase = (spu.round() as usize) == 2 && !fracs.is_empty();
+        // Non-integer (or odd) samples/µs runs the fractional-slot path
+        // (prefix-sum integrals): 2.4 MS/s — the RTL-SDR's best rate —
+        // works natively.
+        let fractional = (spu - spu.round()).abs() > 1e-9 || (spu.round() as usize) % 2 != 0;
+        let two_phase = !fractional && (spu.round() as usize) == 2 && !fracs.is_empty();
         Ok(Self {
-            half: spu.round() as usize / 2,
+            half: if fractional { 1 } else { spu.round() as usize / 2 },
+            half_f: if fractional { Some(spu / 2.0) } else { None },
             two_phase,
             fracs: fracs.to_vec(),
             last_sample: Complex::new(0.0, 0.0),
@@ -85,6 +91,109 @@ impl PpmDemod {
     fn slot(power: &[f32], half: usize, base: usize, slot: usize) -> f32 {
         let s = base + slot * half;
         power[s..s + half].iter().sum()
+    }
+
+    /// Fractional-rate variant: energy in half-µs slot `slot` from a
+    /// prefix-sum array, with linearly weighted fractional edges.
+    /// `half_f` is samples per half-µs (e.g. 1.2 at 2.4 MS/s).
+    #[inline]
+    fn slot_f(prefix: &[f64], half_f: f64, frac: f64, base: usize, slot: usize) -> f32 {
+        let start = base as f64 + frac + slot as f64 * half_f;
+        let end = start + half_f;
+        let (s0, s1) = (start.floor() as usize, end.floor() as usize);
+        let (f0, f1) = (start - s0 as f64, end - s1 as f64);
+        if s1 + 1 >= prefix.len() {
+            return 0.0;
+        }
+        // ∫ start..end of the sample-held power.
+        let whole = prefix[s1] - prefix[s0 + 1];
+        let head = (prefix[s0 + 1] - prefix[s0]) * (1.0 - f0);
+        let tail = (prefix[s1 + 1] - prefix[s1]) * f1;
+        (whole + head + tail) as f32
+    }
+
+    /// Scan a fractional-rate power stream (prefix sums) — the path
+    /// for rates that are not an even integer number of samples/µs
+    /// (2.4 MS/s natively, the RTL-SDR's best rate). Same candidate
+    /// gates and CRC arbitration as the integer path; the timing grid
+    /// is every input sample (finer than 0.5 µs above 2 MS/s).
+    #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::too_many_arguments)]
+    fn scan_f(
+        power: &[f32],
+        prefix: &[f64],
+        half_f: f64,
+        frac: f64,
+        end: usize,
+        noise: &mut f32,
+        validator: &mut FrameValidator,
+        track_noise: bool,
+    ) -> Vec<(usize, AdsbFrame)> {
+        let mut out = Vec::new();
+        let mut i = 0;
+        while i < end {
+            if track_noise {
+                *noise += NOISE_ALPHA * (power[i] - *noise);
+            }
+
+            let pulses: f32 = PREAMBLE_PULSES
+                .iter()
+                .map(|&p| Self::slot_f(prefix, half_f, frac, i, p))
+                .sum::<f32>()
+                / 4.0;
+            if pulses < *noise * half_f as f32 * 1.2 {
+                i += 1;
+                continue;
+            }
+            let quiet_max = PREAMBLE_QUIET
+                .iter()
+                .map(|&q| Self::slot_f(prefix, half_f, frac, i, q))
+                .fold(0.0f32, f32::max);
+            let pulse_min = PREAMBLE_PULSES
+                .iter()
+                .map(|&p| Self::slot_f(prefix, half_f, frac, i, p))
+                .fold(f32::MAX, f32::min);
+            if pulse_min < quiet_max * PULSE_QUIET_RATIO {
+                i += 1;
+                continue;
+            }
+
+            let data_off = PREAMBLE_US * 2;
+            // Bit decisions sample interpolated power at each half-bit
+            // CENTER: the slot-integral splits a boundary-straddling
+            // sample's energy across both halves and flips bits at
+            // adverse sampling phases (measured at 2.4 MS/s); the
+            // center is always inside its pulse.
+            let center = |slot: usize| -> f32 {
+                let pos = i as f64 + frac + (slot as f64 + 0.5) * half_f;
+                let s0 = pos.floor() as usize;
+                let f = (pos - s0 as f64) as f32;
+                if s0 + 1 >= power.len() {
+                    return 0.0;
+                }
+                power[s0] * (1.0 - f) + power[s0 + 1] * f
+            };
+            let bit = |k: usize| -> u8 {
+                let first = center(data_off + 2 * k);
+                let second = center(data_off + 2 * k + 1);
+                (first > second) as u8
+            };
+            let df = (0..5).fold(0u8, |v, k| (v << 1) | bit(k));
+            let nbits = if df >= 16 { LONG_BITS } else { SHORT_BITS };
+            let mut bytes = vec![0u8; nbits / 8];
+            for k in 0..nbits {
+                bytes[k / 8] = (bytes[k / 8] << 1) | bit(k);
+            }
+
+            let level = 10.0 * (pulses / half_f as f32).max(1e-12).log10();
+            if let Some(frame) = validator.validate(&bytes, level) {
+                out.push((i, frame));
+                i += (((PREAMBLE_US + nbits) * 2) as f64 * half_f) as usize;
+            } else {
+                i += 1;
+            }
+        }
+        out
     }
 
     /// Scan one power grid; emits (position, frame).
@@ -166,12 +275,54 @@ impl PpmDemod {
             }
         }
 
-        let frame_samples = (PREAMBLE_US + LONG_BITS) * 2 * self.half;
+        let frame_samples = match self.half_f {
+            Some(hf) => (((PREAMBLE_US + LONG_BITS) * 2) as f64 * hf).ceil() as usize + 2,
+            None => (PREAMBLE_US + LONG_BITS) * 2 * self.half,
+        };
         let mut out = Vec::new();
         if self.power.len() < frame_samples {
             return out;
         }
         let end = self.power.len() - frame_samples;
+
+        if let Some(hf) = self.half_f {
+            let mut prefix = Vec::with_capacity(self.power.len() + 1);
+            let mut acc = 0.0f64;
+            prefix.push(0.0);
+            for &p in &self.power {
+                acc += p as f64;
+                prefix.push(acc);
+            }
+            // Sub-sample phase passes (the integer path's grid sweep,
+            // fractionally): candidates at each offset, merged by
+            // bytes + position.
+            let mut found: Vec<(usize, AdsbFrame)> = Vec::new();
+            for (pass, frac) in [0.0f64, 0.25, 0.5, 0.75].into_iter().enumerate() {
+                let pass_found = Self::scan_f(
+                    &self.power,
+                    &prefix,
+                    hf,
+                    frac,
+                    end,
+                    &mut self.noise,
+                    &mut self.validator,
+                    pass == 0,
+                );
+                for (pos, f) in pass_found {
+                    let dup = found.iter().any(|(p, g)| {
+                        g.bytes == f.bytes
+                            && (*p as i64 - pos as i64).unsigned_abs() < frame_samples as u64
+                    });
+                    if !dup {
+                        found.push((pos, f));
+                    }
+                }
+            }
+            found.sort_by_key(|(p, _)| *p);
+            out.extend(found.into_iter().map(|(_, f)| f));
+            self.power.drain(..end.min(self.power.len()));
+            return out;
+        }
 
         let raw_found = Self::scan(
             &self.power,

--- a/crates/xng-mode-adsb/tests/end_to_end.rs
+++ b/crates/xng-mode-adsb/tests/end_to_end.rs
@@ -61,6 +61,32 @@ fn works_at_higher_sample_rates() {
 
 #[test]
 fn rejects_unsupported_rates() {
-    assert!(AdsbDecoder::new(2_400_000.0).is_err());
+    // 2.4 MS/s (non-integer samples/µs) runs the fractional path now.
+    assert!(AdsbDecoder::new(2_400_000.0).is_ok());
     assert!(AdsbDecoder::new(1_000_000.0).is_err());
+}
+
+/// Native 2.4 MS/s (12 samples per 5 µs): synthesize at 12 MS/s
+/// (integer modulator grid) and decimate by 5 — exact, no resampler.
+#[test]
+fn decodes_at_2400ksps_fractional_path() {
+    let mut hi = vec![Complex::new(0.0f32, 0.0f32); 6000];
+    hi.extend(frame_iq(&ID_FRAME, 12, 0.6));
+    hi.extend(vec![Complex::new(0.0, 0.0); 12000]);
+    hi.extend(frame_iq(&POS_FRAME, 12, 0.4));
+    hi.extend(vec![Complex::new(0.0, 0.0); 6000]);
+    let mut iq: Vec<Complex<f32>> = hi.into_iter().step_by(5).collect();
+    let mut noise = Noise(0x0123_4567_89ab_cdef);
+    for s in &mut iq {
+        *s += Complex::new(noise.next() * 0.02, noise.next() * 0.02);
+    }
+
+    let mut dec = AdsbDecoder::new(2_400_000.0).unwrap();
+    let mut frames = Vec::new();
+    for chunk in iq.chunks(777) {
+        frames.extend(dec.process(chunk));
+    }
+    assert_eq!(frames.len(), 2, "expected both frames: {frames:?}");
+    assert_eq!(frames[0].callsign.as_deref(), Some("KLM1023"));
+    assert_eq!(frames[1].altitude_ft, Some(38_000));
 }

--- a/docs/notes/BENCHMARKS.md
+++ b/docs/notes/BENCHMARKS.md
@@ -126,6 +126,23 @@ xng decode ais_6m.cs16 -f cs16 -m ais -r 6000000 -c 162000000 --channels 161.975
 AIS-catcher -r CS16 ais_6m.cs16 -s 6000000 -n
 ```
 
+**readsb round (2026-06-12)**: readsb (wiedehopf, built from source,
+`--no-fix`) is the strongest ADS-B oracle: **167 unique** on the
+2.4 MS/s resample of modes1, vs dump1090-fa's 162 and our 161 (at
+2 MS/s). Two improvements followed:
+
+1. **Native 2.4 MS/s support** — the RTL-SDR's best rate, previously
+   rejected (integer-samples/µs requirement). The fractional path
+   integrates half-µs slots from prefix sums with fractional edges and
+   decides bits at interpolated half-bit **centers** (the slot
+   integral splits a boundary-straddling sample's energy across both
+   halves and flips bits at adverse phases — measured), with four
+   sub-sample phase passes merged by bytes+position.
+2. Result: **157 unique at 2.4 MS/s** on readsb's own input file
+   (94 % of readsb; was 0 — the rate didn't work at all). The 2 MS/s
+   path is untouched (gate: 323). Remaining readsb edge: its
+   phase-classified bit templates.
+
 ## Decode CPU (×-realtime, Apple M-series; `bench/cpu.sh`)
 
 | mode | effort | speed | decode recall |


### PR DESCRIPTION
## What

Task #44 — benchmarked against **readsb** (wiedehopf, built from source, `--no-fix`), which turns out to be the strongest ADS-B oracle: **167 unique** on the 2.4 MS/s resample of modes1 (dump1090-fa: 162; xng at 2 MS/s: 161).

Improvement: a **fractional-rate demod path** accepting any rate ≥ 2 MS/s — including **2.4 MS/s, the RTL-SDR's best rate, which previously errored out**:

- preamble gates from prefix-sum slot integrals with fractional edges
- bit decisions at interpolated half-bit **centers** — the slot integral splits a boundary-straddling sample's energy across both halves and flips bits at adverse sampling phases (found via a phase probe at 2.4 MS/s)
- four sub-sample phase passes merged by bytes + position (the fractional analogue of the 2 MS/s grid sweep)

## Measured

| | unique frames (same 2.4M file) |
|---|---|
| readsb `--no-fix` | 167 |
| **xng @2.4 MS/s** | **157 (94 %)** — was 0 (rate rejected) |
| xng @2 MS/s (original capture) | 161 (untouched; gate 323 green) |

Remaining readsb edge: phase-classified bit templates — documented as the next lever. New loopback test synthesizes at 12 MS/s and decimates by 5 (exact).

## Testing
Workspace + all four bench gates green; new `decodes_at_2400ksps_fractional_path` loopback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled native support for 2.4 MS/s RTL-SDR sample rate with optimized fractional-rate decoding

* **Documentation**
  * Updated quick-start example to use 2.4 MS/s sample rate configuration
  * Added performance benchmarks demonstrating 2.4 MS/s decoding results

<!-- end of auto-generated comment: release notes by coderabbit.ai -->