### PR TITLE
Dashboard: optional Iridium satellite + ring-location map layers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ bench/data/ais_96k.cs16
 bench/data/vdl2_105k_conj.s16
 bench/data/hfdl_48k.cs16
 bench/data/adsb_quiet_24m.cu8
+.gstack/

--- a/src/outputs/assets/dashboard.html
+++ b/src/outputs/assets/dashboard.html
@@ -93,6 +93,24 @@ L.tileLayer('https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png', {
   attribution: '&copy; OpenStreetMap, &copy; CARTO · silhouettes &copy; <a href="https://github.com/plane-watch/pw-silhouettes">Plane Watch</a>', maxZoom: 18,
 }).addTo(map);
 
+// Optional Iridium overlays: satellite positions + the targeted ring/beam
+// ground footprints (cf. iridium-toolkit live-map). Toggle via the layer
+// control; visibility is persisted. Kept out of the aircraft/vessel
+// auto-fit so global satellite positions never yank the view.
+const satLayer = L.layerGroup();
+const ringLayer = L.layerGroup();
+L.control.layers(null,
+  { '🛰 Iridium satellites': satLayer, '◎ Ring locations': ringLayer },
+  { position: 'topright', collapsed: false }).addTo(map);
+if (localStorage.getItem('xng.satLayer') !== '0') satLayer.addTo(map);
+if (localStorage.getItem('xng.ringLayer') !== '0') ringLayer.addTo(map);
+map.on('overlayadd overlayremove', () => {
+  localStorage.setItem('xng.satLayer', map.hasLayer(satLayer) ? '1' : '0');
+  localStorage.setItem('xng.ringLayer', map.hasLayer(ringLayer) ? '1' : '0');
+});
+const satMarkers = new Map();  // sat id -> {marker, trail}
+const ringMarkers = new Map(); // "sat-beam" -> circleMarker
+
 // Aircraft silhouettes: PlaneWatch pw-silhouettes (CC BY-NC-SA 4.0,
 // used with permission). Resolved by ICAO type designator via the
 // repo's airframes/<TYPE>.json metadata (follows aliasOf), fetched
@@ -192,6 +210,76 @@ const shipIcon = (cog, type) => {
     `fill="${color}" stroke="#0b0e14" stroke-width="1.5"/></svg>`,
     iconSize: [16, 16], iconAnchor: [8, 8] });
 };
+const IRIDIUM = '#73daca';
+const satIcon = () => L.divIcon({ className: '', html:
+  `<div style="font-size:18px;line-height:18px;color:${IRIDIUM};text-shadow:0 0 4px #000">&#128752;</div>`,
+  iconSize: [20, 20], iconAnchor: [10, 10] });
+
+// Sync the optional Iridium layers from the state snapshot. Satellite
+// markers (with a faint ground track) and ring/beam footprint circles
+// are managed in their own layer groups, independent of the main marker
+// cull, and never contribute to the auto-fit bounds.
+function syncIridium(s) {
+  const seenSat = new Set();
+  for (const sat of (s.iridium_sats || [])) {
+    seenSat.add(sat.sat);
+    const name = sat.name || ('S' + String(sat.sat).padStart(2, '0'));
+    const label = escapeHtml(name);
+    const popup = entityPopup('', label, [
+      ['satellite', sat.name ? escapeHtml(sat.name) : null],
+      ['sat id', sat.sat],
+      ['beam', sat.beam],
+      ['position', `${sat.lat.toFixed(2)}, ${sat.lon.toFixed(2)}`],
+      ['altitude', sat.alt != null ? `${sat.alt} km` : null],
+      ['seen', `${fmtAge(s.now - sat.seen)} ago`],
+    ]);
+    let e = satMarkers.get(sat.sat);
+    if (!e) {
+      e = { marker: L.marker([sat.lat, sat.lon], { icon: satIcon() }).addTo(satLayer) };
+      e.marker.bindTooltip(label, { permanent: true, direction: 'right', offset: [10, 0], className: 'lbl' });
+      e.marker.bindPopup(popup);
+      satMarkers.set(sat.sat, e);
+    } else {
+      e.marker.setLatLng([sat.lat, sat.lon]);
+      e.marker.setTooltipContent(label);
+      e.marker.setPopupContent(popup);
+    }
+    if (sat.trail && sat.trail.length > 1) {
+      if (e.trail) e.trail.setLatLngs(sat.trail);
+      else e.trail = L.polyline(sat.trail, { color: IRIDIUM, weight: 1, opacity: 0.4, dashArray: '3,4' }).addTo(satLayer);
+    }
+  }
+  for (const [k, e] of satMarkers) if (!seenSat.has(k)) {
+    satLayer.removeLayer(e.marker);
+    if (e.trail) satLayer.removeLayer(e.trail);
+    satMarkers.delete(k);
+  }
+
+  const seenRing = new Set();
+  for (const r of (s.iridium_rings || [])) {
+    const key = r.sat + '-' + r.beam;
+    seenRing.add(key);
+    const popup = entityPopup('', escapeHtml(`ring S${r.sat}/B${r.beam}`), [
+      ['sat id', r.sat],
+      ['beam', r.beam],
+      ['position', `${r.lat.toFixed(2)}, ${r.lon.toFixed(2)}`],
+      ['seen', `${fmtAge(s.now - r.seen)} ago`],
+    ]);
+    let m = ringMarkers.get(key);
+    if (!m) {
+      m = L.circleMarker([r.lat, r.lon], { radius: 6, color: IRIDIUM, weight: 1, fillColor: IRIDIUM, fillOpacity: 0.15 }).addTo(ringLayer);
+      m.bindPopup(popup);
+      ringMarkers.set(key, m);
+    } else {
+      m.setLatLng([r.lat, r.lon]);
+      m.setPopupContent(popup);
+    }
+  }
+  for (const [k, m] of ringMarkers) if (!seenRing.has(k)) {
+    ringLayer.removeLayer(m);
+    ringMarkers.delete(k);
+  }
+}
 
 const markers = new Map(); // key -> {marker, trail}
 let fitted = false;
