### PR TITLE
Iridium: prove + harden the wideband path at 6 MS/s

### DIFF
--- a/crates/xng-mode-iridium/src/wideband.rs
+++ b/crates/xng-mode-iridium/src/wideband.rs
@@ -12,6 +12,14 @@ use std::sync::Arc;
 
 /// Detection threshold over the per-bin noise floor (gr-iridium: 16 dB).
 const THRESHOLD: f32 = 40.0; // linear ≈ 16 dB
+/// Frames to average into the noise floor before detecting. Seeding the
+/// floor from a single frame (its random per-bin magnitude) leaves many
+/// bins initialized near a noise null, so for the EMA's whole settling
+/// time those bins read tens of dB "hot" and fire spuriously — fatal at
+/// the larger FFTs of higher capture rates. A short warmup mean fixes
+/// the floor before any detection. 64 frames ≈ 33 ms, well before the
+/// first real burst.
+const WARMUP_FRAMES: u64 = 64;
 /// Maximum burst duration in seconds.
 const MAX_BURST_S: f64 = 0.092;
 /// Time to keep capturing after the burst leaves the detector.
@@ -44,6 +52,8 @@ pub struct IridiumWideband {
     start_abs: u64,
     /// Next FFT frame index to process.
     next_frame: u64,
+    /// Frames folded into the floor so far (for the warmup mean).
+    floor_frames: u64,
     active: Vec<ActiveBurst>,
 }
 
@@ -88,6 +98,7 @@ impl IridiumWideband {
             buf: Vec::new(),
             start_abs: 0,
             next_frame: 0,
+            floor_frames: 0,
             active: Vec::new(),
             recent: Vec::new(),
         })
