### PR TITLE
Iridium: GSMTAP output — Iridium GSM frames to Wireshark via UDP

### DIFF
--- a/crates/xng-mode-iridium/src/sbd.rs
+++ b/crates/xng-mode-iridium/src/sbd.rs
@@ -110,7 +110,10 @@ impl SbdReassembler {
             return Some(SbdMessage { kind: "mt-position", details: pos, acars: None });
         }
         // GSM call-control / mobility / SMS signalling.
-        if let Some(g) = crate::gsm::decode(data) {
+        if let Some(mut g) = crate::gsm::decode(data) {
+            // Carry the raw L2 bytes + direction for GSMTAP/Wireshark export.
+            g["raw_l2_hex"] = json!(data.iter().map(|b| format!("{b:02x}")).collect::<String>());
+            g["ul"] = json!(ul);
             return Some(SbdMessage { kind: "gsm", details: g, acars: None });
         }
         // SBD packet types (toolkit ReassembleIDASBD).

--- a/src/commands/scan.rs
+++ b/src/commands/scan.rs
@@ -385,6 +385,7 @@ pub(crate) fn scan_group(
             sbs: None,
             beast: None,
             nmea_tcp: None,
+            gsmtap: None,
             http: None,
             mqtt: None,
             mqtt_topic: "xng".into(),

--- a/src/commands/station.rs
+++ b/src/commands/station.rs
@@ -47,6 +47,7 @@ pub struct OutputsToml {
     pub sbs: Option<String>,
     pub beast: Option<String>,
     pub nmea_tcp: Option<String>,
+    pub gsmtap: Option<String>,
     pub http: Option<String>,
     pub aircraft_db: Option<PathBuf>,
     pub mqtt: Option<String>,

--- a/src/commands/survey.rs
+++ b/src/commands/survey.rs
@@ -426,6 +426,7 @@ fn dwell(
             sbs: None,
             beast: None,
             nmea_tcp: None,
+            gsmtap: None,
             http: None,
             mqtt: None,
             mqtt_topic: "xng".into(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -125,6 +125,10 @@ struct OutputOpts {
     /// Serve raw NMEA AIVDM over TCP (e.g. 0.0.0.0:10110)
     #[arg(long)]
     nmea_tcp: Option<String>,
+    /// Send Iridium GSM (CC/MM/SMS) frames to Wireshark via GSMTAP/UDP
+    /// (default 127.0.0.1:4729 when given without an address)
+    #[arg(long, num_args = 0..=1, default_missing_value = "127.0.0.1:4729")]
+    gsmtap: Option<String>,
     /// JSON file mapping hex VDL2 ground-station addresses to names
     /// (shown in console output)
     #[arg(long)]
@@ -187,6 +191,7 @@ impl OutputOpts {
                 sbs: self.sbs.clone(),
                 beast: self.beast.clone(),
                 nmea_tcp: self.nmea_tcp.clone(),
+                gsmtap: self.gsmtap.clone(),
                 http: self.http.clone(),
                 mqtt: self.mqtt.clone(),
                 mqtt_topic: self.mqtt_topic.clone(),
@@ -663,6 +668,7 @@ fn main() -> anyhow::Result<()> {
                         sbs: None,
                         beast: None,
                         nmea_tcp: None,
+                        gsmtap: None,
                         http: None,
                         mqtt: None,
                         mqtt_topic: "xng".into(),
@@ -700,6 +706,7 @@ fn run_station_cmd(config: &std::path::Path) -> anyhow::Result<()> {
         sbs: st.outputs.sbs.clone(),
         beast: st.outputs.beast.clone(),
         nmea_tcp: st.outputs.nmea_tcp.clone(),
+        gsmtap: st.outputs.gsmtap.clone(),
         http: st.outputs.http.clone(),
         mqtt: st.outputs.mqtt.clone(),
         mqtt_topic: st.outputs.mqtt_topic.clone().unwrap_or_else(|| "xng".into()),

--- a/src/outputs/gsmtap.rs
+++ b/src/outputs/gsmtap.rs
@@ -1,0 +1,121 @@
+//! GSMTAP output: send Iridium duplex GSM (CC/MM/SMS) frames to Wireshark
+//! via UDP (the osmocom de-facto standard, default port 4729). Wireshark's
+//! GSMTAP dissector then unpacks the LAPDm/GSM layers. The 16-byte header
+//! mirrors iridium-sniffer `gsmtap.c`: type ABIS, ARFCN = the Iridium
+//! channel index (uplink flagged 0x4000), the absolute frequency carried
+//! in frame_number.
+
+use std::sync::Arc;
+use tokio::net::UdpSocket;
+use tokio::sync::broadcast;
+use xng_types::{Message, MessageBody};
+
+const GSMTAP_VERSION: u8 = 2;
+const GSMTAP_HDR_LEN_WORDS: u8 = 4; // 4×32-bit = 16 bytes
+const GSMTAP_TYPE_ABIS: u8 = 2;
+const GSMTAP_SUB_BCCH: u8 = 1;
+const ARFCN_F_UPLINK: u16 = 0x4000;
+const IR_BASE_FREQ: f64 = 1_616_000_000.0;
+const IR_CHANNEL_WIDTH: f64 = 41_666.667;
+
+/// Build a GSMTAP packet (16-byte header + L2 payload) for one Iridium
+/// GSM frame.
+fn packet(l2: &[u8], freq_hz: f64, ul: bool, signal_dbm: i8) -> Vec<u8> {
+    let fchan = ((freq_hz - IR_BASE_FREQ) / IR_CHANNEL_WIDTH) as i64 as u16;
+    let arfcn = if ul { fchan | ARFCN_F_UPLINK } else { fchan };
+    let l2 = &l2[..l2.len().min(240)];
+    let mut p = Vec::with_capacity(16 + l2.len());
+    p.push(GSMTAP_VERSION);
+    p.push(GSMTAP_HDR_LEN_WORDS);
+    p.push(GSMTAP_TYPE_ABIS);
+    p.push(0); // timeslot
+    p.extend_from_slice(&arfcn.to_be_bytes());
+    p.push(signal_dbm as u8);
+    p.push(0); // snr_db
+    p.extend_from_slice(&(freq_hz as u32).to_be_bytes()); // frame_number
+    p.push(GSMTAP_SUB_BCCH);
+    p.push(0); // antenna_nr
+    p.push(0); // sub_slot
+    p.push(0); // res
+    p.extend_from_slice(l2);
+    p
+}
+
+fn hex_to_bytes(s: &str) -> Vec<u8> {
+    (0..s.len() / 2)
+        .filter_map(|i| u8::from_str_radix(&s[i * 2..i * 2 + 2], 16).ok())
+        .collect()
+}
+
+/// Build the GSMTAP packet for a message, or None if it is not an
+/// Iridium GSM frame carrying raw L2 bytes.
+fn message_packet(
+    kind: &str,
+    details: &serde_json::Value,
+    freq_hz: u64,
+    rssi_db: Option<f32>,
+) -> Option<Vec<u8>> {
+    if kind != "gsm" {
+        return None;
+    }
+    let l2 = hex_to_bytes(details.get("raw_l2_hex")?.as_str()?);
+    if l2.is_empty() {
+        return None;
+    }
+    let ul = details.get("ul").and_then(|v| v.as_bool()).unwrap_or(false);
+    let signal = rssi_db.unwrap_or(0.0).clamp(-127.0, 0.0) as i8;
+    Some(packet(&l2, freq_hz as f64, ul, signal))
+}
+
+pub async fn run(rx: broadcast::Receiver<Arc<Message>>, addr: String) -> std::io::Result<()> {
+    let sock = UdpSocket::bind("0.0.0.0:0").await?;
+    sock.connect(&addr).await?;
+    tracing::info!("GSMTAP output → {addr}");
+    let mut rx = rx;
+    loop {
+        match rx.recv().await {
+            Ok(msg) => {
+                let MessageBody::Iridium { kind, details } = &msg.body else { continue };
+                if let Some(pkt) = message_packet(kind, details, msg.frequency_hz, msg.signal.rssi_db)
+                {
+                    let _ = sock.send(&pkt).await;
+                }
+            }
+            Err(broadcast::error::RecvError::Lagged(_)) => continue,
+            Err(_) => return Ok(()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn header_layout() {
+        // freq 1624.000 MHz → channel (1624e6-1616e6)/41666.667 = 191.99…,
+        // truncated to 191 (matching the toolkit/sniffer int() convention).
+        let p = packet(&[0xaa, 0xbb], 1_624_000_000.0, false, -20);
+        assert_eq!(p.len(), 18);
+        assert_eq!(p[0], 2); // version
+        assert_eq!(p[2], 2); // type ABIS
+        let arfcn = u16::from_be_bytes([p[4], p[5]]);
+        assert_eq!(arfcn, 191);
+        // uplink sets the flag.
+        let pu = packet(&[0xaa], 1_624_000_000.0, true, -20);
+        assert_eq!(u16::from_be_bytes([pu[4], pu[5]]), 191 | 0x4000);
+        // frame_number carries the frequency.
+        assert_eq!(u32::from_be_bytes([p[8], p[9], p[10], p[11]]), 1_624_000_000);
+    }
+
+    #[test]
+    fn message_glue() {
+        // A gsm frame with raw L2 → a packet; everything else → None.
+        let d = serde_json::json!({ "raw_l2_hex": "0518aabb", "ul": true });
+        let p = message_packet("gsm", &d, 1_624_000_000, Some(-30.0)).expect("packet");
+        assert_eq!(&p[16..], &[0x05, 0x18, 0xaa, 0xbb]); // L2 after 16-byte hdr
+        assert_eq!(u16::from_be_bytes([p[4], p[5]]) & 0x4000, 0x4000); // uplink flag
+        assert!(message_packet("ida", &d, 1_624_000_000, None).is_none());
+        assert!(message_packet("gsm", &serde_json::json!({}), 0, None).is_none());
+    }
+}

--- a/src/outputs/mod.rs
+++ b/src/outputs/mod.rs
@@ -8,6 +8,7 @@ pub mod asf2_grpc;
 pub mod asf2_quic;
 pub mod console;
 pub mod dbinfo;
+pub mod gsmtap;
 pub mod http;
 pub mod jsonl;
 pub mod metrics;

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -41,6 +41,8 @@ pub struct OutputConfig {
     pub beast: Option<String>,
     /// NMEA (AIVDM) TCP server address.
     pub nmea_tcp: Option<String>,
+    /// GSMTAP/UDP target for Iridium GSM frames (Wireshark).
+    pub gsmtap: Option<String>,
     /// Web dashboard listen address (live map + message stream).
     pub http: Option<String>,
     /// MQTT broker URL (mqtt://[user:pass@]host[:port]).
@@ -429,6 +431,10 @@ fn spawn_outputs(
     if let Some(addr) = outputs.nmea_tcp.clone() {
         let rx = bus.subscribe();
         output_tasks.push(tokio::spawn(crate::outputs::nmea_tcp::run(rx, addr)));
+    }
+    if let Some(addr) = outputs.gsmtap.clone() {
+        let rx = bus.subscribe();
+        output_tasks.push(tokio::spawn(crate::outputs::gsmtap::run(rx, addr)));
     }
     if let Some(addr) = outputs.http.clone() {
         let rx = bus.subscribe();


### PR DESCRIPTION
A new `--gsmtap [addr]` output (default `127.0.0.1:4729`) wraps decoded Iridium duplex GSM (CC/MM/SMS) frames in the osmocom **GSMTAP** header and sends them over UDP, so Wireshark's GSMTAP dissector unpacks the LAPDm/GSM layers — the same interop path iridium-toolkit (`-m gsmtap`) and iridium-sniffer provide.

## Details
- 16-byte header mirrors the reference: type ABIS, sub BCCH, **ARFCN** = Iridium channel index (`(freq-1616e6)/41666.667`, truncated like the reference) with the **0x4000 uplink flag**, absolute frequency in `frame_number`, signal level from the burst.
- The `gsm` frame now carries `raw_l2_hex` + `ul`; freq/level come from the `Message`.
- Wired through `OutputOpts` / `OutputConfig` / station TOML (`gsmtap = "..."`) / `spawn_outputs` like the other UDP/TCP sinks.

## Tests
Unit-tested: the packet layout (version / type / ARFCN / uplink-flag / frame_number) and the message→packet glue (gsm + raw_l2 → packet; non-gsm / empty → none). **Workspace: 299 pass.** (Live end-to-end fires when GSM traffic is present — sparse; the path is proven by the format + glue tests.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GSMTAP output support to send Iridium GSM frames to Wireshark via UDP.
  * New `--gsmtap` command-line option to enable GSMTAP export (defaults to `127.0.0.1:4729`).
  * Station configuration files now support optional GSMTAP output settings.
  * Enhanced GSM message data with raw layer-2 information and direction metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->