### PR TITLE
v0.16.0: 2.4 MS/s, dashboard v2, readsb benchmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3702,7 +3702,7 @@ dependencies = [
 
 [[package]]
 name = "xng"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3743,7 +3743,7 @@ dependencies = [
 
 [[package]]
 name = "xng-acars"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "base64",
  "crc",
@@ -3755,7 +3755,7 @@ dependencies = [
 
 [[package]]
 name = "xng-dsp"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "crc",
  "num-complex",
@@ -3764,7 +3764,7 @@ dependencies = [
 
 [[package]]
 name = "xng-mode-acars"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "chrono",
  "num-complex",
@@ -3776,7 +3776,7 @@ dependencies = [
 
 [[package]]
 name = "xng-mode-adsb"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "chrono",
  "num-complex",
@@ -3787,7 +3787,7 @@ dependencies = [
 
 [[package]]
 name = "xng-mode-aero"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "chrono",
  "num-complex",
@@ -3801,7 +3801,7 @@ dependencies = [
 
 [[package]]
 name = "xng-mode-ais"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "chrono",
  "num-complex",
@@ -3812,7 +3812,7 @@ dependencies = [
 
 [[package]]
 name = "xng-mode-hfdl"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "chrono",
  "num-complex",
@@ -3825,7 +3825,7 @@ dependencies = [
 
 [[package]]
 name = "xng-mode-iridium"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "chrono",
  "crc",
@@ -3840,7 +3840,7 @@ dependencies = [
 
 [[package]]
 name = "xng-mode-stdc"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "chrono",
  "num-complex",
@@ -3853,7 +3853,7 @@ dependencies = [
 
 [[package]]
 name = "xng-mode-vdl2"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "chrono",
  "num-complex",
@@ -3866,7 +3866,7 @@ dependencies = [
 
 [[package]]
 name = "xng-proto"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "chrono",
  "prost",
@@ -3877,7 +3877,7 @@ dependencies = [
 
 [[package]]
 name = "xng-sdr"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "num-complex",
  "pkg-config",
@@ -3888,7 +3888,7 @@ dependencies = [
 
 [[package]]
 name = "xng-types"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "chrono",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["legacy"]
 resolver = "2"
 
 [workspace.package]
-version = "0.15.0"
+version = "0.16.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/airframesio/xng"


### PR DESCRIPTION
Version bump for PRs #106–#110:

- **ADS-B native 2.4 MS/s** — the RTL-SDR's best rate, previously rejected outright: fractional-slot demod path with center-tap decisions and a 16-pass sub-sample grid → **164 unique (98 % of readsb) with 5 frames readsb misses**; effort-gated for Pi-class live use
- **readsb benchmarked** as the strongest Mode S oracle (167), added to BENCHMARKS.md
- **Dashboard v2**: position trails, click-to-focus entity table, countries from vendored ICAO/MID allocation tables, `--aircraft-db` registrations/types
- **README benchmark chart**; release notes now include a generated *What's changed* changelog (this release is the first to carry it)
- ADS-B rounds 3–4 falsifications recorded with numbers

Tag v0.16.0 follows the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)