@@ -114,13 +125,23 @@ impl IridiumWideband {
             self.fft.process(&mut spec);
             let mag: Vec<f32> = spec.iter().map(|c| c.norm_sqr()).collect();
 
-            // Update floors and find hot bins.
+            // Update the per-bin noise floor. Warm up with a running
+            // mean over the first WARMUP_FRAMES (no detection yet), then
+            // track with the slow EMA. Detecting before the floor is
+            // settled produces band-wide false bursts.
             if self.floor.is_empty() {
-                self.floor = mag.clone();
+                self.floor = vec![0.0; self.nfft];
             }
+            self.floor_frames += 1;
+            let warming = self.floor_frames <= WARMUP_FRAMES;
             let mut hot = vec![false; self.nfft];
             for (k, &m) in mag.iter().enumerate() {
                 let f = &mut self.floor[k];
+                if warming {
+                    // Incremental mean of the frames seen so far.
+                    *f += (m - *f) / self.floor_frames as f32;
+                    continue;
+                }
                 hot[k] = m > *f * THRESHOLD;
                 // Bursts are brief; the slow EMA dilutes them like
                 // gr-iridium's 512-frame history.

--- a/crates/xng-mode-iridium/tests/wideband.rs
+++ b/crates/xng-mode-iridium/tests/wideband.rs
@@ -186,3 +186,63 @@ fn decodes_gr_iridium_capture_via_wideband() {
         .count();
     assert_eq!(violations, 0, "PRBS15 must hold");
 }
+
+/// The wideband path must work at the rates the station actually uses,
+/// not just 2 MS/s. Upsample the real gr-iridium reference burst to
+/// each rate (the modulator's fixed-tap RRC can't synthesize a clean
+/// signal at high sps, so reuse real samples like the 2 MS/s test) and
+/// confirm it still detects + demodulates.
+#[test]
+fn decodes_real_burst_at_station_rates() {
+    let raw = std::fs::read(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/tests/data/grtest_prbs15_250k.i16"
+    ))
+    .expect("fixture present");
+    let chan: Vec<Complex<f32>> = raw
+        .chunks_exact(4)
+        .map(|b| {
+            Complex::new(
+                i16::from_le_bytes([b[0], b[1]]) as f32 / 32768.0,
+                i16::from_le_bytes([b[2], b[3]]) as f32 / 32768.0,
+            )
+        })
+        .collect();
+    for &(fs, off) in &[(2_000_000.0f64, 400_000.0f64), (6_000_000.0, -1_900_000.0), (6_000_000.0, 500_000.0)] {
+        let up = (fs / 250_000.0).round() as usize; // 8 at 2M, 24 at 6M
+        let mut sig = vec![Complex::new(0.0f32, 0.0); (0.05 * fs) as usize];
+        sig.extend(chan.iter().flat_map(|&s| std::iter::repeat(s).take(up)));
+        sig.extend(std::iter::repeat(Complex::new(0.0f32, 0.0)).take((0.2 * fs) as usize));
+        for (i, s) in sig.iter_mut().enumerate() {
+            let ph = std::f64::consts::TAU * off * i as f64 / fs;
+            *s *= Complex::from_polar(1.0, ph as f32);
+        }
+        // light noise
+        let mut z = 0x1234_5678_9abc_def0u64;
+        for s in &mut sig {
+            z ^= z << 13; z ^= z >> 7; z ^= z << 17;
+            let n1 = (z as f32 / u64::MAX as f32) - 0.5;
+            z ^= z << 13; z ^= z >> 7; z ^= z << 17;
+            let n2 = (z as f32 / u64::MAX as f32) - 0.5;
+            *s += Complex::new(n1 * 0.01, n2 * 0.01);
+        }
+        let mut wb = IridiumWideband::new(fs).unwrap();
+        let mut bursts = Vec::new();
+        for chunk in sig.chunks(65_536) {
+            bursts.extend(wb.process(chunk));
+        }
+        assert!(!bursts.is_empty(), "fs={fs} off={off}: no burst found");
+        // Nearest the fundamental (ZOH leaves ±250 kHz images).
+        let b = bursts
+            .iter()
+            .min_by(|a, b| (a.offset_hz - off).abs().partial_cmp(&(b.offset_hz - off).abs()).unwrap())
+            .unwrap();
+        assert_eq!(&b.bits[..24], &frame::ACCESS_DL[..], "fs={fs} off={off}: preamble");
+        let payload = &b.bits[24..];
+        let violations = (15..payload.len())
+            .filter(|&i| payload[i] != (payload[i - 15] ^ payload[i - 14]))
+            .count();
+        assert_eq!(violations, 0, "fs={fs} off={off}: PRBS15 must hold");
+        eprintln!("fs={fs} off={off}: decoded {} bursts, PRBS15 clean", bursts.len());
+    }
+}


### PR DESCRIPTION
## Summary
Triggered by the live Iridium session decoding nothing. **Conclusion: the iridium core works correctly at the station's 6 MS/s** — the live silence is the antenna/signal (separately confirmed: SAWbird+IR powered and passing the band, but a full-band capture shows zero burst energy; the Maxtena PN100/M1621HCT-EXT1 passive antenna needs clear sky view).

What this PR adds:
- **`decodes_real_burst_at_station_rates`** — the wideband decoder had **no test above 2 MS/s**, yet the station runs it at 6 MS/s (decim 24); that gap is exactly why 6 MS/s correctness was unknown. The test upsamples the *real* gr-iridium reference burst to 2 and 6 MS/s at several offsets (including near the band edge) and asserts detect + demod with clean PRBS15. It passes — 6 MS/s is correct.
- **Noise-floor warmup** — the per-bin floor was seeded from a single frame, so many bins started near a noise null and read tens of dB "hot" for the EMA's whole settling time: a startup burst-detection storm, worse at the larger FFTs of higher rates (wasted CPU — CRC rejects them, so no false *decodes*). Now averages the floor over the first 64 frames (~33 ms) before detecting; real-burst detection is unaffected.

Note for future testing: `modulate()` is the **wrong** way to synthesize high-rate test signal — its RRC is a fixed 81 taps (~half a symbol at 6 MS/s sps=240), so it produces garbage above ~2 MS/s. Upsample real bursts instead (as this test and the existing 2 MS/s test do).

Bench gates unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved wideband burst detection accuracy by implementing a noise floor warmup phase that ensures stable threshold comparisons before detection begins.

* **Tests**
  * Added comprehensive integration test validating burst detection across multiple sampling rates, frequency offsets, and noise conditions with payload verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->