### PR TITLE
v0.17.0: trustworthy live decode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3702,7 +3702,7 @@ dependencies = [
 
 [[package]]
 name = "xng"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3743,7 +3743,7 @@ dependencies = [
 
 [[package]]
 name = "xng-acars"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "base64",
  "crc",
@@ -3755,7 +3755,7 @@ dependencies = [
 
 [[package]]
 name = "xng-dsp"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "crc",
  "num-complex",
@@ -3764,7 +3764,7 @@ dependencies = [
 
 [[package]]
 name = "xng-mode-acars"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "chrono",
  "num-complex",
@@ -3776,7 +3776,7 @@ dependencies = [
 
 [[package]]
 name = "xng-mode-adsb"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "chrono",
  "num-complex",
@@ -3787,7 +3787,7 @@ dependencies = [
 
 [[package]]
 name = "xng-mode-aero"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "chrono",
  "num-complex",
@@ -3801,7 +3801,7 @@ dependencies = [
 
 [[package]]
 name = "xng-mode-ais"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "chrono",
  "num-complex",
@@ -3812,7 +3812,7 @@ dependencies = [
 
 [[package]]
 name = "xng-mode-hfdl"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "chrono",
  "num-complex",
@@ -3825,7 +3825,7 @@ dependencies = [
 
 [[package]]
 name = "xng-mode-iridium"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "chrono",
  "crc",
@@ -3840,7 +3840,7 @@ dependencies = [
 
 [[package]]
 name = "xng-mode-stdc"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "chrono",
  "num-complex",
@@ -3853,7 +3853,7 @@ dependencies = [
 
 [[package]]
 name = "xng-mode-vdl2"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "chrono",
  "num-complex",
@@ -3866,7 +3866,7 @@ dependencies = [
 
 [[package]]
 name = "xng-proto"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "chrono",
  "prost",
@@ -3877,7 +3877,7 @@ dependencies = [
 
 [[package]]
 name = "xng-sdr"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "num-complex",
  "pkg-config",
@@ -3888,7 +3888,7 @@ dependencies = [
 
 [[package]]
 name = "xng-types"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "chrono",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["legacy"]
 resolver = "2"
 
 [workspace.package]
-version = "0.16.0"
+version = "0.17.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/airframesio/xng"


### PR DESCRIPTION
Version bump for v0.17.0. Highlights since v0.16.0 (the release changelog is generated from the merged PRs):
- **Two-sighting ICAO confirmation** kills phantom ADS-B frames on live RF (70 → 0 on a quiet minute), with a CI **false-positive ceiling gate** so it can't regress.
- **CPR speed gate**: corrupted position fixes no longer zigzag trails or drag the track reference.
- **Dashboard v3**: mode filter chips with live rates, pause/search, click-to-expand decoded JSON, station header — plus **PlaneWatch silhouettes** (used with permission), richer entity popups, selection highlight, and a sanitized, commit-pinned SVG pipeline.
- **ADS-B live effort** 2 → 4 passes (281 → 296 of max's 313 at 2.4 MS/s, ~5.9× realtime).
- **AIS deep-weak rescue: 68 % → 91 %** of AIS-catcher, zero false decodes (MMSI two-sighting policy).
- **HFDL rescue: 89 % → 97 %** of dumphfdl.

🤖 Generated with [Claude Code](https://claude.com/claude-code)