### PR TITLE
Add 'xng status': live per-session table for a running station

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,23 @@ A full example config and a hardened systemd unit live in
 [`contrib/`](contrib/). Sessions can also replay IQ files (`file =`
 instead of `sdr =`) — useful for regression runs over recorded nights.
 
+`xng status` prints a live per-session table for a running station
+(querying its dashboard endpoint, default `127.0.0.1:8080`, or
+`--http host:port`):
+
+```text
+  KE-KSEA-1   up 3h12m   41 aircraft · 7 vessels
+  ┌────────┬────────┬─────────┬─────────────────────┬───────────────────────────────────┐
+  │ SDR    │ Serial │ Mode    │ Tuning              │ Status                            │
+  ├────────┼────────┼─────────┼─────────────────────┼───────────────────────────────────┤
+  │ rtlsdr │ 001    │ ACARS   │ 11 ch @ 130.940 MHz │ decoding · 4218 msgs · last now   │
+  │ rtlsdr │ 002    │ VDL2    │ 4 ch @ 136.850 MHz  │ decoding · 86 msgs · last 12s ago │
+  │ rtlsdr │ 003    │ AIS     │ 2 ch @ 162.000 MHz  │ decoding · 9304 msgs · last now   │
+  │ rtlsdr │ 004    │ ADSB    │ 1 ch @ 1090.000 MHz │ decoding · 51k msgs · last now    │
+  │ airspy │ —      │ IRIDIUM │ 1 ch @ 1624.000 MHz │ decoding · 240 msgs · last 4s ago │
+  └────────┴────────┴─────────┴─────────────────────┴───────────────────────────────────┘
+```
+
 ### Web dashboard
 
 `--http 0.0.0.0:8080` (any command, or `http =` in the station config)

--- a/src/main.rs
+++ b/src/main.rs
@@ -238,6 +238,13 @@ enum Command {
         /// Path to the station TOML config
         config: PathBuf,
     },
+    /// Show a running station's sessions and live decode status (queries
+    /// its web dashboard endpoint)
+    Status {
+        /// Dashboard address of the running station (host:port)
+        #[arg(long, default_value = "127.0.0.1:8080")]
+        http: String,
+    },
     /// Inspect a recorded IQ file: duration, power, spectral peaks
     IqInfo {
         /// Path to the IQ file
@@ -556,6 +563,7 @@ fn main() -> anyhow::Result<()> {
             listen(&sdr, gain, &tune, &output)
         }
         Command::Station { config } => run_station_cmd(&config),
+        Command::Status { http } => run_status_cmd(&http),
         Command::IqInfo { file, sample_rate, format, center_freq, fft_size } => {
             commands::iq_info::run(&file, sample_rate, format.as_deref(), center_freq, fft_size)
         }
@@ -780,6 +788,130 @@ fn run_station_cmd(config: &std::path::Path) -> anyhow::Result<()> {
         ));
     }
     runtime::run_station(sessions)
