### PR TITLE
BENCHMARKS: ADS-B round-5 falsification (suspect-bit targeted repair)

### DIFF
--- a/docs/notes/BENCHMARKS.md
+++ b/docs/notes/BENCHMARKS.md
@@ -163,6 +163,17 @@ no clock policy fixes; a cache large enough to be pollution-proof
 would weaken the overlay-DF trust model). The ADS-B demod stands at
 its measured best: 161 @2 MS/s, 164 @2.4 MS/s.
 
+**Round 5 (2026-06-12)**: disagreement-flagged suspect bits
+(center-tap vs slot-integral statistics) feeding syndrome-targeted
+1/2-bit repair — implemented, measured, **decoded set bit-identical
+to baseline** (the suspect-pair mechanism never converted a frame on
+this capture). Reverted per the discipline: unmeasurable benefit
+doesn't ship. Conclusion of the ADS-B campaign on current evidence:
+the demod is at its measured ceiling on these captures; the levers
+that could move it further are (a) new bench captures with genuinely
+weak/dense traffic (the current ones saturate), and (b) readsb-style
+per-phase bit templates, parked at an estimated ≤4-frame payoff.
+
 ## Decode CPU (×-realtime, Apple M-series; `bench/cpu.sh`)
 
 | mode | effort | speed | decode recall |


### PR DESCRIPTION
Round 5 of the ADS-B campaign, concluded honestly: disagreement-flagged suspect bits (center-tap vs slot-integral decision statistics) feeding syndrome-targeted 1- and 2-bit repair — implemented, measured on the readsb benchmark file, and the decoded set came out **bit-identical to baseline**. The mechanism never converted a frame. Reverted per the campaign discipline (unmeasurable benefit doesn't ship), recorded with the previous rounds' falsifications.

**Campaign conclusion on current evidence**: the demod is at its measured ceiling on these captures (161 @2 MS/s = 99 % of dump1090-fa; 164 @2.4 MS/s = 98 % of readsb; 5–7 exclusive frames vs each). What would move it further: bench captures with genuinely weak/dense traffic, or per-phase bit templates at an estimated ≤4-frame payoff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated ADS-B demodulation benchmark documentation with latest optimization analysis and performance metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->