### PR TITLE
iridium: decode real off-air wideband captures (noise seed + DDC + ITL)

### DIFF
--- a/crates/xng-mode-iridium/src/demod.rs
+++ b/crates/xng-mode-iridium/src/demod.rs
@@ -43,6 +43,8 @@ pub struct IridiumDemod {
     pwr_pos: usize,
     pwr_sum: f32,
     level: f32,
+    /// Emit per-trigger acquisition diagnostics (XNG_IRIDIUM_DEBUG set).
+    debug: bool,
 }
 
 impl IridiumDemod {
@@ -60,7 +62,19 @@ impl IridiumDemod {
             pwr_pos: 0,
             pwr_sum: 0.0,
             level: 0.0,
+            debug: std::env::var("XNG_IRIDIUM_DEBUG").is_ok(),
         }
+    }
+
+    /// Seed the noise floor. The asymmetric EMA starts at 1.0 and needs
+    /// ~1400 samples of quiet to converge; a continuous stream gives it
+    /// that, but an isolated wideband-extracted burst has only a short
+    /// pre-roll, so without seeding the floor freezes ~18 dB high when the
+    /// burst arrives and the acquisition gate (`noise·8`) sits above the
+    /// signal. The wideband front end seeds this from the channel's own
+    /// measured noise.
+    pub fn seed_noise(&mut self, noise: f32) {
+        self.noise = noise.max(1e-12);
     }
 
     fn sample(&self, abs_pos: f64) -> Option<Complex<f32>> {
@@ -200,6 +214,8 @@ impl IridiumDemod {
             let theta0 = (2.0 * std::f64::consts::PI * cfo / SYMBOL_RATE) as f32;
             let burst_gate = self.noise * 8.0;
             let mut found: Option<(f32, f64, f32, f32, &'static [u8; 24])> = None;
+            let mut dbg_best = f32::INFINITY;
+            let mut dbg_energetic = 0u32;
             let mut hunt = 6.0 * self.sps;
             while hunt < (PRE_SYMS + 26.0) * self.sps {
                 let cand = bstart + hunt;
@@ -222,8 +238,10 @@ impl IridiumDemod {
                 if !energetic {
                     continue;
                 }
+                dbg_energetic += 1;
                 for (uw, access) in [(&UW_DL, ACCESS_DL), (&UW_UL, ACCESS_UL)] {
                     if let Some((cost, p2, th, ph)) = self.uw_fit(cand, uw, theta0) {
+                        dbg_best = dbg_best.min(cost);
                         if cost < 0.05 && found.map(|(c, ..)| cost < c).unwrap_or(true) {
                             found = Some((cost, p2, th, ph, access));
                         }
@@ -232,6 +250,19 @@ impl IridiumDemod {
                 if found.is_some() && hunt > 10.0 * self.sps {
                     break;
                 }
+            }
+            if self.debug {
+                eprintln!(
+                    "  trigger @ {:.0} (t={:.4}s): noise {:.2e} gate {:.2e}, cfo {:+.0} Hz, {} energetic windows, best UW cost {:.4}{}",
+                    pos,
+                    pos / (SYMBOL_RATE * self.sps),
+                    self.noise,
+                    burst_gate,
+                    cfo,
+                    dbg_energetic,
+                    dbg_best,
+                    if found.is_some() { "  SYNC" } else { "" }
+                );
             }
             let Some((_, uw_pos, theta, phase, access)) = found else {
                 // No UW: skip past this energy region.

--- a/crates/xng-mode-iridium/src/frame.rs
+++ b/crates/xng-mode-iridium/src/frame.rs
@@ -135,10 +135,17 @@ pub fn ecc_blocks(blocks: &[Vec<u8>], poly: u32) -> (Vec<u8>, u32) {
         let Some(errs) = bch_repair(poly, &mut b31) else {
             break;
         };
-        // Whole-block even parity (over the repaired 31 bits + parity).
+        // Whole-block even parity (over the repaired 31 bits + parity)
+        // guards against BCH miscorrection. A weight-1 correction on this
+        // d=5 BCH(31,21) is unambiguous (no weight-≤2 error shares a
+        // single-flip syndrome), so an odd overall parity after errs≤1
+        // means the separate parity bit was the second flipped bit — a
+        // harmless error that does not touch the 21 data bits. Only an
+        // errs==2 correction (BCH at its t=2 limit) with bad parity
+        // signals a likely >2-error miscorrection worth truncating on.
         let ones: u32 =
             b31.iter().map(|&v| v as u32).sum::<u32>() + block[31] as u32;
-        if ones % 2 == 1 && errs > 0 {
+        if ones % 2 == 1 && errs >= 2 {
             break;
         }
         if errs > 0 {
@@ -174,6 +181,9 @@ pub enum FrameKind {
     Bc,
     /// Messaging header seen (payload not parsed in v1).
     Ms,
+    /// Time-Location ("TL", satellite ranging broadcast). 96-bit header
+    /// `11` + 94 zeros; the payload is descrambled, not BCH-coded.
+    Itl,
     /// LCW-bearing duplex frame (DA/voice/IP/sync by frame type).
     Lw,
     Unknown,
@@ -184,6 +194,21 @@ pub enum FrameKind {
 pub fn classify(data: &[u8]) -> FrameKind {
     if data.len() >= 32 && data[..32] == HEADER_MESSAGING[..] {
         return FrameKind::Ms;
+    }
+    // ITL ("TL", Time-Location): 96-bit header is `11` followed by 94
+    // zeros (toolkit `header_time_location`). Match tolerantly — the
+    // 24-bit access + UW fit already confirmed a real burst, so a handful
+    // of off-air bit errors in the header must not let an ITL frame fall
+    // through to the IRA classifier, where its near-all-zero header is a
+    // valid (degenerate) BCH codeword and would mis-decode as an all-zero
+    // ring alert.
+    if data.len() >= 96 {
+        let diff = (data[0] == 0) as u32
+            + (data[1] == 0) as u32
+            + data[2..96].iter().map(|&b| b as u32).sum::<u32>();
+        if diff <= 3 {
+            return FrameKind::Itl;
+        }
     }
     if data.len() > 6 + 64 && ndivide(HDR_POLY, &data[..6]) == 0 {
         let (b1, b2) = de_interleave2(&data[6..6 + 64]);
@@ -207,12 +232,24 @@ pub fn classify(data: &[u8]) -> FrameKind {
         }
     }
     if data.len() >= 96 {
-        let (b1, b2, b3) = de_interleave3(&data[..96]);
-        if ndivide(RINGALERT_BCH_POLY, &b1[..31]) == 0
-            && ndivide(RINGALERT_BCH_POLY, &b2[..31]) == 0
-            && ndivide(RINGALERT_BCH_POLY, &b3[..31]) == 0
-        {
-            return FrameKind::Ra;
+        let (mut b1, mut b2, mut b3) = de_interleave3(&data[..96]);
+        let zeros = (ndivide(RINGALERT_BCH_POLY, &b1[..31]) == 0) as u32
+            + (ndivide(RINGALERT_BCH_POLY, &b2[..31]) == 0) as u32
+            + (ndivide(RINGALERT_BCH_POLY, &b3[..31]) == 0) as u32;
+        // Accept BCH-*correctable* headers, not just all-zero syndromes:
+        // a real off-air RA burst routinely carries one correctable bit
+        // error in the header, which the downstream ecc_blocks fixes. The
+        // 24-bit access code already gated this as a genuine burst, so
+        // requiring >=1 clean block + a small total error budget keeps
+        // false classifications away while not dropping real frames.
+        if let (Some(e1), Some(e2), Some(e3)) = (
+            bch_repair(RINGALERT_BCH_POLY, &mut b1[..31]),
+            bch_repair(RINGALERT_BCH_POLY, &mut b2[..31]),
+            bch_repair(RINGALERT_BCH_POLY, &mut b3[..31]),
+        ) {
+            if zeros >= 1 && e1 + e2 + e3 <= 3 {
+                return FrameKind::Ra;
+            }
         }
     }
     FrameKind::Unknown
@@ -345,6 +382,56 @@ mod tests {
         b31[17] ^= 1;
         assert_eq!(bch_repair(RINGALERT_BCH_POLY, &mut b31), Some(2));
         assert_eq!(&b31[..21], &data[..]);
+    }
+
+    #[test]
+    fn itl_header_classifies_as_itl_not_ra() {
+        // ITL ("TL"): 96-bit header `11` + 94 zeros, then payload.
+        let mut data = vec![0u8; 96 + 64];
+        data[0] = 1;
+        data[1] = 1;
+        for i in 96..data.len() {
+            data[i] = ((i * 7) % 3 == 0) as u8;
+        }
+        assert_eq!(classify(&data), FrameKind::Itl);
+        // A couple of off-air bit errors in the zero run still match ITL.
+        let mut noisy = data.clone();
+        noisy[40] = 1;
+        noisy[71] = 1;
+        assert_eq!(classify(&noisy), FrameKind::Itl);
+        // A degenerate all-zero header must never become a ring alert (its
+        // blocks are the trivially-valid all-zero BCH codeword).
+        assert_ne!(classify(&vec![0u8; 96 + 64]), FrameKind::Ra);
+    }
+
+    #[test]
+    fn ira_header_still_classifies_as_ra() {
+        // A real IRA header (nonzero data) is well clear of the ITL
+        // tolerance and must still classify as RA.
+        let b1 = bch_encode(RINGALERT_BCH_POLY, &rand_bits(21, 101));
+        let b2 = bch_encode(RINGALERT_BCH_POLY, &rand_bits(21, 102));
+        let b3 = bch_encode(RINGALERT_BCH_POLY, &rand_bits(21, 103));
+        let mut data = interleave3(&b1, &b2, &b3);
+        data.extend(std::iter::repeat(0u8).take(64));
+        assert_eq!(classify(&data), FrameKind::Ra);
+    }
+
+    #[test]
+    fn ecc_blocks_tolerates_flipped_parity_bit() {
+        // Three valid RA header blocks; block 2 carries one correctable
+        // BCH error AND a flipped overall-parity bit. The weight-1 BCH
+        // correction is unambiguous, so the block (and the whole frame)
+        // must survive rather than truncate at the parity mismatch.
+        let mut blocks = vec![
+            bch_encode(RINGALERT_BCH_POLY, &rand_bits(21, 11)),
+            bch_encode(RINGALERT_BCH_POLY, &rand_bits(21, 12)),
+            bch_encode(RINGALERT_BCH_POLY, &rand_bits(21, 13)),
+        ];
+        blocks[2][5] ^= 1; // BCH-correctable bit error
+        blocks[2][31] ^= 1; // overall even-parity bit flipped
+        let (payload, fixed) = ecc_blocks(&blocks, RINGALERT_BCH_POLY);
+        assert_eq!(payload.len(), 63, "all three blocks must survive");
+        assert!(fixed >= 1);
     }
 }
 

--- a/crates/xng-mode-iridium/src/lib.rs
+++ b/crates/xng-mode-iridium/src/lib.rs
@@ -125,6 +125,22 @@ pub fn decode_bits(bits: &[u8]) -> Option<ira::IridiumFrame> {
                 raw_bits: bits.to_vec(),
             })
         }
+        frame::FrameKind::Itl => {
+            // Time-Location (satellite ranging broadcast). The 96-bit
+            // `11`+0… header is recognized; the descrambled payload's
+            // satellite/plane PRS decode needs the toolkit's lookup tables
+            // and is deferred, but the frame is reported with its true
+            // type rather than mis-decoded as an all-zero ring alert.
+            Some(ira::IridiumFrame {
+                kind: "itl",
+                details: serde_json::json!({
+                    "type": "time-location",
+                    "payload_bits": data.len().saturating_sub(96),
+                }),
+                acars: None,
+                raw_bits: bits.to_vec(),
+            })
+        }
         _ => None,
     }
 }

--- a/crates/xng-mode-iridium/src/wideband.rs
+++ b/crates/xng-mode-iridium/src/wideband.rs
@@ -9,6 +9,7 @@ use crate::CHANNEL_RATE;
 use num_complex::Complex;
 use rustfft::Fft;
 use std::sync::Arc;
+use xng_dsp::Ddc;
 
 /// Detection threshold over the per-bin noise floor (gr-iridium: 16 dB).
 const THRESHOLD: f32 = 40.0; // linear ≈ 16 dB
@@ -26,6 +27,12 @@ const MAX_BURST_S: f64 = 0.092;
 const POST_S: f64 = 0.012;
 /// Pre-burst samples to include (preamble ramp).
 const PRE_S: f64 = 0.004;
+/// One-sided channel passband for the per-burst DDC. Wider than the
+/// single-channel decoder's 25 kHz so the demod's ±30 kHz tone-CFO search
+/// can still recover bursts whose detection centroid sits well off the
+/// true channel center under spectral leakage; the extra noise this admits
+/// is removed again by the demod's own matched processing.
+const WIDEBAND_PASSBAND_HZ: f64 = 50_000.0;
 
 struct ActiveBurst {
     /// Center bin of the detection.
@@ -41,7 +48,6 @@ pub struct IridiumWideband {
     /// suppressing duplicate split detections.
     recent: Vec<(u64, u64, usize)>,
     input_rate: f64,
-    decim: usize,
     fft: Arc<dyn Fft<f32>>,
     nfft: usize,
     window: Vec<f32>,
@@ -55,6 +61,8 @@ pub struct IridiumWideband {
     /// Frames folded into the floor so far (for the warmup mean).
     floor_frames: u64,
     active: Vec<ActiveBurst>,
+    /// Emit per-burst detection diagnostics (XNG_IRIDIUM_DEBUG set).
+    debug: bool,
 }
 
 /// A demodulated burst: bit stream plus its frequency offset from the
@@ -86,7 +94,6 @@ impl IridiumWideband {
             .collect();
         Ok(Self {
             input_rate,
-            decim,
             fft: rustfft::FftPlanner::new().plan_fft_forward(nfft),
             nfft,
             window,
@@ -101,6 +108,7 @@ impl IridiumWideband {
             floor_frames: 0,
             active: Vec::new(),
             recent: Vec::new(),
+            debug: std::env::var("XNG_IRIDIUM_DEBUG").is_ok(),
         })
     }
 
@@ -278,29 +286,61 @@ impl IridiumWideband {
         } else {
             (bin as f64 - self.nfft as f64) * self.input_rate / self.nfft as f64
         };
-        // Mix to baseband and decimate with a simple boxcar-of-decim FIR
-        // (the demod's own processing tolerates the soft rolloff).
+        if self.debug {
+            eprintln!(
+                "burst: bin {bin}, offset {f_off:+.0} Hz, frames {}..{} (t={:.4}s, {} frames)",
+                b.start_frame,
+                b.last_frame,
+                (b.start_frame * frame_len) as f64 / self.input_rate,
+                b.last_frame - b.start_frame + 1,
+            );
+        }
+        // Mix to baseband and decimate with a proper windowed-sinc DDC.
+        // A boxcar-of-decim averager is a poor anti-alias filter: its sinc
+        // sidelobes fold ~8 dB of wideband noise into the 250 kHz channel
+        // (measured peak/mean 8.5 dB vs 16.6 dB through a real anti-alias
+        // FIR on the same burst) — enough to push a marginal burst below
+        // the demod's acquisition gate. The DDC's two-stage Blackman-Harris
+        // FIR rejects the out-of-channel noise the same way the
+        // single-channel decoder does.
         let rel0 = (s0 - self.start_abs) as usize;
         let rel1 = (s1 - self.start_abs) as usize;
-        let step = -std::f64::consts::TAU * f_off / self.input_rate;
-        let mut chan: Vec<Complex<f32>> = Vec::with_capacity((rel1 - rel0) / self.decim + 1);
-        let mut acc = Complex::new(0.0f32, 0.0);
-        let mut n = 0usize;
-        for (i, s) in self.buf[rel0..rel1].iter().enumerate() {
-            let ph = step * (rel0 + i) as f64;
-            acc += s * Complex::from_polar(1.0, ph as f32);
-            n += 1;
-            if n == self.decim {
-                chan.push(acc / self.decim as f32);
-                acc = Complex::new(0.0, 0.0);
-                n = 0;
-            }
+        let mut ddc = Ddc::new(self.input_rate, CHANNEL_RATE, f_off, WIDEBAND_PASSBAND_HZ).ok()?;
+        let mut chan: Vec<Complex<f32>> = Vec::new();
+        ddc.process(&self.buf[rel0..rel1], &mut chan);
+
+        // Robust noise-floor estimate (20th percentile of channel power):
+        // the segment is pre-roll + burst + post, so a low order statistic
+        // lands in the noise regardless of burst length. This seeds the
+        // demod, whose own EMA floor would not converge within this short
+        // isolated segment (see IridiumDemod::seed_noise).
+        let mut powers: Vec<f32> = chan.iter().map(|s| s.norm_sqr()).collect();
+        let noise_floor = if powers.is_empty() {
+            1.0
+        } else {
+            let k = powers.len() / 5;
+            powers.select_nth_unstable_by(k, |a, b| a.total_cmp(b));
+            powers[k]
+        };
+        if self.debug {
+            let n = chan.len().max(1);
+            let mean = chan.iter().map(|s| s.norm_sqr()).sum::<f32>() / n as f32;
+            let peak = chan.iter().map(|s| s.norm_sqr()).fold(0.0f32, f32::max);
+            eprintln!(
+                "  channel: {} samples, mean pwr {:.2e}, peak pwr {:.2e}, noise {:.2e}, peak/noise {:.1} dB",
+                chan.len(),
+                mean,
+                peak,
+                noise_floor,
+                10.0 * (peak / noise_floor.max(1e-12)).log10()
+            );
         }
         // Quiet tail so the demod's burst-end detection and lookahead
         // complete within this call.
         chan.extend(std::iter::repeat(Complex::new(0.0f32, 0.0)).take((CHANNEL_RATE * 0.15) as usize));
 
         let mut demod = IridiumDemod::new(CHANNEL_RATE);
+        demod.seed_noise(noise_floor);
         let mut bits_out = demod.process(&chan);
         bits_out
             .pop()

--- a/docs/notes/IRIDIUM.md
+++ b/docs/notes/IRIDIUM.md
@@ -89,3 +89,42 @@ Validation: iridium-toolkit's parser run offline as an oracle on
 generated frames (bit-identical field decode), vectors vendored into
 unit tests; live RA channel needs only an L-band antenna (bursts every
 few seconds worldwide).
+
+## Wideband (wave 2) — decoding real off-air bursts
+
+The full-band hunter (`wideband.rs`) detects bursts by FFT, downmixes
+each to baseband, and feeds the single-channel demod. Getting this to
+decode a real 6 MS/s off-air capture (SAWbird+IR / Maxtena PN100) took
+three fixes, each isolated and tested:
+
+1. **Channelize with the DDC, not a boxcar.** A boxcar-of-decim averager
+   is a poor anti-alias filter — its sinc sidelobes fold ~8 dB of
+   wideband noise into the 250 kHz channel (measured peak/noise 8.5 dB
+   vs 16.6 dB through a real FIR on the same burst). Each burst now goes
+   through `xng_dsp::Ddc` (the same two-stage windowed-sinc the
+   single-channel path uses) at a 50 kHz one-sided passband (wider than
+   the single channel's 25 kHz so the demod's ±30 kHz tone-CFO search can
+   recover off-center detections).
+2. **Seed the demod noise floor (the decisive fix).** The demod's
+   asymmetric noise EMA starts at 1.0 and needs ~1400 quiet samples to
+   converge. A continuous stream gives it that; an isolated
+   wideband-extracted burst has only ~1000 channel samples of pre-roll,
+   so the floor froze ~18 dB high when the burst arrived and the
+   acquisition gate (`noise·8`) sat *above* the signal — zero energetic
+   windows, no UW fit attempted. The front end now estimates the
+   channel's noise (20th-percentile power) and `seed_noise()`s the demod
+   so the gate is correct from the first sample. This alone took the real
+   capture from 0 → decoding (clean UW costs 0.003–0.04).
+3. **Don't over-reject in the BCH/classify gates.** `ecc_blocks` trusts a
+   weight-1 BCH correction even when the separate even-parity bit is
+   flipped (an unambiguous correction on this d=5 code; the parity flip
+   is just a second, harmless error), and `classify` accepts
+   BCH-*correctable* RA headers, not only zero-syndrome ones.
+
+Frame typing: **ITL ("TL", Time-Location)** must be classified *before*
+IRA. Its 96-bit header is `11` + 94 zeros, which is a valid (degenerate)
+all-zero BCH codeword — so without an explicit ITL check it falls through
+to the IRA classifier and mis-decodes as a ring alert with an all-zero
+satellite/position. The real captures are dominated by ITL bursts; they
+are now reported as `kind:"itl"` (full satellite/plane PRS decode via the
+toolkit's `itl.py` tables is still TODO).


### PR DESCRIPTION
## What

The wideband Iridium hunter detected real bursts in a 6 MS/s off-air capture (SAWbird+IR / Maxtena PN100) but decoded **0 frames**. This makes it decode them, with three isolated, unit-tested fixes plus a missing frame type.

## Root causes & fixes

1. **Channelization — boxcar → DDC.** Each detected burst was downmixed and decimated with a boxcar-of-decim averager, a poor anti-alias filter: its sinc sidelobes fold ~8 dB of wideband noise into the 250 kHz channel (measured **peak/noise 8.5 dB** vs **16.6 dB** through a real FIR on the same burst). Now uses `xng_dsp::Ddc` (the two-stage windowed-sinc the single-channel path already trusts), 50 kHz one-sided passband so the demod's ±30 kHz tone-CFO search can recover off-center detections.

2. **Seed the demod noise floor — the decisive fix.** The demod's asymmetric noise EMA starts at 1.0 and needs ~1400 quiet samples to converge. A continuous stream gives it that; an isolated wideband-extracted burst has only ~1000 channel samples of pre-roll, so the floor froze ~**18 dB too high** when the burst arrived and the acquisition gate (`noise·8`) sat *above* the signal → 0 energetic windows, UW fit never attempted. The front end now estimates channel noise (20th-percentile power) and `seed_noise()`s the demod. This alone took the capture **0 → decoding** (clean UW costs 0.003–0.04).

3. **Stop over-rejecting in ECC/classify.** `ecc_blocks` now trusts a weight-1 BCH correction even when the separate even-parity bit is also flipped (unambiguous on this d=5 code; the parity flip is a harmless second error), and `classify` accepts BCH-*correctable* RA headers, not only zero-syndrome ones.

4. **Add the ITL ("TL", Time-Location) frame type, classified before IRA.** Its 96-bit `11`+0… header is a valid *degenerate* all-zero BCH codeword, so without an explicit ITL check it fell through to the IRA classifier and mis-decoded as a ring alert with an all-zero satellite/position. The real captures are ITL-dominated; they now report `kind:"itl"` (full satellite/plane PRS decode via the toolkit's `itl.py` tables is TODO).

## Result

- Real off-air capture: **0 → 2 ITL frames** decoded, correctly typed (no false all-zero ring alerts).
- All **283 workspace tests pass**, including new guards: `itl_header_classifies_as_itl_not_ra`, `ira_header_still_classifies_as_ra`, `ecc_blocks_tolerates_flipped_parity_bit`.
- Adds `XNG_IRIDIUM_DEBUG`-gated acquisition/detection diagnostics for future field work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional debug diagnostics mode for demodulation analysis.
  * Added support for Time-Location (ITL) frame type detection.
  * Improved noise floor estimation for enhanced demodulation performance.

* **Bug Fixes**
  * Enhanced frame classification logic to better distinguish frame types.
  * Refined error correction handling for improved frame validation.

* **Documentation**
  * Updated wideband decoder documentation with latest improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->