### PR TITLE
ADS-B: 4-pass live effort + quiet-capture false-positive ceiling gate

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -19,6 +19,6 @@ jobs:
       - name: Fetch AIS fixture (release asset)
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release download bench-fixtures-v1 -p ais_96k.cs16 -p vdl2_105k_conj.s16 -p hfdl_48k.cs16 -D bench/data/
+        run: gh release download bench-fixtures-v1 -p ais_96k.cs16 -p vdl2_105k_conj.s16 -p hfdl_48k.cs16 -p adsb_quiet_24m.cu8 -D bench/data/
       - name: Decode-count regression gate
         run: bash bench/run.sh

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ legacy/target
 bench/data/ais_96k.cs16
 bench/data/vdl2_105k_conj.s16
 bench/data/hfdl_48k.cs16
+bench/data/adsb_quiet_24m.cu8

--- a/bench/README.md
+++ b/bench/README.md
@@ -8,6 +8,7 @@ fixtures and fails if any count drops below its baseline
 |---|---|---|
 | `data/modes1.cu8` | ADS-B/Mode S: the canonical dump1090 test capture (antirez/dump1090 `testfiles/modes1.bin`, BSD), 2 MS/s UC8, ~0.18 s of dense 1090 MHz traffic | vendored |
 | `data/ais_96k.cs16` | AIS: 5 min at 162.000 MHz (Airspy Mini, Sacramento, 2026-06-11), 6 MS/s → 96 kS/s cs16; ~53 mostly-weak base-station bursts | [release asset](https://github.com/airframesio/xng/releases/tag/bench-fixtures-v1) (115 MB) |
+| `data/adsb_quiet_24m.cu8` | ADS-B **false-positive ceiling**: 20 s of quiet live 1090 MHz RF (RTL-SDR, Sacramento, 2026-06-12), 2.4 MS/s UC8. Near-floor gates produce ~70 phantom CRC-clean frames/min on noise without the two-sighting ICAO confirmation; the gate fails if the count *exceeds* `adsb_quiet_max` | [release asset](https://github.com/airframesio/xng/releases/tag/bench-fixtures-v1) (96 MB) |
 
 ```bash
 cargo build --release
@@ -24,3 +25,4 @@ Oracle calibration (what the strongest open decoders get on the same
 fixtures, methodology, and the history of xng's numbers) lives in
 [docs/notes/BENCHMARKS.md](../docs/notes/BENCHMARKS.md). Baselines are
 floors for *our* counts — raise them when a demod improvement lands.
+Keys ending in `_max` are ceilings (false-positive gates) instead.

--- a/bench/baselines.json
+++ b/bench/baselines.json
@@ -1,7 +1,8 @@
 {
-  "_comment": "Minimum decode counts per fixture. Raise these when a demod improvement lands (they are the new floor); never lower without a documented tradeoff. Calibration history in docs/notes/BENCHMARKS.md.",
+  "_comment": "Minimum decode counts per fixture. Raise these when a demod improvement lands (they are the new floor); never lower without a documented tradeoff. Calibration history in docs/notes/BENCHMARKS.md. Keys ending in _max are CEILINGS (false-positive gates): fail when the count EXCEEDS the value.",
   "adsb_modes1": 310,
   "ais_offair": 48,
   "vdl2_offair": 42,
-  "hfdl_offair": 31
+  "hfdl_offair": 31,
+  "adsb_quiet_max": 4
 }

--- a/bench/run.sh
+++ b/bench/run.sh
@@ -30,9 +30,31 @@ check() { # name actual
   fi
 }
 
+check_max() { # name actual — ceiling gate for false-positive fixtures
+  local max
+  max=$(python3 -c "import json;print(json.load(open('$BASE'))['$1'])")
+  if [ "$2" -gt "$max" ]; then
+    echo "REGRESSION: $1 decoded $2 frames (ceiling <= $max — false positives)"
+    fail=1
+  else
+    echo "ok: $1 = $2 frames (ceiling <= $max)"
+  fi
+}
+
 # ADS-B: the canonical dump1090 test capture (vendored).
 adsb=$(count bench/data/modes1.cu8 cu8 adsb 2000000 1090000000 1090)
 check adsb_modes1 "$adsb"
+
+# ADS-B false-positive gate: 20 s of quiet live 1090 RF (release
+# asset). Near-floor candidate gates + CRC trials produce ~70 phantom
+# frames/min on noise unless the two-sighting ICAO confirmation holds
+# them back; this asserts the phantom rate stays ~zero.
+if [ -f bench/data/adsb_quiet_24m.cu8 ]; then
+  quiet=$(count bench/data/adsb_quiet_24m.cu8 cu8 adsb 2400000 1090000000 1090)
+  check_max adsb_quiet_max "$quiet"
+else
+  echo "skip: bench/data/adsb_quiet_24m.cu8 not present (release asset)"
+fi
 
 # AIS: 5-minute off-air capture (release asset; fetched by CI or
 # manually: gh release download bench-fixtures-v1 -p ais_96k.cs16 -D bench/data/).

--- a/crates/xng-mode-adsb/src/demod.rs
+++ b/crates/xng-mode-adsb/src/demod.rs
@@ -307,9 +307,12 @@ impl PpmDemod {
             // bytes + position.
             let mut found: Vec<(usize, AdsbFrame)> = Vec::new();
             // Effort follows the integer path's grid choice: live (one
-            // extra phase configured) runs 2 passes; max runs 16
+            // extra phase configured) runs 4 passes; max runs 16
             // (measured asymptote: 157 → 163 → 164 unique at 4/8/16).
-            let npass: usize = if self.fracs.len() <= 1 { 2 } else { 16 };
+            // Live was 2 until real-RF testing showed it left frames
+            // on the table (modes1@2.4M: 281 → 296 of max's 313 going
+            // 2 → 4 passes).
+            let npass: usize = if self.fracs.len() <= 1 { 4 } else { 16 };
             for (pass, frac) in
                 (0..npass).map(|k| k as f64 / npass as f64).enumerate()
             {

--- a/docs/notes/BENCHMARKS.md
+++ b/docs/notes/BENCHMARKS.md
@@ -244,3 +244,12 @@ required a cached ICAO, so they now inherit confirmed-only trust.
 Measured cost: zero. modes1 is a single heavily-repeated aircraft —
 the gate still reads 323 at 2 MS/s. Measured benefit: the quiet live
 capture drops from 70 phantoms to exactly 0, matching both oracles.
+
+Follow-ups locked in by CI: the first 20 s of the quiet capture is now
+a release-asset fixture with a **ceiling gate** (`adsb_quiet_max = 4`,
+measured 1) — any future relaxation of the candidate gates that brings
+the phantoms back fails the bench job. And live demod effort at
+fractional rates was raised from 2 to 4 sub-sample passes after the
+same live session showed 2-pass live decoding 7 msgs/45 s where max
+got 36: on modes1 resampled to 2.4 MS/s, live goes 281 → 296 of max's
+313 while still running ~5.9× realtime.


### PR DESCRIPTION
## Summary
Locks in this week's live-RF findings:
- **Live effort 2 → 4 passes** (fractional-rate path): live testing showed 2-pass live decoded 7 msgs/45 s where max got 36 — most of the link budget unused. On modes1 resampled to 2.4 MS/s: **281 → 296** of max's 313, still **~5.9× realtime** (8.9 s of dense traffic in 1.52 s user). Integer-rate live (2/6 MS/s) unchanged.
- **False-positive ceiling gate**: the first 20 s of the quiet 1090 capture that exposed the phantom-frame defect is now a `bench-fixtures-v1` release asset. New `check_max` semantics in `bench/run.sh` (`_max` keys are ceilings): `adsb_quiet_max = 4`, measured **1** with the two-sighting confirmation vs ~23 without it. Any future gate relaxation that re-admits CRC-clean noise fails CI.
- Docs: bench/README fixture table + BENCHMARKS.md follow-up note.
- All gates green: 323 / 1≤4 / 52 / 33 / 44.

🤖 Generated with [Claude Code](https://claude.com/claude-code)