@@ -397,11 +485,14 @@ function render() {
       markers.delete(k);
     }
   });
+  syncIridium(s);
   if (!fitted && pts.length) { map.fitBounds(pts, { maxZoom: 9, padding: [40, 40] }); fitted = true; }
 
   if (s.station) document.getElementById('station').textContent = s.station;
+  const nsat = (s.iridium_sats || []).length;
   document.getElementById('status').textContent =
-    `up ${fmtUptime(s.now - s.started)} · ${s.aircraft.length} aircraft · ${s.vessels.length} vessels`;
+    `up ${fmtUptime(s.now - s.started)} · ${s.aircraft.length} aircraft · ${s.vessels.length} vessels` +
+    (nsat ? ` · ${nsat} sats` : '');
 
   const rate = rates();
   document.getElementById('chips').innerHTML = Object.entries(s.totals)

--- a/src/outputs/http.rs
+++ b/src/outputs/http.rs
@@ -20,10 +20,24 @@ const RECENT_CAP: usize = 200;
 /// Drop map entities not heard from in this many seconds.
 const EXPIRE_S: u64 = 300;
 
+/// Iridium ring-alert positions split by altitude (cf. iridium-toolkit
+/// live-map): a frame's geocentric position is either the broadcasting
+/// satellite (~800 km) or a ground beam footprint (~0 km).
+const SAT_ALT_MIN_KM: f64 = 500.0;
+const RING_ALT_MAX_KM: f64 = 100.0;
+/// Satellites move continuously (keep longer); ground footprints are
+/// transient.
+const SAT_EXPIRE_S: u64 = 600;
+const RING_EXPIRE_S: u64 = 300;
+
 #[derive(Default)]
 struct Dash {
     aircraft: HashMap<String, Value>,
     vessels: HashMap<u32, Value>,
+    /// Iridium satellite positions, keyed by satellite id.
+    iridium_sats: HashMap<u64, Value>,
+    /// Iridium ring/beam ground footprints, keyed by "sat-beam".
+    iridium_rings: HashMap<String, Value>,
     recent: VecDeque<Value>,
     totals: HashMap<String, u64>,
     /// Last time (unix secs) a message of each mode was seen — drives
@@ -149,6 +163,42 @@ fn update(d: &mut Dash, m: &Message) {
                 }
             }
         }
+        // Iridium ring alerts carry the broadcasting satellite's geocentric
+        // position; split into satellite positions (high altitude) and
+        // targeted ground beam footprints (low altitude) for the map.
+        MessageBody::Iridium { kind, details } if kind == "ring-alert" => {
+            let (lat, lon, alt) = (
+                details.get("lat").and_then(Value::as_f64),
+                details.get("lon").and_then(Value::as_f64),
+                details.get("alt_km").and_then(Value::as_f64),
+            );
+            let sat = details.get("sat").and_then(Value::as_u64);
+            if let (Some(lat), Some(lon), Some(alt), Some(sat)) = (lat, lon, alt, sat) {
+                let beam = details.get("beam").and_then(Value::as_u64).unwrap_or(0);
+                if alt > SAT_ALT_MIN_KM {
+                    let e = d.iridium_sats.entry(sat).or_insert_with(|| json!({}));
+                    let o = e.as_object_mut().unwrap();
+                    o.insert("sat".into(), json!(sat));
+                    o.insert("beam".into(), json!(beam));
+                    o.insert("lat".into(), json!(lat));
+                    o.insert("lon".into(), json!(lon));
+                    o.insert("alt".into(), json!(alt.round()));
+                    o.insert("seen".into(), json!(now_s()));
+                    if let Some(name) = details.get("satellite") {
+                        o.insert("name".into(), name.clone());
+                    }
+                    push_trail(o, lat, lon); // satellite ground track
+                } else if alt < RING_ALT_MAX_KM {
+                    let e = d.iridium_rings.entry(format!("{sat}-{beam}")).or_insert_with(|| json!({}));
+                    let o = e.as_object_mut().unwrap();
+                    o.insert("sat".into(), json!(sat));
+                    o.insert("beam".into(), json!(beam));
+                    o.insert("lat".into(), json!(lat));
+                    o.insert("lon".into(), json!(lon));
+                    o.insert("seen".into(), json!(now_s()));
+                }
+            }
+        }
         _ => {}
     }
 
