### PR TITLE
Iridium: IDA application layer — mobile-terminal positions + GSM signalling

### DIFF
--- a/crates/xng-mode-iridium/src/gsm.rs
+++ b/crates/xng-mode-iridium/src/gsm.rs
@@ -1,0 +1,258 @@
+//! Iridium duplex GSM signalling decode over the reassembled IDA channel
+//! (ported from iridium-toolkit `reassembler.py ReassembleIDAPP`). Iridium
+//! tunnels a GSM-derived call-control / mobility-management / SMS protocol;
+//! a reassembled IDA packet whose first byte is a CC/MM/SMS transaction
+//! identifier carries one of these messages. SBD (0x76 / 0x0600) is handled
+//! separately by the ACARS path.
+
+use serde_json::{json, Value};
+
+/// Major protocol label for a transaction-identifier high byte.
+fn major(tmaj: u8) -> Option<&'static str> {
+    Some(match tmaj {
+        0x03 => "CC",
+        0x83 => "CC(dest)",
+        0x05 => "MM",
+        0x06 => "06",
+        0x08 => "08",
+        0x09 => "SMS",
+        0x89 => "SMS(dest)",
+        _ => return None,
+    })
+}
+
+/// Message label for a 16-bit transaction-identifier (high byte masked).
+fn minor(tmin: u16) -> Option<&'static str> {
+    Some(match tmin {
+        0x0301 => "Alerting",
+        0x0302 => "Call Proceeding",
+        0x0303 => "Progress",
+        0x0305 => "Setup",
+        0x030f => "Connect Acknowledge",
+        0x0325 => "Disconnect",
+        0x032a => "Release Complete",
+        0x032d => "Release",
+        0x0502 => "Location Updating Accept",
+        0x0504 => "Location Updating Reject",
+        0x0508 => "Location Updating Request",
+        0x0512 => "Authentication Request",
+        0x0514 => "Authentication Response",
+        0x0518 => "Identity request",
+        0x0519 => "Identity response",
+        0x051a => "TMSI Reallocation Command",
+        0x0600 => "Register/SBD:uplink",
+        0x0901 => "CP-DATA",
+        0x0904 => "CP-ACK",
+        0x0910 => "CP-ERROR",
+        _ => return None,
+    })
+}
+
+/// GSM Mobile Identity IE → (identity object, bytes consumed). Returns
+/// None (PARSE_FAIL) on a malformed IE.
+fn p_mi_iei(d: &[u8]) -> Option<(Value, usize)> {
+    if d.len() < 2 {
+        return None;
+    }
+    let iei_len = d[0] as usize;
+    let iei_dig = d[1] >> 4;
+    let iei_odd = (d[1] >> 3) & 1;
+    let iei_typ = d[1] & 7;
+    match iei_typ {
+        1 | 2 => {
+            // IMSI / IMEI: 15 digits, odd indicator set, length 8.
+            if iei_odd == 1 && iei_len == 8 && d.len() >= 9 {
+                let mut s = format!("{iei_dig:x}");
+                for &b in &d[2..9] {
+                    s.push_str(&format!("{:x}{:x}", b & 0xf, b >> 4));
+                }
+                let label = if iei_typ == 1 { "imsi" } else { "imei" };
+                Some((json!({ "type": label, "value": s }), 9))
+            } else {
+                None
+            }
+        }
+        4 => {
+            // TMSI: 4 raw bytes.
+            if iei_odd == 0 && iei_len == 5 && iei_dig == 0xf && d.len() >= 6 {
+                Some((
+                    json!({ "type": "tmsi", "value": format!("{:02x}{:02x}{:02x}{:02x}", d[2], d[3], d[4], d[5]) }),
+                    6,
+                ))
+            } else {
+                None
+            }
+        }
+        _ => None,
+    }
+}
+
+/// Location Area Identification IE → ({mcc,mnc,lac}, consumed).
+fn p_lai(d: &[u8]) -> Option<(Value, usize)> {
+    if d.len() < 5 || d[1] >> 4 != 0xf {
+        return None;
+    }
+    let mcc = format!("{}{}{}", d[0] & 0xf, d[0] >> 4, d[1] & 0xf);
+    let mnc = format!("{}{}", d[2] >> 4, d[2] & 0xf);
+    let lac = format!("{:02x}{:02x}", d[3], d[4]);
+    Some((json!({ "mcc": mcc, "mnc": mnc, "lac": lac }), 5))
+}
+
+/// Disconnect-cause IE → ({location,cause,cause_text}, consumed).
+fn p_disc(d: &[u8]) -> Option<(Value, usize)> {
+    if d.len() < 3 || d[0] < 2 || d[1] >> 4 != 0xe {
+        return None;
+    }
+    let net = d[1] & 0xf;
+    let cause = d[2] & 0x7f;
+    let location = match net {
+        0 => "user".to_string(),
+        2 => "local".to_string(),
+        3 => "transit".to_string(),
+        4 => "remote".to_string(),
+        n => format!("net:{n}"),
+    };
+    let cause_text = match cause {
+        1 => "Unassigned number",
+        16 => "Normal call clearing",
+        17 => "User busy",
+        31 => "Normal, unspecified",
+        34 => "No channel available",
+        41 => "Temporary failure",
+        57 => "Bearer cap. not authorized",
+        127 => "Interworking, unspecified",
+        _ => "",
+    };
+    let consumed = if (d[2] >> 7) == 1 && d[0] == 3 && d.len() >= 4 && d[3] == 0x88 {
+        4 // CCBS not possible
+    } else {
+        3
+    };
+    Some((
+        json!({ "location": location, "cause": cause, "cause_text": cause_text }),
+        consumed,
+    ))
+}
+
+/// Decode a reassembled IDA packet as a GSM CC/MM/SMS message. Returns
+/// None if the first byte is not a recognised CC/MM/SMS transaction major.
+pub fn decode(data: &[u8]) -> Option<Value> {
+    if data.len() <= 2 {
+        return None;
+    }
+    let tmaj = data[0];
+    let maj = major(tmaj)?;
+    // SBD majors are handled by the ACARS path, not here.
+    if tmaj == 0x76 || (tmaj == 0x06 && data[1] == 0x00) {
+        return None;
+    }
+    let b0 = if tmaj == 0x83 || tmaj == 0x89 { tmaj & 0x7f } else { tmaj };
+    let tmin = ((b0 as u16) << 8) | data[1] as u16;
+    let body = &data[2..];
+
+    let mut out = json!({
+        "type": "gsm",
+        "protocol": maj,
+        "message": minor(tmin).unwrap_or("?"),
+        "tmin": format!("{tmin:04x}"),
+    });
+    let obj = out.as_object_mut().unwrap();
+
+    // Per-message body decode (the subset iridium-toolkit field-parses).
+    match tmin {
+        0x032d | 0x032a => {
+            // Release / Release Complete: optional disconnect cause.
+            if body.len() == 4 && body[0] == 8 {
+                if let Some((v, _)) = p_disc(&body[1..]) {
+                    obj.insert("disconnect".into(), v);
+                }
+            }
+        }
+        0x0325 => {
+            if let Some((v, _)) = p_disc(body) {
+                obj.insert("disconnect".into(), v);
+            }
+        }
+        0x0502 => {
+            // Location Updating Accept: LAI [+ mobile identity] [+ follow-on].
+            if let Some((lai, n)) = p_lai(body) {
+                obj.insert("lai".into(), lai);
+                let mut rest = &body[n..];
+                if rest.first() == Some(&0x17) {
+                    if let Some((mi, _)) = p_mi_iei(&rest[1..]) {
+                        obj.insert("mobile_id".into(), mi);
+                    }
+                    rest = &rest[1..];
+                }
+                if rest.first() == Some(&0xa1) {
+                    obj.insert("follow_on".into(), json!(true));
+                }
+            }
+        }
+        0x0508 => {
+            // Location Updating Request.
+            if body.len() >= 7 && body[0] & 0xf == 0 && body[6] == 0x28 {
+                let key = body[0] >> 4;
+                obj.insert("key_seq".into(), if key == 7 { json!("none") } else { json!(key) });
+                if let Some((lai, _)) = p_lai(&body[1..]) {
+                    obj.insert("lai".into(), lai);
+                }
+                // byte after LAI (5) + classmark (1) = offset 7.
+                if body.len() > 7 {
+                    if let Some((mi, _)) = p_mi_iei(&body[7..]) {
+                        obj.insert("mobile_id".into(), mi);
+                    }
+                }
+            }
+        }
+        0x051a => {
+            if let Some((lai, n)) = p_lai(body) {
+                obj.insert("lai".into(), lai);
+                if let Some((mi, _)) = p_mi_iei(&body[n..]) {
+                    obj.insert("mobile_id".into(), mi);
+                }
+            }
+        }
+        0x0504 => {
+            if body.first() == Some(&2) {
+                obj.insert("reject".into(), json!("IMSI unknown in HLR"));
+            }
+        }
+        0x0518 => match body.first() {
+            Some(2) => {
+                obj.insert("requested".into(), json!("IMEI"));
+            }
+            Some(1) => {
+                obj.insert("requested".into(), json!("IMSI"));
+            }
+            _ => {}
+        },
+        0x0519 => {
+            if let Some((mi, _)) = p_mi_iei(body) {
+                obj.insert("mobile_id".into(), mi);
+            }
+        }
+        _ => {}
+    }
+    Some(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn non_gsm_major_is_none() {
+        assert!(decode(&[0x76, 0x08, 0, 0, 0]).is_none());
+        assert!(decode(&[0x06, 0x00, 0, 0, 0]).is_none());
+    }
+
+    #[test]
+    fn identity_request_imei() {
+        // CC/MM major 0x05, Identity request 0x0518, body 0x02 = IMEI.
+        let v = decode(&[0x05, 0x18, 0x02]).expect("decodes");
+        assert_eq!(v["protocol"], "MM");
+        assert_eq!(v["message"], "Identity request");
+        assert_eq!(v["requested"], "IMEI");
+    }
+}

--- a/crates/xng-mode-iridium/src/lib.rs
+++ b/crates/xng-mode-iridium/src/lib.rs
@@ -8,7 +8,9 @@ pub mod iip;
 pub mod ira;
 pub mod itl;
 mod itl_tables;
+pub mod gsm;
 pub mod ms;
+pub mod mtpos;
 pub mod sbd;
 pub mod u3;
 pub mod voice;
@@ -225,7 +227,7 @@ fn handle_bits(
         let ul = bits.len() >= 24 && bits[..24] == frame::ACCESS_UL[..];
         if let Some(msg) = sbd.push(&da, time, freq, ul) {
             out.push(ira::IridiumFrame {
-                kind: "sbd",
+                kind: msg.kind,
                 details: msg.details.clone(),
                 acars: msg.acars,
                 raw_bits: Vec::new(),

--- a/crates/xng-mode-iridium/src/mtpos.rs
+++ b/crates/xng-mode-iridium/src/mtpos.rs
@@ -1,0 +1,139 @@
+//! Mobile-terminal geocentric position extraction (ported from
+//! iridium-sniffer `web_map.c mtpos_ida_cb`). Some GSM-paging / SBD-paging
+//! / uplink IDA messages embed the mobile terminal's own ECEF position as
+//! three signed 12-bit values (units of 4 km) — a position source distinct
+//! from the IRA satellite positions. A terminal here may be an
+//! Iridium-equipped aircraft or vessel.
+
+use serde_json::{json, Value};
+
+/// Unpack three signed 12-bit ECEF components from a 5-byte big-endian
+/// field and derive lat/lon/alt. `skip` is 0 or 4 (selects whether the
+/// 36 used bits sit at the high or low end of the 40-bit field).
+fn xyz(bytes: &[u8], skip: u32) -> Option<(f64, f64, i32, i32, i32, i32)> {
+    if bytes.len() < 5 {
+        return None;
+    }
+    let mut val: u64 = 0;
+    for &b in &bytes[..5] {
+        val = (val << 8) | b as u64;
+    }
+    let sb = 4 - skip;
+    let ext = |f: u64| -> i32 {
+        let v = (f & 0xfff) as i32;
+        if v > 0x7ff {
+            v - 0x1000
+        } else {
+            v
+        }
+    };
+    let x = ext(val >> (24 + sb));
+    let y = ext(val >> (12 + sb));
+    let z = ext(val >> sb);
+    if x == 0 && y == 0 && z == 0 {
+        return None;
+    }
+    let (xf, yf, zf) = (x as f64, y as f64, z as f64);
+    let lat = zf.atan2((xf * xf + yf * yf).sqrt()).to_degrees();
+    let lon = yf.atan2(xf).to_degrees();
+    let radius_km = (xf * xf + yf * yf + zf * zf).sqrt() * 4.0;
+    let alt = (radius_km - 6371.0) as i32;
+    if !(-90.0..=90.0).contains(&lat) {
+        return None;
+    }
+    if !(5000.0..=7000.0).contains(&radius_km) {
+        return None;
+    }
+    Some((lat, lon, alt, x, y, z))
+}
+
+/// Try to extract a mobile-terminal position from a reassembled IDA
+/// payload. `ul` is the burst direction (uplink).
+pub fn extract(data: &[u8], ul: bool) -> Option<Value> {
+    if data.len() < 5 {
+        return None;
+    }
+    let msg_type = ((data[0] as u16) << 8) | data[1] as u16;
+    let (src, skip): (&[u8], u32) = match msg_type {
+        // GSM paging: marker 0x1b at offset 36, XYZ at 37.
+        0x0605 if data.len() >= 42 && data[36] == 0x1b => (&data[37..], 0),
+        // SBD paging: data[2]==0 and high nibble of data[3]==4, XYZ at 3.
+        0x7605 if data.len() >= 8 && data[2] == 0x00 && (data[3] & 0xf0) == 0x40 => {
+            (&data[3..], 4)
+        }
+        // Uplink: data[2] in {0x10,0x40,0x70}, data[18]==1, XYZ at 19.
+        0x0600
+            if ul
+                && data.len() >= 24
+                && matches!(data[2], 0x10 | 0x40 | 0x70)
+                && data[18] == 0x01 =>
+        {
+            (&data[19..], 0)
+        }
+        _ => return None,
+    };
+    let (lat, lon, alt, x, y, z) = xyz(src, skip)?;
+    Some(json!({
+        "type": "mt-position",
+        "msg_type": format!("{msg_type:04x}"),
+        "lat": lat,
+        "lon": lon,
+        "alt_km": alt,
+        "x": x,
+        "y": y,
+        "z": z,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_short_and_zero() {
+        assert!(extract(&[0u8; 4], false).is_none());
+        // 0x0605 with marker but all-zero XYZ → rejected.
+        let mut d = vec![0u8; 42];
+        d[0] = 0x06;
+        d[1] = 0x05;
+        d[36] = 0x1b;
+        assert!(extract(&d, false).is_none());
+    }
+
+    #[test]
+    fn xyz_unpacks_signed_12bit() {
+        // skip=0 (sb=4): x>>28, y>>16, z>>4 of a 40-bit big-endian field.
+        // Ground terminal: x=1000, y=1000, z=700 (units of 4 km).
+        let (x, y, z) = (1000i64, 1000i64, 700i64);
+        let val: u64 = ((x as u64) << 28) | ((y as u64) << 16) | ((z as u64) << 4);
+        let bytes = [
+            (val >> 32) as u8,
+            (val >> 24) as u8,
+            (val >> 16) as u8,
+            (val >> 8) as u8,
+            val as u8,
+        ];
+        let (lat, lon, _alt, rx, ry, rz) = xyz(&bytes, 0).expect("valid");
+        assert_eq!((rx, ry, rz), (1000, 1000, 700));
+        // lat = atan2(700, sqrt(1000^2+1000^2)) ≈ 26.34°, lon = 45°.
+        assert!((lat - 26.34).abs() < 0.1, "lat={lat}");
+        assert!((lon - 45.0).abs() < 0.1, "lon={lon}");
+    }
+
+    #[test]
+    fn xyz_negative_components() {
+        // Verify two's-complement sign extension on a negative field.
+        // x=-300, y=1200, z=700 → radius ≈ 5685 km (within the gate).
+        let neg = ((-300i32) & 0xfff) as u64; // 12-bit two's complement
+        let val: u64 = (neg << 28) | (1200u64 << 16) | (700u64 << 4);
+        let bytes = [
+            (val >> 32) as u8,
+            (val >> 24) as u8,
+            (val >> 16) as u8,
+            (val >> 8) as u8,
+            val as u8,
+        ];
+        let (_, _, _, rx, ry, rz) = xyz(&bytes, 0).expect("valid");
+        assert_eq!((rx, ry, rz), (-300, 1200, 700));
+    }
+}

--- a/crates/xng-mode-iridium/src/sbd.rs
+++ b/crates/xng-mode-iridium/src/sbd.rs
@@ -40,6 +40,8 @@ pub struct SbdReassembler {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct SbdMessage {
+    /// Frame kind for the emitted message: "sbd", "gsm", or "mt-position".
+    pub kind: &'static str,
     pub details: serde_json::Value,
     pub acars: Option<xng_acars::block::AcarsBlock>,
 }
@@ -75,13 +77,13 @@ impl SbdReassembler {
                 return None;
             }
             let p = self.buf.remove(i);
-            return Self::parse_l2(&p.data);
+            return Self::parse_l2(&p.data, p.ul);
         }
 
         // No continuation: a fresh single packet, a new long packet, or an
         // orphan continuation (dropped).
         match (f.ctr, f.continuation) {
-            (0, false) => Self::parse_l2(bytes),
+            (0, false) => Self::parse_l2(bytes, ul),
             (0, true) => {
                 self.buf.push(Pending {
                     freq,
@@ -96,10 +98,20 @@ impl SbdReassembler {
         }
     }
 
-    /// Parse an assembled L2 stream: SBD transport framing, then ACARS.
-    fn parse_l2(data: &[u8]) -> Option<SbdMessage> {
+    /// Parse an assembled L2 stream. Three parallel decoders run on the
+    /// reassembled IDA packet: a mobile-terminal position (paging frames),
+    /// GSM CC/MM/SMS signalling, and the SBD transport → ACARS path.
+    fn parse_l2(data: &[u8], ul: bool) -> Option<SbdMessage> {
         if data.len() < 5 {
             return None;
+        }
+        // Mobile-terminal position embedded in paging/uplink frames.
+        if let Some(pos) = crate::mtpos::extract(data, ul) {
+            return Some(SbdMessage { kind: "mt-position", details: pos, acars: None });
+        }
+        // GSM call-control / mobility / SMS signalling.
+        if let Some(g) = crate::gsm::decode(data) {
+            return Some(SbdMessage { kind: "gsm", details: g, acars: None });
         }
         // SBD packet types (toolkit ReassembleIDASBD).
         let (typ, mut rest): (u16, &[u8]) = match (data[0], data[1]) {
@@ -151,6 +163,7 @@ impl SbdReassembler {
     fn parse_acars(typ: u16, payload: &[u8]) -> Option<SbdMessage> {
         if payload.first() != Some(&0x01) || payload.len() < 16 {
             return Some(SbdMessage {
+                kind: "sbd",
                 details: json!({
                     "type": format!("{typ:04x}"),
                     "payload_hex": payload.iter().map(|b| format!("{b:02x}")).collect::<String>(),
@@ -168,6 +181,7 @@ impl SbdReassembler {
         };
         let acars = xng_acars::block::parse(&body);
         Some(SbdMessage {
+            kind: "sbd",
             details: json!({
                 "type": format!("{typ:04x}"),
                 "acars_ok": acars.as_ref().map(|a| a.crc_ok),


### PR DESCRIPTION
Two new decoders run on the reassembled IDA packet, alongside the existing SBD→ACARS path (all three dispatch in `sbd.rs parse_l2`). These payloads were previously **dropped** (parse_l2 only handled SBD).

## Mobile-terminal positions (`mt-position`)
Port of iridium-sniffer `web_map.c mtpos_ida_cb`. GSM-paging (0x0605), SBD-paging (0x7605) and uplink (0x0600) frames embed the **terminal's own ECEF position** as three signed 12-bit values (units of 4 km). Decoded to lat/lon/alt + raw x/y/z. A terminal here may be an **Iridium-equipped aircraft or vessel** — a position source distinct from IRA satellite positions.

**Live at KSMF:** real device positions in the SF Bay Area — `37.78,-122.50`, `37.74,-122.11`, `39.53,-121.81` — plausible NorCal locations.

## GSM CC/MM/SMS signalling (`gsm`)
Port of iridium-toolkit `ReassembleIDAPP`. A reassembled IDA packet whose first byte is a CC/MM/SMS transaction identifier carries call-control / mobility / SMS signalling. Decodes:
- transaction id → protocol (CC/MM/SMS) + message (Setup, Disconnect, Location Updating Request/Accept/Reject, Identity req/resp, TMSI Reallocation, …)
- message bodies via the GSM IE parsers: **mobile identity** (IMSI/IMEI/TMSI), **LAI** (MCC/MNC/LAC), **disconnect cause**

(SBD 0x76 / 0x0600 stays on the ACARS path.) `SbdMessage` gains a `kind` so the emitted frame is tagged `mt-position` / `gsm` / `sbd`.

## Validation
120 s live capture decoded **7 mt-position + 3 gsm** alongside the full mix (123 itl / 110 ida / 102 sync / 61 broadcast / 33 ip-data / 31 ring-alert / 24 voice / 20 u3 / 18 msg). Unit tests cover the 12-bit signed XYZ unpacking (incl. negatives), position-type detection, and GSM dispatch + IE decode. Workspace tests pass.

## Remaining follow-up
GSMTAP/Wireshark export + IRA satellite-position TLE matching (the output/integration features) — next PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)