### PR TITLE
Iridium: U3 (ft=3) RS8/RS6 inner decode (I38/I36)

### DIFF
--- a/crates/xng-mode-iridium/src/iip.rs
+++ b/crates/xng-mode-iridium/src/iip.rs
@@ -25,7 +25,7 @@ fn iip_type_name(t: u8) -> &'static str {
 /// The toolkit's 16-bit one's-complement-style checksum over the
 /// 31-byte RS message: sum of 14 LE u16 + 1 byte + 1 LE u16, carry
 /// folded once, complemented.
-fn checksum_16(msg: &[u8; 31]) -> u16 {
+pub(crate) fn checksum_16(msg: &[u8; 31]) -> u16 {
     let mut sum: u32 = 0;
     for w in msg[..28].chunks_exact(2) {
         sum += u16::from_le_bytes([w[0], w[1]]) as u32;

--- a/crates/xng-mode-iridium/src/lib.rs
+++ b/crates/xng-mode-iridium/src/lib.rs
@@ -10,6 +10,7 @@ pub mod itl;
 mod itl_tables;
 pub mod ms;
 pub mod sbd;
+pub mod u3;
 pub mod voice;
 pub mod wideband;
 pub mod modulate;
@@ -410,6 +411,11 @@ pub fn lcw_traffic_frame(bits: &[u8]) -> Option<ira::IridiumFrame> {
     } else if ft == 1 {
         // IP channel: IIP/IIQ/IIR frame classification.
         if let Some(serde_json::Value::Object(extra)) = iip::parse_ip_payload(payload) {
+            details.as_object_mut().unwrap().extend(extra);
+        }
+    } else if ft == 3 {
+        // U3 (mission-control in-band signalling): RS8/RS6 inner decode.
+        if let serde_json::Value::Object(extra) = u3::parse_u3(payload) {
             details.as_object_mut().unwrap().extend(extra);
         }
     }

--- a/crates/xng-mode-iridium/src/u3.rs
+++ b/crates/xng-mode-iridium/src/u3.rs
@@ -1,0 +1,113 @@
+//! U3 (LCW frame type 3, "mission-control in-band signalling") inner
+//! decode (iridium-toolkit `IridiumLCW3Message`). The 312-bit payload is
+//! Reed-Solomon protected; try the GF(256) byte code first (→ I38, with a
+//! 16-bit checksum and an odd byte), then the GF(64) 6-bit code (→ I36,
+//! whose first symbol selects a numeric sub-format). Falls back to a raw
+//! dump (IU3). The RS codes are the same ones the voice path uses.
+
+use crate::iip::checksum_16;
+use crate::voice::{rs6_correct, vod_correct, RS6_N};
+use serde_json::{json, Value};
+
+fn hex(bytes: &[u8]) -> String {
+    bytes.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+/// Decode the post-LCW payload bits of an ft==3 (U3) burst.
+pub fn parse_u3(payload_bits: &[u8]) -> Value {
+    if payload_bits.len() < 312 {
+        return json!({ "u3_type": "IU3" });
+    }
+    let p = &payload_bits[..312];
+
+    // I38: GF(256) RS over the 39-byte view (31 data + 8 checks).
+    let mut bytes = [0u8; 39];
+    for (i, c) in p.chunks(8).take(39).enumerate() {
+        bytes[i] = c.iter().fold(0u8, |v, &b| (v << 1) | b);
+    }
+    if let Some(rs8m) = vod_correct(&bytes) {
+        // rs8m: 31 bytes. csum over [0:28]+[29:31]; odd byte at [28].
+        let cs_ok = checksum_16(&rs8m) == 0;
+        let oddbyte = rs8m[28];
+        // On a clean checksum the toolkit drops the trailing 3 bytes
+        // (oddbyte + 2 csum) and the trailing zeros.
+        let data: &[u8] = if cs_ok {
+            let end = rs8m[..28].iter().rposition(|&x| x != 0).map_or(0, |i| i + 1);
+            &rs8m[..end]
+        } else {
+            &rs8m[..]
+        };
+        return json!({
+            "u3_type": "I38",
+            "cs_ok": cs_ok,
+            "odd_byte": oddbyte,
+            "data_hex": hex(data),
+        });
+    }
+
+    // I36: GF(64) RS(52,42) over the 6-bit view.
+    let mut cw6 = [0u8; RS6_N];
+    for (i, c) in p.chunks(6).take(RS6_N).enumerate() {
+        cw6[i] = c.iter().fold(0u8, |v, &b| (v << 1) | b);
+    }
+    if let Ok(fixed) = rs6_correct(&mut cw6) {
+        let rs6m = &cw6[..42];
+        let subformat = rs6m[0];
+        // Bit string of symbols 1..42 (each 6 bits, MSB-first).
+        let v: Vec<u8> = rs6m[1..]
+            .iter()
+            .flat_map(|&s| (0..6).rev().map(move |k| (s >> k) & 1))
+            .collect();
+        let mut out = json!({
+            "u3_type": "I36",
+            "subformat": subformat,
+            "rs_corrected": fixed,
+        });
+        // Numeric sub-formats carry 24-bit groups after a 2-bit lead.
+        let group = |bits: &[u8], n: usize| -> Vec<u64> {
+            bits.chunks(n)
+                .filter(|c| c.len() == n)
+                .map(|c| c.iter().fold(0u64, |a, &b| (a << 1) | b as u64))
+                .collect()
+        };
+        match subformat {
+            6 => {
+                let mut nums = group(&v[2..], 24);
+                while nums.last() == Some(&0) {
+                    nums.pop();
+                }
+                out["numbers"] = json!(nums);
+            }
+            32 | 34 => {
+                let body = &v[2..v.len().saturating_sub(4)];
+                let mut nums = group(body, 24);
+                let tail = group(&v[v.len().saturating_sub(4)..], 4);
+                if let Some(&t) = tail.first() {
+                    if t != 0 {
+                        nums.push(t);
+                    }
+                }
+                while nums.last() == Some(&0x7ffff) {
+                    nums.pop();
+                }
+                out["numbers"] = json!(nums);
+            }
+            _ => {
+                out["data_hex"] = json!(hex(rs6m));
+            }
+        }
+        return out;
+    }
+
+    json!({ "u3_type": "IU3" })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn short_payload_is_iu3() {
+        assert_eq!(parse_u3(&[0u8; 100])["u3_type"], "IU3");
+    }
+}

--- a/crates/xng-mode-iridium/src/voice.rs
+++ b/crates/xng-mode-iridium/src/voice.rs
@@ -75,13 +75,13 @@ impl Gf64 {
     }
 }
 
-const RS6_N: usize = 52;
+pub(crate) const RS6_N: usize = 52;
 const RS6_NPAR: usize = 10;
 const RS6_FCR: u32 = 54;
 
 /// Errors-only RS decode of the 52×6-bit voice codeword. Returns the
 /// number of corrected symbols, or Err if the word is uncorrectable.
-fn rs6_correct(cw: &mut [u8; RS6_N]) -> Result<usize, ()> {
+pub(crate) fn rs6_correct(cw: &mut [u8; RS6_N]) -> Result<usize, ()> {
     let gf = Gf64::new();
     let n = RS6_N;
 
@@ -209,7 +209,7 @@ fn rs6_correct(cw: &mut [u8; RS6_N]) -> Result<usize, ()> {
 
 /// GF(256) RS for the VOD byte view: 31 data + 8 transmitted checks +
 /// 8 untransmitted (erased) checks, fcr 0, prim 0x11d.
-fn vod_correct(payload: &[u8; 39]) -> Option<[u8; 31]> {
+pub(crate) fn vod_correct(payload: &[u8; 39]) -> Option<[u8; 31]> {
     let rs = ReedSolomon::new(0x11d, 16, 0);
     // Embed as the tail of a full 255-symbol codeword; the 8 missing
     // check octets are erasures at the end.

--- a/crates/xng-mode-iridium/tests/offair_oracle.rs
+++ b/crates/xng-mode-iridium/tests/offair_oracle.rs
@@ -91,4 +91,6 @@ fn offair_u3_lcw_handoff() {
     assert_eq!(f.details["frame_ft"], 3);
     assert_eq!(f.details["lcw"]["type"], "hndof");
     assert_eq!(f.details["lcw"]["code"], "handoff_cand");
+    // iridium-parser.py decoded this one as IU3 (RS did not correct).
+    assert_eq!(f.details["u3_type"], "IU3");
 }


### PR DESCRIPTION
Completes the one frame sub-decode we surfaced but left raw. The ft=3 "mission-control in-band signalling" (U3) payload is Reed-Solomon protected; this ports iridium-toolkit's `IridiumLCW3Message`:

- **I38** — GF(256) byte code (39→31), with the 16-bit `checksum_16` and odd byte
- **I36** — GF(64) `RS(52,42)` 6-bit code, first symbol selects a numeric sub-format (24-bit number groups for subformats 6/32/34)
- **IU3** — raw fallback when neither RS corrects

The RS codes are **identical** to the voice path (I38 = VOD's GF(256), I36 = VO6's `RS(52,42)`) and the checksum is IIQ/IIR's, so this reuses `vod_correct` / `rs6_correct` / `checksum_16` (exposed `pub(crate)`) — no new codec. The `u3` frame now carries `u3_type` + `cs_ok`/`odd_byte`/`data_hex` (I38) or `subformat`/`numbers` (I36).

Validated: the captured U3 frame decodes as **IU3**, matching `iridium-parser.py` (RS didn't correct it); the oracle asserts it. Workspace tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)