### PR TITLE
iridium: decode off-air duplex (LCW) frames — unblock SBD/ACARS path

### DIFF
--- a/crates/xng-mode-iridium/src/lib.rs
+++ b/crates/xng-mode-iridium/src/lib.rs
@@ -155,6 +155,7 @@ fn handle_bits(
     pager: &mut ms::PagerReassembler,
     out: &mut Vec<ira::IridiumFrame>,
 ) {
+    let n0 = out.len();
     if let Some(f) = decode_bits(bits) {
         // Multi-part pages: emit the assembled text when complete.
         if f.kind == "msg" {
@@ -205,6 +206,16 @@ fn handle_bits(
                 raw_bits: Vec::new(),
             });
         }
+    }
+    // Diagnose access-matched bursts that produced nothing (XNG_IRIDIUM_DEBUG).
+    if out.len() == n0 && std::env::var("XNG_IRIDIUM_DEBUG").is_ok() {
+        let data = if bits.len() > 24 { &bits[24..] } else { bits };
+        let head: String = data.iter().take(48).map(|&b| if b == 1 { '1' } else { '0' }).collect();
+        eprintln!(
+            "  DROP {} bits, classify={:?}, data[0..48]={head}",
+            bits.len(),
+            frame::classify(data)
+        );
     }
 }
 
@@ -275,10 +286,23 @@ fn decode_lcw_bits(bits: &[u8]) -> Option<(u8, &[u8])> {
     } else {
         return None;
     };
-    if frame::classify(data) != frame::FrameKind::Lw {
+    // Do NOT gate on the strict zero-syndrome `classify() == Lw`: real
+    // off-air LCWs routinely carry a few bit errors, which that check
+    // rejects outright (the burst then drops as Unknown). `decode_lcw`
+    // already BCH-corrects all three LCW components — accept it when the
+    // correction is light. Heavy correction means it isn't really an LCW
+    // frame. The 24-bit access code has already confirmed a genuine burst,
+    // and the frame type is validated by the callers (voice/ip/sync/DA),
+    // with a CRC on the DA path.
+    let (ft, _, _, errs) = frame::decode_lcw(data)?;
+    // DA (ft=2) carries ACARS/SBD and is CRC-protected downstream, so a bad
+    // LCW correction is caught there — give it the BCH's full reach. The
+    // CRC-less classes (voice/IP/sync) get a tight bound so a noisy LCW
+    // can't fabricate them.
+    let max_errs = if ft == 2 { 6 } else { 2 };
+    if errs > max_errs {
         return None;
     }
-    let (ft, _, _, _) = frame::decode_lcw(data)?;
     Some((ft, data))
 }
 

--- a/crates/xng-mode-iridium/tests/sbd_acars.rs
+++ b/crates/xng-mode-iridium/tests/sbd_acars.rs
@@ -29,6 +29,29 @@ fn da_roundtrip() {
 }
 
 #[test]
+fn da_decodes_with_lcw_bit_errors() {
+    // Real off-air LCWs carry a few bit errors. The LCW BCH corrects them,
+    // so decode_lcw_bits must accept the burst rather than gate on the
+    // strict zero-syndrome classify() (which drops it as Unknown). Without
+    // the tolerant gate this burst does not decode at all.
+    let mut payload = [0u8; 20];
+    for (i, b) in payload.iter_mut().enumerate() {
+        *b = (i as u8) * 5 + 1;
+    }
+    let mut bits = da_burst_bits(false, 1, 12, &payload);
+    // Flip two bits inside the 46-bit LCW (data positions 0..46, i.e. bit
+    // indices 24..70) — within the BCH's correction reach.
+    bits[24 + 2] ^= 1;
+    bits[24 + 40] ^= 1;
+    let (da, _) =
+        xng_mode_iridium::decode_da_bits(&bits).expect("DA with LCW bit errors still decodes");
+    assert_eq!(da.ctr, 1);
+    assert_eq!(da.len, 12);
+    assert_eq!(da.data, payload);
+    assert!(da.crc_ok, "payload CRC is unaffected by the LCW errors");
+}
+
+#[test]
 fn sbd_acars_end_to_end() {
     // A short ACARS block (standard SOH..DEL, built by xng-acars).
     let block = xng_acars::block::build(


### PR DESCRIPTION
## What

With full sky view the wideband hunter sees abundant Iridium **duplex** bursts that sync perfectly (UW cost ~0.002, access matched) — but every one was dropping as `Unknown`, so no voice/IP/sync/DA frames and no path to ACARS.

## Root cause

`decode_lcw_bits` gated on the **strict zero-syndrome** `classify() == Lw`. Any off-air bit error in the LCW fails that check → the burst drops — even though `decode_lcw` already BCH-corrects all three LCW components *behind* the gate. The entire duplex→DA→SBD→ACARS chain was unreachable on real RF.

## Fix

- **Drop the strict pre-gate** in `decode_lcw_bits`; accept the burst on `decode_lcw`'s own error-tolerant success. The 24-bit access code already confirms a genuine burst.
- **Frame-type-aware error budget:** DA (`ft=2`, the ACARS/SBD carrier) is CRC-protected downstream, so it gets the BCH's full reach (`errs ≤ 6`); the CRC-less classes (voice/IP/sync) get `errs ≤ 2` so a noisy LCW can't fabricate them.
- Adds an `XNG_IRIDIUM_DEBUG` diagnostic for access-matched bursts that yield no frame.

## Validation

- Real off-air duplex capture: bursts that previously **all** dropped now decode as `ida`/`sync`.
- New test `da_decodes_with_lcw_bit_errors`: a DA burst with LCW bit errors decodes (CRC verifies); **without** this fix it doesn't decode at all.
- Full iridium suite passes (lib 17, sbd 4, e2e 5, wideband 4, crossval 1).

Note: Iridium duplex traffic is **per-satellite-pass intermittent**, so live ACARS appears only during active periods — this lands the decode path so the station catches them when present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved decoding of burst traffic so some messages with correctable bit errors are now accepted instead of being dropped.
  * Added more informative debug output for dropped bursts when troubleshooting is enabled.
* **Tests**
  * Added coverage for decoding messages that contain correctable bit errors, confirming headers and payloads still decode successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->