+}
+
+/// `xng status`: query a running station's dashboard JSON and print a
+/// per-session table with live decode status.
+fn run_status_cmd(http: &str) -> anyhow::Result<()> {
+    let body = http_get(http, "/api/state").map_err(|e| {
+        anyhow::anyhow!(
+            "could not reach a station at http://{http}/ ({e}). Is one running with `http = \"{http}\"` in its config (or --http {http})?"
+        )
+    })?;
+    let s: serde_json::Value = serde_json::from_str(&body)?;
+
+    let now = s["now"].as_u64().unwrap_or(0);
+    let started = s["started"].as_u64().unwrap_or(now);
+    let station = s["station"].as_str().unwrap_or("xng station");
+    let totals = &s["totals"];
+    let last_seen = &s["last_seen"];
+
+    let up = now.saturating_sub(started);
+    let (h, m, sec) = (up / 3600, (up % 3600) / 60, up % 60);
+    let uptime = if h > 0 { format!("{h}h{m:02}m") } else if m > 0 { format!("{m}m{sec:02}s") } else { format!("{sec}s") };
+    println!("\n  {station}   up {uptime}   {} aircraft · {} vessels",
+        s["aircraft"].as_array().map_or(0, |a| a.len()),
+        s["vessels"].as_array().map_or(0, |a| a.len()));
+
+    // Build rows from the session list.
+    let empty = vec![];
+    let sessions = s["sessions"].as_array().unwrap_or(&empty);
+    let mut rows: Vec<[String; 5]> = Vec::new();
+    for sess in sessions {
+        let sdr = sess["sdr"].as_str().unwrap_or("?");
+        let serial = sess["serial"].as_str().unwrap_or("—");
+        let mode = sess["mode"].as_str().unwrap_or("?");
+        let chans = sess["channels"].as_array().map_or(0, |c| c.len());
+        let center = sess["center_mhz"].as_f64().unwrap_or(0.0);
+        let driver = sdr.split(',').next().unwrap_or(sdr)
+            .strip_prefix("driver=").unwrap_or(sdr);
+        let count = totals[mode].as_u64().unwrap_or(0);
+        let seen = last_seen[mode].as_u64();
+        let status = match (count, seen) {
+            (0, _) => "awaiting traffic".to_string(),
+            (n, Some(t)) => {
+                let ago = now.saturating_sub(t);
+                let when = if ago < 5 { "now".to_string() }
+                    else if ago < 90 { format!("{ago}s ago") }
+                    else { format!("{}m ago", ago / 60) };
+                let live = if ago < 60 { "decoding" } else { "idle" };
+                format!("{live} · {n} msgs · last {when}")
+            }
+            (n, None) => format!("{n} msgs"),
+        };
+        rows.push([
+            driver.to_string(),
+            serial.to_string(),
+            mode.to_uppercase(),
+            format!("{chans} ch @ {center:.3} MHz"),
+            status,
+        ]);
+    }
+    if rows.is_empty() {
+        println!("\n  (station reports no sessions)\n");
+        return Ok(());
+    }
+    print_table(&["SDR", "Serial", "Mode", "Tuning", "Status"], &rows);
+    println!();
+    Ok(())
+}
+
+/// Minimal blocking HTTP/1.0 GET for the local dashboard (small JSON;
+/// avoids pulling in an HTTP client crate).
+fn http_get(addr: &str, path: &str) -> std::io::Result<String> {
+    use std::io::{Read, Write};
+    let mut stream = std::net::TcpStream::connect(addr)?;
+    stream.set_read_timeout(Some(std::time::Duration::from_secs(5)))?;
+    write!(stream, "GET {path} HTTP/1.1\r\nHost: {addr}\r\nConnection: close\r\n\r\n")?;
+    stream.flush()?;
+    // Accumulate until EOF. A minimal server may RST rather than send a
+    // clean FIN; tolerate a reset once we already have the response.
+    let mut raw = Vec::new();
+    let mut buf = [0u8; 8192];
+    loop {
+        match stream.read(&mut buf) {
+            Ok(0) => break,
+            Ok(n) => raw.extend_from_slice(&buf[..n]),
+            Err(e) if e.kind() == std::io::ErrorKind::ConnectionReset && !raw.is_empty() => break,
+            Err(e) => return Err(e),
+        }
+    }
+    let raw = String::from_utf8_lossy(&raw);
+    let body = raw
+        .split_once("\r\n\r\n")
+        .map(|(_, b)| b)
+        .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::InvalidData, "no HTTP body"))?;
+    Ok(body.to_string())
+}
+
+/// Render a box-drawing table sized to its content.
+fn print_table(headers: &[&str], rows: &[[String; 5]]) {
+    let mut w: Vec<usize> = headers.iter().map(|h| h.chars().count()).collect();
+    for r in rows {
+        for (i, cell) in r.iter().enumerate() {
+            w[i] = w[i].max(cell.chars().count());
+        }
+    }
+    let line = |l: &str, mid: &str, r: &str| {
+        let segs: Vec<String> = w.iter().map(|&n| "─".repeat(n + 2)).collect();
+        format!("{l}{}{r}", segs.join(mid))
+    };
+    let fmt_row = |cells: &[String]| {
+        let parts: Vec<String> = cells
+            .iter()
+            .enumerate()
+            .map(|(i, c)| format!(" {c:<width$} ", width = w[i]))
+            .collect();
+        format!("│{}│", parts.join("│"))
+    };
+    println!("  {}", line("┌", "┬", "┐"));
+    let hdr: Vec<String> = headers.iter().map(|h| h.to_string()).collect();
+    println!("  {}", fmt_row(&hdr));
+    println!("  {}", line("├", "┼", "┤"));
+    for r in rows {
+        println!("  {}", fmt_row(r));
+    }
+    println!("  {}", line("└", "┴", "┘"));
 }
 
 fn open_sdr(

--- a/src/outputs/http.rs
+++ b/src/outputs/http.rs
@@ -26,11 +26,16 @@ struct Dash {
     vessels: HashMap<u32, Value>,
     recent: VecDeque<Value>,
     totals: HashMap<String, u64>,
+    /// Last time (unix secs) a message of each mode was seen — drives
+    /// the `xng status` per-session liveness column.
+    last_seen: HashMap<String, u64>,
     /// Monotonic message id — lets the page keep expansion state
     /// across poll re-renders.
     next_id: u64,
     station: String,
     started: u64,
+    /// Static per-session descriptors (SDR, mode, tuning) for status.
+    sessions: Vec<Value>,
 }
 
 /// Append to the entity's position trail (decimated: only when moved
@@ -57,6 +62,7 @@ fn now_s() -> u64 {
 fn update(d: &mut Dash, m: &Message) {
     let mode = m.mode.as_str().to_string();
     *d.totals.entry(mode.clone()).or_insert(0) += 1;
+    d.last_seen.insert(mode.clone(), now_s());
 
     match &m.body {
         MessageBody::ModeS {
@@ -170,10 +176,12 @@ fn snapshot(d: &mut Dash) -> String {
     json!({
         "station": d.station,
         "started": d.started,
+        "sessions": d.sessions,
         "aircraft": d.aircraft.values().collect::<Vec<_>>(),
         "vessels": d.vessels.values().collect::<Vec<_>>(),
         "messages": d.recent.iter().rev().take(100).collect::<Vec<_>>(),
         "totals": d.totals,
+        "last_seen": d.last_seen,
         "now": now_s(),
     })
     .to_string()
@@ -183,10 +191,12 @@ pub async fn run(
     mut rx: broadcast::Receiver<Arc<Message>>,
     addr: String,
     station: String,
+    sessions: Vec<Value>,
 ) -> std::io::Result<()> {
     let state = Arc::new(Mutex::new(Dash {
         station,
         started: now_s(),
+        sessions,
         ..Dash::default()
     }));
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -365,10 +365,41 @@ impl ModeChannel {
 }
 
 /// Spawn the configured output sinks on the current tokio runtime.
+/// JSON descriptor of one decode session for the dashboard / `xng status`.
+fn session_descriptor(
+    sdr: &Option<SdrInfo>,
+    mode: Mode,
+    center_hz: u64,
+    channels_hz: &[u64],
+    sample_rate: f64,
+) -> serde_json::Value {
+    let (selector, serial) = match sdr {
+        Some(s) => (s.id.clone(), s.serial.clone().or_else(|| parse_serial(&s.id))),
+        None => ("file".to_string(), None),
+    };
+    serde_json::json!({
+        "sdr": selector,
+        "serial": serial,
+        "mode": mode.as_str(),
+        "center_mhz": center_hz as f64 / 1e6,
+        "channels": channels_hz.iter().map(|c| *c as f64 / 1e6).collect::<Vec<_>>(),
+        "sample_rate": sample_rate,
+    })
+}
+
+/// Pull `serial=…` out of a SoapySDR-style selector string.
+fn parse_serial(selector: &str) -> Option<String> {
+    selector.split(',').find_map(|kv| {
+        let (k, v) = kv.split_once('=')?;
+        (k.trim() == "serial").then(|| v.trim().to_string())
+    })
+}
+
 fn spawn_outputs(
     bus: &MessageBus,
     outputs: &OutputConfig,
     station: &StationIdentity,
+    sessions: &[serde_json::Value],
 ) -> Vec<tokio::task::JoinHandle<Result<(), std::io::Error>>> {
     let mut output_tasks = Vec::new();
     output_tasks.push(tokio::spawn({
@@ -402,7 +433,8 @@ fn spawn_outputs(
     if let Some(addr) = outputs.http.clone() {
         let rx = bus.subscribe();
         let ident = station.ident.clone();
-        output_tasks.push(tokio::spawn(crate::outputs::http::run(rx, addr, ident)));
+        let sessions = sessions.to_vec();
+        output_tasks.push(tokio::spawn(crate::outputs::http::run(rx, addr, ident, sessions)));
     }
     if let Some(url) = outputs.mqtt.clone() {
         let rx = bus.subscribe();
@@ -477,7 +509,9 @@ pub fn run_session(mut source: Box<dyn IqSource>, cfg: SessionConfig) -> anyhow:
                 }
             });
         }
-        let output_tasks = spawn_outputs(&bus, &cfg.outputs, &station);
+        let desc =
+            vec![session_descriptor(&cfg.sdr, cfg.mode, capture_center, &cfg.channels_hz, sample_rate)];
+        let output_tasks = spawn_outputs(&bus, &cfg.outputs, &station, &desc);
 
         // Ctrl-C → graceful stop.
         tokio::spawn({
@@ -664,6 +698,7 @@ pub fn run_station(sessions: Vec<(Box<dyn IqSource>, SessionConfig)>) -> anyhow:
         capture_center: u64,
     }
     let mut prepared = Vec::new();
+    let mut sessions_desc = Vec::new();
     for (source, cfg) in sessions {
         let sample_rate = source.sample_rate();
         let capture_center =
@@ -695,6 +730,13 @@ pub fn run_station(sessions: Vec<(Box<dyn IqSource>, SessionConfig)>) -> anyhow:
             sample_rate,
             capture_center as f64 / 1e6
         );
+        sessions_desc.push(session_descriptor(
+            &cfg.sdr,
+            cfg.mode,
+            capture_center,
+            &cfg.channels_hz,
+            sample_rate,
+        ));
         prepared.push(Prepared { source, decoders, cfg, capture_center });
     }
 
@@ -714,7 +756,7 @@ pub fn run_station(sessions: Vec<(Box<dyn IqSource>, SessionConfig)>) -> anyhow:
                 }
             });
         }
-        let output_tasks = spawn_outputs(&bus, &prepared[0].cfg.outputs, &station);
+        let output_tasks = spawn_outputs(&bus, &prepared[0].cfg.outputs, &station, &sessions_desc);
 
         tokio::spawn({
             let stop = stop.clone();


### PR DESCRIPTION
## Summary
A CLI status view for a running station, requested from the live multi-SDR soak.

```text
  KE-KSMF-ACARS1-TEST   up 1m16s   7 aircraft · 3 vessels
  ┌────────┬────────┬─────────┬─────────────────────┬───────────────────────────────────┐
  │ SDR    │ Serial │ Mode    │ Tuning              │ Status                            │
  ├────────┼────────┼─────────┼─────────────────────┼───────────────────────────────────┤
  │ rtlsdr │ 001    │ ACARS   │ 11 ch @ 130.940 MHz │ decoding · 1 msgs · last 44s ago  │
  │ rtlsdr │ 002    │ VDL2    │ 4 ch @ 136.850 MHz  │ awaiting traffic                  │
  │ rtlsdr │ 003    │ AIS     │ 2 ch @ 162.000 MHz  │ decoding · 25 msgs · last now     │
  │ rtlsdr │ 004    │ ADSB    │ 1 ch @ 1090.000 MHz │ decoding · 18 msgs · last 14s ago │
  │ airspy │ —      │ IRIDIUM │ 1 ch @ 1624.000 MHz │ awaiting traffic                  │
  └────────┴────────┴─────────┴─────────────────────┴───────────────────────────────────┘
```

- `xng status [--http host:port]` fetches the station's `/api/state` and renders a per-session box table: SDR, serial (parsed from the selector), mode, tuning (channel count + center), and a live status (decoding / idle / awaiting traffic) from per-mode message counts and last-seen. Header shows station id, uptime, and aircraft/vessel counts.
- `/api/state` now includes a `sessions` array (SDR selector, mode, center, channels, sample-rate — built once at startup) and a per-mode `last_seen` map. Both the station and single-session (`xng listen --http`) paths populate it via a shared `session_descriptor` helper.
- Dependency-free: a tiny blocking HTTP/1.1 GET that tolerates the hand-rolled server's RST-on-close.
- Verified live against the 5-session KerberosSDR + Airspy station. Bench gates unchanged (323 / 1≤4 / 72 / 36 / 44).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added `xng status` command to display live per-session status table with uptime, aircraft/vessel message counts, and SDR mode/tuning details
* Dashboard now tracks last-seen timestamps per message mode and includes session metadata in API state responses

<!-- end of auto-generated comment: release notes by coderabbit.ai -->