@@ -173,12 +223,18 @@ fn snapshot(d: &mut Dash) -> String {
     let cutoff = now_s().saturating_sub(EXPIRE_S);
     d.aircraft.retain(|_, v| v["seen"].as_u64().unwrap_or(0) >= cutoff);
     d.vessels.retain(|_, v| v["seen"].as_u64().unwrap_or(0) >= cutoff);
+    let sat_cut = now_s().saturating_sub(SAT_EXPIRE_S);
+    let ring_cut = now_s().saturating_sub(RING_EXPIRE_S);
+    d.iridium_sats.retain(|_, v| v["seen"].as_u64().unwrap_or(0) >= sat_cut);
+    d.iridium_rings.retain(|_, v| v["seen"].as_u64().unwrap_or(0) >= ring_cut);
     json!({
         "station": d.station,
         "started": d.started,
         "sessions": d.sessions,
         "aircraft": d.aircraft.values().collect::<Vec<_>>(),
         "vessels": d.vessels.values().collect::<Vec<_>>(),
+        "iridium_sats": d.iridium_sats.values().collect::<Vec<_>>(),
+        "iridium_rings": d.iridium_rings.values().collect::<Vec<_>>(),
         "messages": d.recent.iter().rev().take(100).collect::<Vec<_>>(),
         "totals": d.totals,
         "last_seen": d.last_seen,
@@ -239,4 +295,48 @@ pub async fn run(
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use xng_types::{AppInfo, Mode, Provenance, StationIdentity};
+
+    fn ring_alert(sat: u64, alt_km: f64) -> Message {
+        Message {
+            mode: Mode::Iridium,
+            timestamp: chrono::Utc::now(),
+            frequency_hz: 1_626_270_000,
+            signal: Default::default(),
+            decode: Default::default(),
+            body: MessageBody::Iridium {
+                kind: "ring-alert".into(),
+                details: json!({
+                    "sat": sat, "beam": 5, "lat": 40.0, "lon": -120.0,
+                    "alt_km": alt_km, "satellite": "IRIDIUM 106"
+                }),
+            },
+            raw: None,
+            source: Provenance {
+                station: StationIdentity::new("T"),
+                app: AppInfo::xng(),
+                sdr: None,
+                channel: None,
+            },
+        }
+    }
+
+    #[test]
+    fn buckets_iridium_satellites_and_rings_by_altitude() {
+        let mut d = Dash::default();
+        update(&mut d, &ring_alert(44, 797.0)); // satellite altitude → sat
+        update(&mut d, &ring_alert(77, 16.0)); // ground footprint → ring
+        assert_eq!(d.iridium_sats.len(), 1);
+        assert_eq!(d.iridium_rings.len(), 1);
+        let snap: Value = serde_json::from_str(&snapshot(&mut d)).unwrap();
+        assert_eq!(snap["iridium_sats"][0]["sat"], 44);
+        assert_eq!(snap["iridium_sats"][0]["name"], "IRIDIUM 106");
+        assert_eq!(snap["iridium_rings"][0]["sat"], 77);
+        assert_eq!(snap["iridium_rings"][0]["beam"], 5);
+    }
 }


### PR DESCRIPTION
Two toggleable map overlays on the live dashboard, like iridium-toolkit's `live-map`: the broadcasting **Iridium satellites** and the **targeted ring/beam ground footprints**. The data's already decoded from ring-alert frames — this surfaces it.

## Backend (`http.rs`)
Bucket ring-alert positions by altitude:
- geocentric **~800 km → satellite** (keyed by sat id, labelled with the satmap NORAD name when matched, with a ground-track trail)
- **<100 km → ground beam footprint** (keyed by sat+beam)

Served in `/api/state` as `iridium_sats` / `iridium_rings`, each with its own expiry (sats 10 min, rings 5 min).

## Frontend (`dashboard.html`)
A Leaflet layer control (top-right) toggles each overlay; visibility persists to `localStorage`. Satellites render as a 🛰 marker with a faint dashed ground track; rings as a teal footprint circle. Both stay **out of the aircraft/vessel auto-fit** so global satellite positions never yank the local view. Status line gains a sat count.

## Validation
- Backend bucketing unit test (sat vs ring by altitude → `/api/state`)
- Browser render (gstack /browse) with injected data: the **IRIDIUM 106 satellite marker + ground track** and the **ring footprint circle** render with **no console errors**; both layer toggles present
- Workspace tests pass (**304**)

🤖 Generated with [Claude Code](https://claude.com/claude-code)