### PR TITLE
ADS-B 2.4M: denser phase-pass grid (157 → 164 unique, 98% of readsb)

### DIFF
--- a/crates/xng-mode-adsb/src/demod.rs
+++ b/crates/xng-mode-adsb/src/demod.rs
@@ -164,6 +164,13 @@ impl PpmDemod {
             // sample's energy across both halves and flips bits at
             // adverse sampling phases (measured at 2.4 MS/s); the
             // center is always inside its pulse.
+            // Bit decisions at interpolated half-bit centers of the
+            // pass phase. Falsified alternatives (measured on the
+            // readsb benchmark file): trimmed-slot integrals 152,
+            // preamble-contrast phase refinement 154, vs centers 157.
+            // (Per-candidate phase refinement by preamble contrast was
+            // also tried: 154 — overfits preamble noise. Plain pass-
+            // grid centers win.)
             let center = |slot: usize| -> f32 {
                 let pos = i as f64 + frac + (slot as f64 + 0.5) * half_f;
                 let s0 = pos.floor() as usize;
@@ -297,7 +304,13 @@ impl PpmDemod {
             // fractionally): candidates at each offset, merged by
             // bytes + position.
             let mut found: Vec<(usize, AdsbFrame)> = Vec::new();
-            for (pass, frac) in [0.0f64, 0.25, 0.5, 0.75].into_iter().enumerate() {
+            // Effort follows the integer path's grid choice: live (one
+            // extra phase configured) runs 2 passes; max runs 16
+            // (measured asymptote: 157 → 163 → 164 unique at 4/8/16).
+            let npass: usize = if self.fracs.len() <= 1 { 2 } else { 16 };
+            for (pass, frac) in
+                (0..npass).map(|k| k as f64 / npass as f64).enumerate()
+            {
                 let pass_found = Self::scan_f(
                     &self.power,
                     &prefix,

--- a/docs/notes/BENCHMARKS.md
+++ b/docs/notes/BENCHMARKS.md
@@ -140,8 +140,17 @@ AIS-catcher -r CS16 ais_6m.cs16 -s 6000000 -n
    sub-sample phase passes merged by bytes+position.
 2. Result: **157 unique at 2.4 MS/s** on readsb's own input file
    (94 % of readsb; was 0 — the rate didn't work at all). The 2 MS/s
-   path is untouched (gate: 323). Remaining readsb edge: its
-   phase-classified bit templates.
+   path is untouched (gate: 323).
+
+**Round 2 (same day): 157 → 164 (98 % of readsb).** The winning lever
+was simply a denser sub-sample pass grid (4 → 8 → 16 passes measured
+157 → 163 → 164; asymptote at 16), now effort-gated (live = 2 passes
+= 148 unique within a Pi budget; max = 16). Falsified along the way,
+with numbers: trimmed-slot bit integrals (152 — edge energy hurts
+more than extra energy helps) and per-candidate preamble-contrast
+phase refinement (154 — overfits preamble noise). xng also decodes
+**5 frames readsb misses**; the remaining 4-frame readsb edge is its
+phase-classified bit templates.
 
 ## Decode CPU (×-realtime, Apple M-series; `bench/cpu.sh`)
 


### PR DESCRIPTION
## What

Task #45 — closing the 2.4 MS/s gap to readsb with measured experiments:

| approach | unique (readsb file) |
|---|---|
| center taps, 4 passes (baseline) | 157 |
| trimmed-slot integrals | 152 ✗ falsified |
| preamble-contrast phase refinement | 154 ✗ falsified |
| **center taps, 8 passes** | 163 |
| **center taps, 16 passes** | **164** (asymptote) |
| readsb `--no-fix` | 167 (xng decodes **5 it misses**) |

The honest winner is simple: a denser sub-sample pass grid. Both classic "smarter" approaches measured worse and are documented with their numbers. Effort-gated: `live` = 2 passes (148 unique, within a Pi budget), `max` = 16.

The remaining 4-frame readsb edge is its phase-classified bit templates — diminishing returns vs the CPU and complexity, parked with the harness in place.

## Testing
Workspace + bench gates green (2 MS/s path untouched at 323); the 2.4M loopback covers the dense grid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)