### PR TITLE
iridium: drop degenerate all-zero bursts (false ring-alerts / empty voice)

### DIFF
--- a/crates/xng-mode-iridium/src/ira.rs
+++ b/crates/xng-mode-iridium/src/ira.rs
@@ -35,6 +35,13 @@ pub fn parse_ra(data: &[u8], fixed: u32, raw_bits: &[u8]) -> Option<IridiumFrame
     let x = pos_component(data, 13);
     let y = pos_component(data, 25);
     let z = pos_component(data, 37);
+    // Reject the degenerate all-zero header: an idle/noisy burst whose
+    // blocks BCH-correct to the trivially-valid all-zero codeword would
+    // otherwise emit a bogus ring alert at sat 0 / position (0,0,0). No
+    // real broadcasting satellite sits at Earth's center.
+    if sat == 0 && x == 0 && y == 0 && z == 0 {
+        return None;
+    }
     let ra_int = field(data, 49..56);
     let ts = data[56];
     let eip = data[57];

--- a/crates/xng-mode-iridium/src/lib.rs
+++ b/crates/xng-mode-iridium/src/lib.rs
@@ -155,6 +155,16 @@ fn handle_bits(
     pager: &mut ms::PagerReassembler,
     out: &mut Vec<ira::IridiumFrame>,
 ) {
+    // Drop degenerate idle/all-zero bursts up front. Their post-access bits
+    // BCH-correct to the trivially-valid all-zero codeword, which would
+    // otherwise surface as a false all-zero ring alert or an empty voice
+    // frame (and the all-zero LCW decodes to ft=0). Every real frame
+    // carries a roughly half-ones payload; an idle burst has almost none.
+    let payload = if bits.len() > 24 { &bits[24..] } else { bits };
+    let ones: usize = payload.iter().map(|&b| b as usize).sum();
+    if ones * 10 < payload.len() {
+        return;
+    }
     let n0 = out.len();
     if let Some(f) = decode_bits(bits) {
         // Multi-part pages: emit the assembled text when complete.

--- a/crates/xng-mode-iridium/tests/e2e.rs
+++ b/crates/xng-mode-iridium/tests/e2e.rs
@@ -240,3 +240,12 @@ fn oracle_validated_ims_vector() {
         Some("CALL OPS +14155550100")
     );
 }
+
+#[test]
+fn rejects_all_zero_ring_alert() {
+    // A degenerate all-zero header (an idle/noisy burst whose blocks
+    // BCH-correct to the trivially-valid zero codeword) must NOT emit a
+    // bogus ring alert at sat 0 / position (0,0,0).
+    let zero = vec![0u8; 96];
+    assert!(xng_mode_iridium::ira::parse_ra(&zero, 0, &[]).is_none());
+}


### PR DESCRIPTION
## What

A 1.5-hour live sweep audit showed **every** emitted `ring-alert` was `sat=0, pos=(0,0,0), alt=−6355` — non-physical garbage. (We also emitted empty `voice` frames with `payload_hex:"000000"`.)

## Root cause

An idle/noisy burst whose post-access bits **BCH-correct to the trivially-valid all-zero codeword** passes *every* code — the RA header blocks, the LCW components, all of it. So it surfaces as a bogus all-zero ring alert, and the all-zero LCW decodes to `ft=0` → an empty voice frame. The access code matched (it's a real burst), but the content is degenerate.

## Fix

- **`handle_bits`:** drop the burst up front when its post-access payload is almost all zeros (`ones*10 < len`). Every real frame (IRA/IBC/IMS/ITL/voice/IP/DA) carries a ~half-ones payload; an idle burst has almost none. This also prevents an all-zero frame from falling through to a false `voice` after `parse_ra` rejects it.
- **`parse_ra`:** reject `sat==0 && x==y==z==0` outright (API-level correctness — no broadcasting satellite sits at Earth's center).

## Validation

- New test `rejects_all_zero_ring_alert`.
- The oracle-validated real IRA (`oracle_validated_vector`, sat 75, real position/pages) **still decodes** — the guard only drops degenerate frames.
- Full iridium suite passes (lib 17, e2e 6, sbd 4, wideband 4, crossval 1).

Context: this is the last cleanup on the Iridium decode path — with the wideband channelization (#127) and duplex/LCW (#128) fixes, the station now decodes the full frame mix (itl/sync/ida/voice/ip-data/ring-alert/sbd/msg); this removes the one class of false output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where degenerate all-zero frames were incorrectly decoded as ring-alert frames. The decoder now properly rejects malformed idle bursts before processing, preventing false alerts from being generated.

* **Tests**
  * Added a test to verify rejection of all-zero ring-alert frames.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->