### PR TITLE
Iridium: satmap — label ring alerts with the broadcasting satellite (SGP4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -475,6 +475,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -609,6 +618,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "document-features"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -718,6 +738,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "flume"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -745,6 +775,15 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
 
 [[package]]
 name = "futures-channel"
@@ -1035,6 +1074,88 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1045,6 +1166,27 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "indexmap"
@@ -1239,6 +1381,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
 name = "litrs"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1339,6 +1487,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -1682,6 +1831,15 @@ name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
 
 [[package]]
 name = "powerfmt"
@@ -2141,6 +2299,7 @@ version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -2336,6 +2495,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sgp4"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9467b9a7be8485ed8be0f336d399c8f32c0fcd60686e7dd2ed3dab75c9a73eb3"
+dependencies = [
+ "chrono",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2397,6 +2567,12 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "siphasher"
@@ -2466,6 +2642,12 @@ checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
  "lock_api",
 ]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "static_assertions"
@@ -2539,6 +2721,17 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "tempfile"
@@ -2685,6 +2878,16 @@ name = "time-core"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
 
 [[package]]
 name = "tinyvec"
@@ -3013,6 +3216,40 @@ name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64",
+ "flate2",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-pki-types",
+ "url",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -3701,6 +3938,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
 name = "xng"
 version = "0.17.0"
 dependencies = [
@@ -3718,12 +3961,14 @@ dependencies = [
  "rustls-pemfile",
  "serde",
  "serde_json",
+ "sgp4",
  "tokio",
  "tokio-stream",
  "toml",
  "tonic",
  "tracing",
  "tracing-subscriber",
+ "ureq",
  "uuid",
  "webpki-roots 0.26.11",
  "xng-acars",
@@ -3906,6 +4151,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3926,10 +4194,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,8 @@ airspyhf = ["xng-sdr/airspyhf"]
 anyhow.workspace = true
 rumqttc.workspace = true
 toml = "0.8"
+sgp4 = "2"
+ureq = "2"
 chrono.workspace = true
 clap = { version = "4", features = ["derive"] }
 num-complex.workspace = true

--- a/src/commands/scan.rs
+++ b/src/commands/scan.rs
@@ -386,6 +386,7 @@ pub(crate) fn scan_group(
             beast: None,
             nmea_tcp: None,
             gsmtap: None,
+            iridium_satmap: None,
             http: None,
             mqtt: None,
             mqtt_topic: "xng".into(),

--- a/src/commands/station.rs
+++ b/src/commands/station.rs
@@ -48,6 +48,7 @@ pub struct OutputsToml {
     pub beast: Option<String>,
     pub nmea_tcp: Option<String>,
     pub gsmtap: Option<String>,
+    pub iridium_satmap: Option<String>,
     pub http: Option<String>,
     pub aircraft_db: Option<PathBuf>,
     pub mqtt: Option<String>,

--- a/src/commands/survey.rs
+++ b/src/commands/survey.rs
@@ -427,6 +427,7 @@ fn dwell(
             beast: None,
             nmea_tcp: None,
             gsmtap: None,
+            iridium_satmap: None,
             http: None,
             mqtt: None,
             mqtt_topic: "xng".into(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ mod tui;
 mod freq;
 mod outputs;
 mod runtime;
+mod satmap;
 mod sdr_args;
 
 use clap::{Args, Parser, Subcommand};
@@ -129,6 +130,11 @@ struct OutputOpts {
     /// (default 127.0.0.1:4729 when given without an address)
     #[arg(long, num_args = 0..=1, default_missing_value = "127.0.0.1:4729")]
     gsmtap: Option<String>,
+    /// Label Iridium ring alerts with the broadcasting satellite via SGP4
+    /// (default: auto-fetch Iridium-NEXT TLEs from Celestrak; or give a
+    /// local TLE file path)
+    #[arg(long, num_args = 0..=1, default_missing_value = "auto")]
+    iridium_satmap: Option<String>,
     /// JSON file mapping hex VDL2 ground-station addresses to names
     /// (shown in console output)
     #[arg(long)]
@@ -178,6 +184,12 @@ impl OutputOpts {
             let n = outputs::dbinfo::AircraftDb::load(p)?;
             tracing::info!("aircraft db: {n} entries");
         }
+        if let Some(src) = &self.iridium_satmap {
+            match satmap::init(src) {
+                Ok(n) => tracing::info!("iridium satmap: {n} satellites ({src})"),
+                Err(e) => tracing::warn!("iridium satmap disabled: {e}"),
+            }
+        }
         let ident = self.station_id.clone().unwrap_or_else(|| "XNG-DEV".to_owned());
         Ok((
             runtime::OutputConfig {
@@ -192,6 +204,7 @@ impl OutputOpts {
                 beast: self.beast.clone(),
                 nmea_tcp: self.nmea_tcp.clone(),
                 gsmtap: self.gsmtap.clone(),
+                iridium_satmap: self.iridium_satmap.clone(),
                 http: self.http.clone(),
                 mqtt: self.mqtt.clone(),
                 mqtt_topic: self.mqtt_topic.clone(),
@@ -669,6 +682,7 @@ fn main() -> anyhow::Result<()> {
                         beast: None,
                         nmea_tcp: None,
                         gsmtap: None,
+                        iridium_satmap: None,
                         http: None,
                         mqtt: None,
                         mqtt_topic: "xng".into(),
@@ -707,6 +721,7 @@ fn run_station_cmd(config: &std::path::Path) -> anyhow::Result<()> {
         beast: st.outputs.beast.clone(),
         nmea_tcp: st.outputs.nmea_tcp.clone(),
         gsmtap: st.outputs.gsmtap.clone(),
+        iridium_satmap: st.outputs.iridium_satmap.clone(),
         http: st.outputs.http.clone(),
         mqtt: st.outputs.mqtt.clone(),
         mqtt_topic: st.outputs.mqtt_topic.clone().unwrap_or_else(|| "xng".into()),
@@ -715,6 +730,12 @@ fn run_station_cmd(config: &std::path::Path) -> anyhow::Result<()> {
     if let Some(p) = &st.outputs.aircraft_db {
         let n = outputs::dbinfo::AircraftDb::load(p)?;
         tracing::info!("aircraft db: {n} entries");
+    }
+    if let Some(src) = &st.outputs.iridium_satmap {
+        match satmap::init(src) {
+            Ok(n) => tracing::info!("iridium satmap: {n} satellites ({src})"),
+            Err(e) => tracing::warn!("iridium satmap disabled: {e}"),
+        }
     }
     let mut sessions = Vec::new();
     for (i, sess) in st.sessions.iter().enumerate() {

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -43,6 +43,8 @@ pub struct OutputConfig {
     pub nmea_tcp: Option<String>,
     /// GSMTAP/UDP target for Iridium GSM frames (Wireshark).
     pub gsmtap: Option<String>,
+    /// Iridium satellite-name matching TLE source ("auto" or a path).
+    pub iridium_satmap: Option<String>,
     /// Web dashboard listen address (live map + message stream).
     pub http: Option<String>,
     /// MQTT broker URL (mqtt://[user:pass@]host[:port]).
@@ -700,6 +702,9 @@ pub(crate) fn decode_loop(
                 if let Some((r, files)) = reasm.as_deref_mut() {
                     apply_reassembly(&mut msg, r, files);
                 }
+                // Label Iridium ring alerts with the broadcasting satellite
+                // (no-op unless a TLE satellite map was loaded at startup).
+                crate::satmap::enrich(&mut msg);
                 if !label_filter.allows(&msg) {
                     continue;
                 }

--- a/src/satmap.rs
+++ b/src/satmap.rs
@@ -1,0 +1,233 @@
+//! IRA → satellite-name matching. Ring-alert frames carry the broadcasting
+//! satellite's geocentric ECEF position (in units of 4 km). By propagating
+//! the current Iridium-NEXT two-line elements with SGP4 and rotating the
+//! TEME result into ECEF (by GMST), we can label each ring alert with the
+//! actual NORAD satellite it came from (cf. iridium-toolkit `InfoIRAMAP`).
+//!
+//! TLEs come from Celestrak (auto-fetched by default) or a local file.
+
+use std::sync::OnceLock;
+use std::time::Duration;
+use xng_types::{Message, MessageBody};
+
+/// Process-global satellite map, loaded once at startup (immutable after).
+static SATMAP: OnceLock<SatMap> = OnceLock::new();
+
+/// Load the satellite map from `source` ("auto" = Celestrak, else a file
+/// path) into the global, returning the satellite count. Call once at
+/// startup before decode tasks spawn.
+pub fn init(source: &str) -> anyhow::Result<usize> {
+    let map = load(source)?;
+    let n = map.len();
+    let _ = SATMAP.set(map);
+    Ok(n)
+}
+
+/// Enrich a ring-alert message with its matched satellite, if a satellite
+/// map has been loaded (no-op otherwise).
+pub fn enrich(msg: &mut Message) {
+    if let Some(map) = SATMAP.get() {
+        map.enrich(msg);
+    }
+}
+
+/// Match gate: a decoded position must lie within this of a propagated
+/// satellite to be attributed to it (IRA positions quantise to 4 km).
+const MAX_DIST_KM: f64 = 100.0;
+
+/// Celestrak Iridium-NEXT TLE group (current elements).
+pub const CELESTRAK_URL: &str =
+    "https://celestrak.org/NORAD/elements/gp.php?GROUP=iridium-NEXT&FORMAT=tle";
+
+struct Sat {
+    name: String,
+    constants: sgp4::Constants,
+    epoch_unix: f64,
+}
+
+pub struct SatMap {
+    sats: Vec<Sat>,
+}
+
+impl SatMap {
+    /// Parse a 3-line-per-satellite TLE text block (name / line1 / line2).
+    pub fn from_tle(text: &str) -> Self {
+        let lines: Vec<&str> = text.lines().collect();
+        let mut sats = Vec::new();
+        let mut i = 0;
+        while i + 2 < lines.len() + 1 {
+            if i + 2 >= lines.len() {
+                break;
+            }
+            let name = lines[i].trim();
+            let l1 = lines[i + 1].trim();
+            let l2 = lines[i + 2].trim();
+            if l1.starts_with("1 ") && l2.starts_with("2 ") {
+                if let Ok(elements) =
+                    sgp4::Elements::from_tle(Some(name.to_string()), l1.as_bytes(), l2.as_bytes())
+                {
+                    if let Ok(constants) = sgp4::Constants::from_elements(&elements) {
+                        let epoch_unix = elements.datetime.and_utc().timestamp() as f64
+                            + elements.datetime.and_utc().timestamp_subsec_nanos() as f64 / 1e9;
+                        sats.push(Sat { name: name.to_string(), constants, epoch_unix });
+                    }
+                }
+                i += 3;
+            } else {
+                i += 1;
+            }
+        }
+        SatMap { sats }
+    }
+
+    pub fn len(&self) -> usize {
+        self.sats.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.sats.is_empty()
+    }
+
+    /// Propagate a satellite to `unix` and return its geocentric ECEF
+    /// position in km (TEME → ECEF via GMST rotation about Z).
+    fn propagate_ecef(s: &Sat, unix: f64) -> Option<[f64; 3]> {
+        let min = (unix - s.epoch_unix) / 60.0;
+        let pred = s.constants.propagate(sgp4::MinutesSinceEpoch(min)).ok()?;
+        let [tx, ty, tz] = pred.position; // TEME, km
+        let (sin_g, cos_g) = gmst_rad(unix).sin_cos();
+        Some([tx * cos_g + ty * sin_g, -tx * sin_g + ty * cos_g, tz])
+    }
+
+    /// Nearest satellite (name, distance km) to a geocentric ECEF position
+    /// (km) at `unix` seconds, within `MAX_DIST_KM`.
+    pub fn match_sat(&self, ex: f64, ey: f64, ez: f64, unix: f64) -> Option<(&str, f64)> {
+        let mut best: Option<(&str, f64)> = None;
+        for s in &self.sats {
+            let Some([cx, cy, cz]) = Self::propagate_ecef(s, unix) else {
+                continue;
+            };
+            let d = ((cx - ex).powi(2) + (cy - ey).powi(2) + (cz - ez).powi(2)).sqrt();
+            if best.is_none_or(|(_, bd)| d < bd) {
+                best = Some((s.name.as_str(), d));
+            }
+        }
+        best.filter(|&(_, d)| d <= MAX_DIST_KM)
+    }
+
+    /// Enrich a ring-alert message with the matched satellite name.
+    pub fn enrich(&self, msg: &mut Message) {
+        let MessageBody::Iridium { kind, details } = &mut msg.body else {
+            return;
+        };
+        if *kind != "ring-alert" {
+            return;
+        }
+        let (Some(x), Some(y), Some(z)) = (
+            details.get("x").and_then(|v| v.as_i64()),
+            details.get("y").and_then(|v| v.as_i64()),
+            details.get("z").and_then(|v| v.as_i64()),
+        ) else {
+            return;
+        };
+        let unix = msg.timestamp.timestamp() as f64
+            + msg.timestamp.timestamp_subsec_nanos() as f64 / 1e9;
+        // IRA ECEF components are in units of 4 km.
+        if let Some((name, dist)) =
+            self.match_sat(x as f64 * 4.0, y as f64 * 4.0, z as f64 * 4.0, unix)
+        {
+            let name = name.to_string();
+            if let Some(obj) = details.as_object_mut() {
+                obj.insert("satellite".into(), serde_json::json!(name));
+                obj.insert("satellite_dist_km".into(), serde_json::json!(dist.round()));
+            }
+        }
+    }
+}
+
+/// Greenwich Mean Sidereal Time (radians) at a Unix timestamp (IAU 1982).
+fn gmst_rad(unix: f64) -> f64 {
+    let jd = unix / 86400.0 + 2440587.5;
+    let t = (jd - 2451545.0) / 36525.0;
+    let gmst_sec = 67310.54841
+        + (876600.0 * 3600.0 + 8640184.812866) * t
+        + 0.093104 * t * t
+        - 6.2e-6 * t * t * t;
+    gmst_sec.rem_euclid(86400.0) * std::f64::consts::TAU / 86400.0
+}
+
+/// Fetch a TLE text block over HTTP(S).
+pub fn fetch_tle(url: &str) -> anyhow::Result<String> {
+    let body = ureq::get(url)
+        .timeout(Duration::from_secs(20))
+        .call()?
+        .into_string()?;
+    Ok(body)
+}
+
+/// Load a SatMap from the configured source: a file path, or (default)
+/// the Celestrak Iridium-NEXT group auto-fetched over HTTPS.
+pub fn load(source: &str) -> anyhow::Result<SatMap> {
+    let text = if source == "auto" {
+        fetch_tle(CELESTRAK_URL)?
+    } else {
+        std::fs::read_to_string(source)?
+    };
+    let map = SatMap::from_tle(&text);
+    if map.is_empty() {
+        anyhow::bail!("no TLEs parsed from {source}");
+    }
+    Ok(map)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn gmst_at_j2000() {
+        // J2000 (2000-01-01 12:00:00 UTC, unix 946728000): GMST ≈ 280.46°.
+        let g = gmst_rad(946_728_000.0).to_degrees();
+        assert!((g - 280.46).abs() < 0.05, "gmst={g}");
+    }
+
+    #[test]
+    fn propagates_tle_to_leo_radius() {
+        // Canonical valid TLE (ISS); at its own epoch the propagated radius
+        // must be a plausible LEO value (~6780 km). Validates that TLE
+        // parsing + SGP4 propagation are wired correctly.
+        let tle = "ISS (ZARYA)\n\
+            1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927\n\
+            2 25544  51.6416 247.4627 0006703 130.5360 325.0288 15.72125391563537\n";
+        let map = SatMap::from_tle(tle);
+        assert_eq!(map.len(), 1);
+        let s = &map.sats[0];
+        let pred = s.constants.propagate(sgp4::MinutesSinceEpoch(0.0)).unwrap();
+        let [x, y, z] = pred.position;
+        let r = (x * x + y * y + z * z).sqrt();
+        assert!((6600.0..7000.0).contains(&r), "radius {r} km out of LEO range");
+    }
+
+    #[test]
+    fn matches_satellite_to_its_own_position() {
+        // Two real Iridium-NEXT TLEs (Celestrak snapshot). Propagating one
+        // to a time near its epoch and feeding its ECEF back to match_sat
+        // must identify that satellite (≈0 km) and not its neighbour —
+        // exercising parse, propagate, TEME→ECEF, nearest-search and gate.
+        let tle = "IRIDIUM 106\n\
+            1 41917U 17003A   26164.81636817  .00000002  00000+0 -64509-5 0  9993\n\
+            2 41917  86.3963  89.9654 0001784  83.5618 276.5781 14.34217470492724\n\
+            IRIDIUM 103\n\
+            1 41918U 17003B   26164.87345235  .00000072  00000+0  18697-4 0  9993\n\
+            2 41918  86.3961  89.8413 0002359  78.7002 281.4459 14.34217734492750\n";
+        let map = SatMap::from_tle(tle);
+        assert_eq!(map.len(), 2);
+        // A time ~30 min after the first TLE's epoch.
+        let unix = map.sats[0].epoch_unix + 1800.0;
+        let [x, y, z] = SatMap::propagate_ecef(&map.sats[0], unix).unwrap();
+        let (name, dist) = map.match_sat(x, y, z, unix).expect("a match");
+        assert_eq!(name, "IRIDIUM 106");
+        assert!(dist < 1.0, "self-match distance {dist} km");
+        // A position 9000 km from any satellite must not match (gate).
+        assert!(map.match_sat(0.0, 0.0, 9000.0, unix).is_none());
+    }
+}


### PR DESCRIPTION
Ring-alert frames carry the broadcasting satellite's geocentric ECEF position. A new `--iridium-satmap [src]` enrichment propagates current Iridium-NEXT TLEs with **SGP4**, rotates the TEME result into ECEF (by **GMST**), and labels each ring alert with the nearest NORAD satellite within 100 km (cf. iridium-toolkit `InfoIRAMAP`). Adds `satellite` + `satellite_dist_km` to ring-alert details.

## TLE source (per your call: both, default auto)
- **Default `auto`** — fetch Celestrak's `iridium-NEXT` group over HTTPS at startup
- **Path** — `--iridium-satmap /path/to/tles.txt` (or station TOML `iridium-satmap = "..."`) for a local file

Loaded once into a process global, applied in the shared decode loop alongside the other enrichments (no-op unless configured). New deps: `sgp4`, `ureq` (rustls already present via QUIC).

## Validation
- **GMST** against the J2000 reference (280.46°)
- **SGP4 propagation** to a plausible LEO radius
- **Real-TLE round trip**: propagate a satellite → feed its ECEF back → `match_sat` identifies it at ≈0 km and rejects a far position (nearest-search + gate)
- **Live**: auto-fetch pulled **80 current satellites** from Celestrak at startup

Workspace tests pass (**303**). (Full live end-to-end matching will exercise once the test Airspy recovers from this session's restart cycling — the math + matching are unit-validated.)

This completes the Iridium "decode everything" effort: every frame type + IDA application layer (positions, GSM signalling) + GSMTAP output + satellite-name enrichment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)