### PR TITLE
ADS-B: two-sighting ICAO confirmation kills phantom frames on live RF

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,3 @@
+{
+  "mcpServers": {}
+}

--- a/crates/xng-mode-adsb/src/demod.rs
+++ b/crates/xng-mode-adsb/src/demod.rs
@@ -193,7 +193,8 @@ impl PpmDemod {
             }
 
             let level = 10.0 * (pulses / half_f as f32).max(1e-12).log10();
-            if let Some(frame) = validator.validate(&bytes, level) {
+            if let Some(frame) = validator.validate(&bytes, level, i) {
+                out.append(&mut validator.released);
                 out.push((i, frame));
                 i += (((PREAMBLE_US + nbits) * 2) as f64 * half_f) as usize;
             } else {
@@ -253,7 +254,8 @@ impl PpmDemod {
             }
 
             let level = 10.0 * (pulses / half as f32).max(1e-12).log10();
-            if let Some(frame) = validator.validate(&bytes, level) {
+            if let Some(frame) = validator.validate(&bytes, level, i) {
+                out.append(&mut validator.released);
                 out.push((i, frame));
                 i += (PREAMBLE_US + nbits) * 2 * half;
             } else {

--- a/crates/xng-mode-adsb/src/frame.rs
+++ b/crates/xng-mode-adsb/src/frame.rs
@@ -75,19 +75,32 @@ pub struct AdsbFrame {
 
 /// Validates candidate frames and learns ICAO addresses from squitters.
 pub struct FrameValidator {
-    /// ICAO → frame counter at last sighting.
+    /// ICAO → frame counter at last sighting (confirmed aircraft only).
     icao_cache: HashMap<u32, u64>,
     counter: u64,
+    /// First sighting of a not-yet-confirmed ICAO: the held frame and
+    /// the sighting-counter at arrival. A second clean frame with the
+    /// same address confirms (random CRC-passing noise never repeats
+    /// an address); both frames are then released. Live captures
+    /// measured ~30 phantom single-sighting DF17s/minute without this.
+    pending: HashMap<u32, (Vec<u8>, f32, usize, u64)>,
+    /// Frames released by a confirmation, drained by the caller.
+    pub released: Vec<(usize, AdsbFrame)>,
 }
 
 impl FrameValidator {
     pub fn new() -> Self {
-        Self { icao_cache: HashMap::new(), counter: 0 }
+        Self {
+            icao_cache: HashMap::new(),
+            counter: 0,
+            pending: HashMap::new(),
+            released: Vec::new(),
+        }
     }
 
     /// Validate a demodulated candidate; returns a frame when parity
     /// checks out.
-    pub fn validate(&mut self, bytes: &[u8], level_dbfs: f32) -> Option<AdsbFrame> {
+    pub fn validate(&mut self, bytes: &[u8], level_dbfs: f32, pos: usize) -> Option<AdsbFrame> {
         let df = bytes[0] >> 3;
         // Syndrome = expected parity over the data bits XOR the received
         // parity field: 0 for clean parity, the overlaid address otherwise.
@@ -118,16 +131,22 @@ impl FrameValidator {
                     }
                 }
                 let icao = u32::from_be_bytes([0, bytes[1], bytes[2], bytes[3]]);
-                self.learn(icao);
+                if !self.confirm(icao, &bytes, level_dbfs, pos) {
+                    return None;
+                }
                 icao
             }
-            // All-call reply: PI overlaid with the interrogator code only.
+            // All-call reply: PI overlaid with the interrogator code
+            // only. DF11 carries no payload worth emitting on first
+            // sight; it counts as a confirmation sighting.
             11 => {
                 if syndrome & 0xFF_FF80 != 0 {
                     return None;
                 }
                 let icao = u32::from_be_bytes([0, bytes[1], bytes[2], bytes[3]]);
-                self.learn(icao);
+                if !self.confirm(icao, &bytes, level_dbfs, pos) {
+                    return None;
+                }
                 icao
             }
             // Address-overlaid parity: accept only known aircraft.
@@ -173,6 +192,64 @@ impl FrameValidator {
                 }
             }
             _ => {}
+        }
+        Some(f)
+    }
+
+    /// Two-sighting confirmation for addresses asserted by a clean
+    /// CRC: known ICAOs pass straight through; an unknown ICAO's first
+    /// frame is held; its second sighting confirms, releases the held
+    /// frame via `released`, and admits the address to the cache.
+    fn confirm(&mut self, icao: u32, bytes: &[u8], level_dbfs: f32, pos: usize) -> bool {
+        if self.icao_cache.contains_key(&icao) {
+            self.learn(icao);
+            return true;
+        }
+        if let Some((held, held_level, held_pos, _)) = self.pending.remove(&icao) {
+            self.learn(icao);
+            // Decode and release the held first frame.
+            if let Some(f) = self.decode_known(&held, held_level) {
+                self.released.push((held_pos, f));
+            }
+            return true;
+        }
+        // First sighting: hold. Cap the pending table (phantom
+        // addresses are random and never repeat; FIFO-ish eviction by
+        // age keeps it small).
+        if self.pending.len() >= 64 {
+            let oldest = self
+                .pending
+                .iter()
+                .min_by_key(|(_, (_, _, _, at))| *at)
+                .map(|(k, _)| *k);
+            if let Some(k) = oldest {
+                self.pending.remove(&k);
+            }
+        }
+        self.pending.insert(icao, (bytes.to_vec(), level_dbfs, pos, self.counter));
+        false
+    }
+
+    /// Decode a frame whose address is already trusted (used when a
+    /// held first frame is released by its confirmation).
+    fn decode_known(&mut self, bytes: &[u8], level_dbfs: f32) -> Option<AdsbFrame> {
+        let df = bytes[0] >> 3;
+        let icao = u32::from_be_bytes([0, bytes[1], bytes[2], bytes[3]]);
+        let mut f = AdsbFrame {
+            df,
+            icao,
+            bytes: bytes.to_vec(),
+            callsign: None,
+            altitude_ft: None,
+            squawk: None,
+            cpr: None,
+            velocity: None,
+            position: None,
+            comm_b: None,
+            level_dbfs,
+        };
+        if df == 17 || df == 18 {
+            decode_extended_squitter(&bytes[4..11], &mut f);
         }
         Some(f)
     }
@@ -251,35 +328,62 @@ mod tests {
         0x8D, 0x40, 0x62, 0x1D, 0x58, 0xC3, 0x82, 0xD6, 0x90, 0xC8, 0xAC, 0x28, 0x63, 0xA7,
     ];
 
+    /// Confirm an ICAO so subsequent single frames validate directly.
+    fn confirmed(v: &mut FrameValidator, frame: &[u8]) -> AdsbFrame {
+        assert!(v.validate(frame, -20.0, 0).is_none(), "first sighting held");
+        v.validate(frame, -20.0, 1000).expect("second sighting confirms")
+    }
+
     #[test]
     fn decodes_published_ident_frame() {
-        let f = FrameValidator::new().validate(&ID_FRAME, -20.0).unwrap();
+        let mut v = FrameValidator::new();
+        let f = confirmed(&mut v, &ID_FRAME);
         assert_eq!(f.df, 17);
         assert_eq!(f.icao, 0x4840D6);
         assert_eq!(f.callsign.as_deref(), Some("KLM1023"));
         assert_eq!(f.altitude_ft, None);
+        // The held first frame was released alongside, fully decoded.
+        assert_eq!(v.released.len(), 1);
+        assert_eq!(v.released[0].0, 0);
+        assert_eq!(v.released[0].1.callsign.as_deref(), Some("KLM1023"));
     }
 
     #[test]
     fn decodes_published_altitude_frame() {
-        let f = FrameValidator::new().validate(&POS_FRAME, -20.0).unwrap();
+        let mut v = FrameValidator::new();
+        let f = confirmed(&mut v, &POS_FRAME);
         assert_eq!(f.icao, 0x40621D);
         assert_eq!(f.altitude_ft, Some(38_000));
+        assert_eq!(v.released[0].1.altitude_ft, Some(38_000));
     }
 
     #[test]
     fn repairs_single_bit_rejects_double() {
         // One flipped bit: the syndrome identifies it and the frame
         // repairs to the original.
+        let mut v = FrameValidator::new();
+        confirmed(&mut v, &ID_FRAME);
         let mut one = ID_FRAME;
         one[6] ^= 0x01;
-        let f = FrameValidator::new().validate(&one, -20.0).expect("repaired");
+        let f = v.validate(&one, -20.0, 0).expect("repaired");
         assert_eq!(f.bytes, &ID_FRAME);
         // Two flipped bits: not repairable, rejected.
         let mut two = ID_FRAME;
         two[6] ^= 0x01;
         two[9] ^= 0x10;
-        assert!(FrameValidator::new().validate(&two, -20.0).is_none());
+        assert!(v.validate(&two, -20.0, 0).is_none());
+    }
+
+    #[test]
+    fn unconfirmed_singletons_never_emit() {
+        // A CRC-clean DF17 whose address is never seen again — the
+        // phantom signature on quiet live captures — stays held.
+        let mut v = FrameValidator::new();
+        assert!(v.validate(&ID_FRAME, -20.0, 0).is_none());
+        assert!(v.released.is_empty());
+        // A different aircraft doesn't confirm it.
+        assert!(v.validate(&POS_FRAME, -20.0, 500).is_none());
+        assert!(v.released.is_empty());
     }
 
     #[test]
@@ -293,10 +397,10 @@ mod tests {
         frame.extend([crc[1] ^ addr[1], crc[2] ^ addr[2], crc[3] ^ addr[3]]);
 
         // Unknown aircraft → rejected.
-        assert!(v.validate(&frame, -20.0).is_none());
-        // Learn the ICAO from a squitter, then the DF4 is accepted.
-        v.validate(&ID_FRAME, -20.0).unwrap();
-        let f = v.validate(&frame, -20.0).unwrap();
+        assert!(v.validate(&frame, -20.0, 0).is_none());
+        // Confirm the ICAO from squitters, then the DF4 is accepted.
+        confirmed(&mut v, &ID_FRAME);
+        let f = v.validate(&frame, -20.0, 0).unwrap();
         assert_eq!(f.df, 4);
         assert_eq!(f.icao, 0x4840D6);
     }

--- a/docs/notes/BENCHMARKS.md
+++ b/docs/notes/BENCHMARKS.md
@@ -214,3 +214,33 @@ file decode = max, SDR commands = live).
 - Iridium/STD-C/Aero: oracle-validated field-exact; no count-style
   sensitivity comparison run yet
 
+## Live-capture authenticity: phantom frames and ICAO confirmation
+
+A 60 s off-air 1090 MHz capture (RTL-SDR, 2.4 MS/s, gain 48, quiet
+minute) exposed a real defect the dense benchmark captures had hidden:
+xng reported 70 "unique frames" where dump1090-fa and readsb both
+reported ~0. The frames had the unmistakable phantom signature — 31
+CRC-clean DF17s carrying 31 *distinct* ICAO addresses, each seen
+exactly once, scattered across implausible allocation blocks.
+
+The math says this must happen: near-floor candidate gates × 16
+sub-sample phase passes over 60 s ≈ 2.3 × 10⁹ CRC trials, and a random
+112-bit candidate passes the 24-bit parity with probability 2⁻²⁴ —
+~140 expected false DF17s per minute of pure noise. The 0.18 s modes1
+fixture expects ~0.4, which is why the benchmarks never showed it.
+Worse, false DF11s (only 17 parity bits effectively checked) were
+*learning* junk ICAOs into the cache, which then validated junk
+address-overlaid DF0/4/5 frames.
+
+Fix: two-sighting ICAO confirmation (the same policy readsb uses for
+unreliable sources). A CRC-clean DF17/18/11 whose address has never
+been seen is held, not emitted; a second clean frame with the same
+address confirms the aircraft, releases the held frame at its original
+position, and admits the ICAO to the cache. Random phantoms never
+repeat an address (P ≈ 2⁻²⁴ per pair), so they die in the pending
+table (capped at 64, age-evicted). Address-overlaid frames already
+required a cached ICAO, so they now inherit confirmed-only trust.
+
+Measured cost: zero. modes1 is a single heavily-repeated aircraft —
+the gate still reads 323 at 2 MS/s. Measured benefit: the quiet live
+capture drops from 70 phantoms to exactly 0, matching both oracles.


### PR DESCRIPTION
## Summary
- A quiet 60 s live 1090 capture exposed phantom decodes: xng reported 70 unique frames vs ~0 from dump1090-fa and readsb — 31 CRC-clean DF17s each carrying a *different* random ICAO seen exactly once. Near-floor gates × 16 phase passes ≈ 2.3e9 CRC trials × 2⁻²⁴ ≈ 140 expected false DF17s/min on noise; dense benchmark captures (0.18 s) hid this. False DF11s were also learning junk ICAOs into the cache, unlocking junk address-overlaid frames.
- Fix: two-sighting ICAO confirmation (readsb's policy for unreliable sources). First clean frame of an unknown address is held; a second sighting confirms, releases the held frame at its true position, and admits the ICAO. Phantoms never repeat an address, so they age out of a 64-entry pending table.
- Cost: zero on benchmarks (modes1 still 323 ≥ 310 at 2 MS/s; 2.4 MS/s grid unchanged). Benefit: the quiet live capture decodes to exactly 0, matching both oracles. New unit test pins the never-confirmed-singleton behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)