### PR TITLE
iridium: frequency-keyed SBD reassembly — fix ACARS in the wideband path

### DIFF
--- a/crates/xng-mode-iridium/src/lib.rs
+++ b/crates/xng-mode-iridium/src/lib.rs
@@ -65,7 +65,7 @@ impl IridiumChannelDecoder {
         let time = self.samples_seen as f64 / CHANNEL_RATE;
         let mut out = Vec::new();
         for burst in self.demod.process(channel) {
-            handle_bits(&burst.bits, time, &mut self.sbd, &mut self.pager, &mut out);
+            handle_bits(&burst.bits, time, 0.0, &mut self.sbd, &mut self.pager, &mut out);
         }
         out
     }
@@ -159,6 +159,7 @@ pub fn decode_bits(bits: &[u8]) -> Option<ira::IridiumFrame> {
 fn handle_bits(
     bits: &[u8],
     time: f64,
+    freq: f64,
     sbd: &mut sbd::SbdReassembler,
     pager: &mut ms::PagerReassembler,
     out: &mut Vec<ira::IridiumFrame>,
@@ -216,7 +217,8 @@ fn handle_bits(
             acars: None,
             raw_bits: raw,
         });
-        if let Some(msg) = sbd.push(&da, time) {
+        let ul = bits.len() >= 24 && bits[..24] == frame::ACCESS_UL[..];
+        if let Some(msg) = sbd.push(&da, time, freq, ul) {
             out.push(ira::IridiumFrame {
                 kind: "sbd",
                 details: msg.details.clone(),
@@ -272,7 +274,7 @@ impl IridiumWidebandDecoder {
         let mut out = Vec::new();
         for burst in self.wb.process(input) {
             let mut frames = Vec::new();
-            handle_bits(&burst.bits, time, &mut self.sbd, &mut self.pager, &mut frames);
+            handle_bits(&burst.bits, time, burst.offset_hz, &mut self.sbd, &mut self.pager, &mut frames);
             out.extend(frames.into_iter().map(|f| (burst.offset_hz, f)));
         }
         out

--- a/crates/xng-mode-iridium/src/sbd.rs
+++ b/crates/xng-mode-iridium/src/sbd.rs
@@ -6,13 +6,36 @@
 use crate::frame::DaFrame;
 use serde_json::json;
 
-/// Reassembles DA fragments (matched by counter continuity and burst
-/// time proximity; single-channel, so no frequency matching) into L2
-/// byte streams, then parses the SBD transport and extracts ACARS.
+/// Frequency match window for grouping a channel's fragments (Hz). The
+/// duplex channels are ~41.7 kHz apart, so this is comfortably narrow
+/// enough not to confuse neighbours while tolerating per-burst CFO drift.
+/// (iridium-toolkit uses ±260 Hz on gr-iridium's finer estimates.)
+const FREQ_TOL_HZ: f64 = 2000.0;
+/// Max gap between consecutive fragments of one message (toolkit 280 ms).
+const FRAG_GAP_S: f64 = 0.28;
+/// In-flight buffer lifetime before it is abandoned (toolkit 1000 ms).
+const EXPIRE_S: f64 = 1.0;
+
+/// One in-flight multi-fragment message.
+struct Pending {
+    freq: f64,
+    ul: bool,
+    /// Counter the next fragment must carry ((last + 1) mod 8).
+    next_ctr: u8,
+    data: Vec<u8>,
+    last_time: f64,
+}
+
+/// Reassembles DA fragments into L2 byte streams, then parses the SBD
+/// transport and extracts ACARS. Fragments are grouped exactly as
+/// iridium-toolkit's `ReassembleIDA` does — by frequency (same duplex
+/// channel), direction, sequential 3-bit counter, and time proximity —
+/// keeping a list of concurrent in-flight messages, which is essential in
+/// the wideband path where many channels are active at once (the old
+/// single-slot, frequency-blind reassembler interleaved fragments from
+/// different channels and almost never completed).
 pub struct SbdReassembler {
-    /// In-flight multi-fragment message: (next expected ctr, data,
-    /// last fragment time in seconds).
-    pending: Option<(u8, Vec<u8>, f64)>,
+    buf: Vec<Pending>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -23,43 +46,53 @@ pub struct SbdMessage {
 
 impl SbdReassembler {
     pub fn new() -> Self {
-        Self { pending: None }
+        Self { buf: Vec::new() }
     }
 
-    /// Feed one CRC-valid DA frame observed at `time` seconds.
-    pub fn push(&mut self, f: &DaFrame, time: f64) -> Option<SbdMessage> {
+    /// Feed one CRC-valid DA frame observed at `time` seconds on the burst
+    /// `freq` (Hz, any consistent reference) and direction (`ul`).
+    pub fn push(&mut self, f: &DaFrame, time: f64, freq: f64, ul: bool) -> Option<SbdMessage> {
         if !f.crc_ok {
             return None;
         }
-        // Expire stale assembly (toolkit: 280 ms between fragments).
-        if let Some((_, _, t)) = &self.pending {
-            if time - t > 0.3 {
-                self.pending = None;
-            }
-        }
+        self.buf.retain(|p| time - p.last_time < EXPIRE_S);
         let bytes = &f.data[..(f.len as usize).min(20)];
-        match (&mut self.pending, f.ctr, f.continuation) {
-            (None, 0, false) => Self::parse_l2(bytes),
-            (None, 0, true) => {
-                self.pending = Some((1, bytes.to_vec(), time));
+
+        // Continue an in-flight message: same channel + direction, the
+        // expected next counter, and within the inter-fragment window.
+        let m = self.buf.iter().position(|p| {
+            (p.freq - freq).abs() < FREQ_TOL_HZ
+                && p.ul == ul
+                && p.next_ctr == f.ctr
+                && time >= p.last_time
+                && time <= p.last_time + FRAG_GAP_S
+        });
+        if let Some(i) = m {
+            self.buf[i].data.extend_from_slice(bytes);
+            self.buf[i].last_time = time;
+            if f.continuation {
+                self.buf[i].next_ctr = (f.ctr + 1) % 8;
+                return None;
+            }
+            let p = self.buf.remove(i);
+            return Self::parse_l2(&p.data);
+        }
+
+        // No continuation: a fresh single packet, a new long packet, or an
+        // orphan continuation (dropped).
+        match (f.ctr, f.continuation) {
+            (0, false) => Self::parse_l2(bytes),
+            (0, true) => {
+                self.buf.push(Pending {
+                    freq,
+                    ul,
+                    next_ctr: 1,
+                    data: bytes.to_vec(),
+                    last_time: time,
+                });
                 None
             }
-            (Some((next, data, _)), ctr, cont) if ctr == *next => {
-                data.extend_from_slice(bytes);
-                if cont {
-                    let d = data.clone();
-                    self.pending = Some(((ctr + 1) % 8, d, time));
-                    None
-                } else {
-                    let d = data.clone();
-                    self.pending = None;
-                    Self::parse_l2(&d)
-                }
-            }
-            _ => {
-                self.pending = None;
-                None
-            }
+            _ => None,
         }
     }
 
@@ -75,13 +108,17 @@ impl SbdReassembler {
             _ => return None,
         };
         match typ {
+            // HELLO / registration: a 29-byte pre-header (any sub-type —
+            // toolkit accepts sub-types 0x10/0x20/0x40/0x50/0x70).
             0x0600 => {
-                if rest.first() != Some(&0x20) || rest.len() < 29 {
+                if rest.len() < 29 {
                     return None;
                 }
                 rest = &rest[29..];
             }
-            0x7608 => {
+            // All 76xx SBD subtypes (7608/7609/760a/760c/d/e) carry a
+            // 0x26 (7-byte) or 0x20 (5-byte) pre-header.
+            t if t >> 8 == 0x76 => {
                 let skip = match rest.first() {
                     Some(0x26) => 7,
                     Some(0x20) => 5,

--- a/crates/xng-mode-iridium/tests/sbd_acars.rs
+++ b/crates/xng-mode-iridium/tests/sbd_acars.rs
@@ -77,7 +77,7 @@ fn sbd_acars_end_to_end() {
         let bits = da_burst_bits(cont, (i % 8) as u8, chunk.len() as u8, &payload);
         let (da, _) = xng_mode_iridium::decode_da_bits(&bits).expect("fragment decodes");
         assert!(da.crc_ok);
-        if let Some(msg) = reasm.push(&da, i as f64 * 0.09) {
+        if let Some(msg) = reasm.push(&da, i as f64 * 0.09, 0.0, false) {
             result = Some(msg);
         }
     }
@@ -87,6 +87,64 @@ fn sbd_acars_end_to_end() {
     assert_eq!(acars.core.tail.as_deref(), Some("N321AB"));
     assert_eq!(acars.core.label, "Q0");
     assert_eq!(acars.core.flight.as_deref(), Some("UA1234"));
+}
+
+#[test]
+fn reassembles_interleaved_channels() {
+    // Two messages whose fragments interleave in time but sit on different
+    // frequencies must each reassemble. The old single-slot, frequency-
+    // blind reassembler would clobber one with the other — this is the
+    // wideband-path bug that stopped ACARS from ever completing.
+    fn l2_for(tail: &str, flight: &str) -> Vec<u8> {
+        let block = xng_acars::block::build(
+            '2', tail, None, "Q0", '5', Some("M01A"), Some(flight), "", false,
+        );
+        let mut l2: Vec<u8> = vec![0x06, 0x00];
+        let mut prehdr = vec![0u8; 29];
+        prehdr[0] = 0x20;
+        prehdr[15] = 1;
+        l2.extend_from_slice(&prehdr);
+        l2.extend_from_slice(&block);
+        l2
+    }
+    fn da_frames(l2: &[u8]) -> Vec<frame::DaFrame> {
+        let chunks: Vec<&[u8]> = l2.chunks(20).collect();
+        chunks
+            .iter()
+            .enumerate()
+            .map(|(i, c)| {
+                let mut p = [0u8; 20];
+                p[..c.len()].copy_from_slice(c);
+                let bits = da_burst_bits(i + 1 < chunks.len(), (i % 8) as u8, c.len() as u8, &p);
+                xng_mode_iridium::decode_da_bits(&bits).expect("frag decodes").0
+            })
+            .collect()
+    }
+    let a = da_frames(&l2_for("N321AB", "UA1234"));
+    let b = da_frames(&l2_for("N555CD", "DL9999"));
+    assert!(a.len() >= 2 && b.len() >= 2, "need multi-fragment messages");
+
+    let mut reasm = SbdReassembler::new();
+    let (mut got_a, mut got_b) = (None, None);
+    for i in 0..a.len().max(b.len()) {
+        let t = i as f64 * 0.1;
+        if let Some(f) = a.get(i) {
+            if let Some(m) = reasm.push(f, t, 100_000.0, false) {
+                got_a = Some(m);
+            }
+        }
+        if let Some(f) = b.get(i) {
+            if let Some(m) = reasm.push(f, t, 200_000.0, false) {
+                got_b = Some(m);
+            }
+        }
+    }
+    let ma = got_a.expect("channel A reassembled").acars.expect("A ACARS");
+    let mb = got_b.expect("channel B reassembled").acars.expect("B ACARS");
+    assert_eq!(ma.core.flight.as_deref(), Some("UA1234"));
+    assert_eq!(ma.core.tail.as_deref(), Some("N321AB"));
+    assert_eq!(mb.core.flight.as_deref(), Some("DL9999"));
+    assert_eq!(mb.core.tail.as_deref(), Some("N555CD"));
 }
 
 #[test]


### PR DESCRIPTION
## What

ACARS over Iridium rides **SBD fragments** (LCW `ft=2` / IDA frames) reassembled across multiple bursts. We were seeing isolated IDA fragments but **never completing an ACARS message** — because the reassembler kept a **single** in-flight slot and explicitly did *"no frequency matching"*.

That's fine for one channel, but **fatal in the wideband path**: many duplex channels are active at once, so fragments from *different* channels interleaved into the one slot and reassembly almost never completed. (Verified against iridium-toolkit's `ReassembleIDA`, which keeps a *list* and matches by frequency.)

## Fix

Reworked `SbdReassembler` to mirror `ReassembleIDA`:
- Keep a **list** of concurrent in-flight messages.
- Group fragments by **frequency** (same duplex channel, ±2 kHz), **direction** (UL/DL), **sequential 3-bit counter**, and the **280 ms** inter-fragment window; expire after 1 s.
- `handle_bits` now threads the burst **frequency** + UL/DL to the reassembler (the wideband burst's `offset_hz`; `0` for the single-channel path).

Also:
- Generalized `parse_l2` to **all `76xx` SBD subtypes** (was `7608`-only; `7609/760a/760c/d/e` now skip their pre-header correctly) and relaxed the `0600` HELLO check to match the reference.
- Confirmed against iridium-toolkit that **`ft=2`/IDA is the SBD carrier** (ft 6 = "PT=", ft 7 = sync), so the existing `ft==2` gate is correct — the "2/6/7" note conflated frame classes.

## Validation

New test `reassembles_interleaved_channels`: two messages whose fragments interleave in time but sit on different frequencies each reassemble to their **own** ACARS (`UA1234`/`N321AB` and `DL9999`/`N555CD`) — impossible under the old single-slot reassembler. Full iridium suite passes (lib 17, e2e 6, itl 1, sbd 5, wideband 4, crossval 1).

Live ACARS now depends only on catching an active duplex SBD pass while parked on that window — the decode path is correct end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced SBD/ACARS message reassembly to handle multiple concurrent messages across different frequencies and directions simultaneously
  * Improved uplink versus downlink message classification
  * Strengthened support for interleaved channel data streams
  * Refined L2 protocol parsing for transport compatibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->