### PR TITLE
Dashboard: map Iridium mobile-terminal positions (the actual devices)

### DIFF
--- a/src/outputs/assets/dashboard.html
+++ b/src/outputs/assets/dashboard.html
@@ -102,20 +102,27 @@ const ringLayer = L.layerGroup();
 // Beam pattern: the full reconstructed 48-cell pattern projected under each
 // tracked satellite (off by default — a denser power-user view).
 const patternLayer = L.layerGroup();
+// Mobile terminals: Iridium customer devices (vessels/aircraft/handhelds)
+// that report their own position — distinct from the beam footprints.
+const deviceLayer = L.layerGroup();
 L.control.layers(null,
-  { '🛰 Iridium satellites': satLayer, '◎ Spot beams': ringLayer, '⬡ Beam pattern': patternLayer },
+  { '🛰 Iridium satellites': satLayer, '◎ Spot beams': ringLayer,
+    '⬡ Beam pattern': patternLayer, '📟 Iridium terminals': deviceLayer },
   { position: 'topright', collapsed: false }).addTo(map);
 if (localStorage.getItem('xng.satLayer') !== '0') satLayer.addTo(map);
 if (localStorage.getItem('xng.ringLayer') !== '0') ringLayer.addTo(map);
 if (localStorage.getItem('xng.patternLayer') === '1') patternLayer.addTo(map);
+if (localStorage.getItem('xng.deviceLayer') !== '0') deviceLayer.addTo(map);
 map.on('overlayadd overlayremove', () => {
   localStorage.setItem('xng.satLayer', map.hasLayer(satLayer) ? '1' : '0');
   localStorage.setItem('xng.ringLayer', map.hasLayer(ringLayer) ? '1' : '0');
   localStorage.setItem('xng.patternLayer', map.hasLayer(patternLayer) ? '1' : '0');
+  localStorage.setItem('xng.deviceLayer', map.hasLayer(deviceLayer) ? '1' : '0');
 });
 const satMarkers = new Map();  // sat id -> {marker, trail}
 const ringMarkers = new Map(); // "sat-beam" -> coverage-cell L.circle
 const patternMarkers = new Map(); // "sat-beam" -> projected pattern cell
+const deviceMarkers = new Map(); // "lat,lon" -> terminal marker
 
 // Aircraft silhouettes: PlaneWatch pw-silhouettes (CC BY-NC-SA 4.0,
 // used with permission). Resolved by ICAO type designator via the
@@ -321,6 +328,32 @@ function syncIridium(s) {
   for (const [k, m] of patternMarkers) if (!seenCell.has(k)) {
     patternLayer.removeLayer(m);
     patternMarkers.delete(k);
+  }
+
+  // Iridium mobile terminals: customer devices that reported their own
+  // position (the real device locations, vs the beam footprints above).
+  const seenDev = new Set();
+  for (const dvc of (s.iridium_devices || [])) {
+    const key = dvc.lat.toFixed(2) + ',' + dvc.lon.toFixed(2);
+    seenDev.add(key);
+    const alt = dvc.alt_km || 0;
+    const popup = `Iridium terminal<br>${dvc.lat.toFixed(3)}, ${dvc.lon.toFixed(3)}` +
+      (alt > 2 ? `<br>alt ~${alt} km` : '') +
+      (dvc.msg_type ? `<br>msg ${dvc.msg_type}` : '');
+    let m = deviceMarkers.get(key);
+    if (!m) {
+      m = L.circleMarker([dvc.lat, dvc.lon],
+        { radius: 4, color: '#f59e0b', weight: 2, fillColor: '#f59e0b', fillOpacity: 0.7 })
+        .addTo(deviceLayer);
+      m.bindPopup(popup);
+      deviceMarkers.set(key, m);
+    } else {
+      m.setPopupContent(popup);
+    }
+  }
+  for (const [k, m] of deviceMarkers) if (!seenDev.has(k)) {
+    deviceLayer.removeLayer(m);
+    deviceMarkers.delete(k);
   }
 }
 

--- a/src/outputs/http.rs
+++ b/src/outputs/http.rs
@@ -37,6 +37,10 @@ struct Dash {
     iridium_sats: HashMap<u64, Value>,
     /// Iridium ring/beam ground footprints, keyed by "sat-beam".
     iridium_rings: HashMap<String, Value>,
+    /// Iridium mobile-terminal positions (vessels/aircraft/handhelds that
+    /// report their own ECEF), keyed by quantized lat/lon so a stationary
+    /// terminal coalesces and a moving one leaves recent fixes.
+    iridium_devices: HashMap<String, Value>,
     /// Reconstructed 48-beam pattern, projected under tracked satellites.
     beams: crate::beam::BeamReconstructor,
     /// Last unix-secs the beam pattern was persisted.
@@ -220,6 +224,26 @@ fn update(d: &mut Dash, m: &Message) {
                 }
             }
         }
+        // Mobile-terminal self-reported positions: the actual Iridium
+        // customer terminals (vessels/aircraft/handhelds), distinct from the
+        // ring-alert beam footprints above.
+        MessageBody::Iridium { kind, details } if kind == "mt-position" => {
+            if let (Some(lat), Some(lon)) = (
+                details.get("lat").and_then(Value::as_f64),
+                details.get("lon").and_then(Value::as_f64),
+            ) {
+                let key = format!("{lat:.2},{lon:.2}");
+                let e = d.iridium_devices.entry(key).or_insert_with(|| json!({}));
+                let o = e.as_object_mut().unwrap();
+                o.insert("lat".into(), json!(lat));
+                o.insert("lon".into(), json!(lon));
+                o.insert("alt_km".into(), json!(details.get("alt_km").and_then(Value::as_i64).unwrap_or(0)));
+                if let Some(mt) = details.get("msg_type") {
+                    o.insert("msg_type".into(), mt.clone());
+                }
+                o.insert("seen".into(), json!(now_s()));
+            }
+        }
         _ => {}
     }
 
@@ -248,6 +272,7 @@ fn snapshot(d: &mut Dash) -> String {
     let ring_cut = now_s().saturating_sub(RING_EXPIRE_S);
     d.iridium_sats.retain(|_, v| v["seen"].as_u64().unwrap_or(0) >= sat_cut);
     d.iridium_rings.retain(|_, v| v["seen"].as_u64().unwrap_or(0) >= ring_cut);
+    d.iridium_devices.retain(|_, v| v["seen"].as_u64().unwrap_or(0) >= ring_cut);
     // Persist the accumulated beam pattern occasionally so it survives
     // restarts and keeps refining across sessions.
     if now_s().saturating_sub(d.beams_saved) > 120 {
@@ -262,6 +287,7 @@ fn snapshot(d: &mut Dash) -> String {
         "vessels": d.vessels.values().collect::<Vec<_>>(),
         "iridium_sats": d.iridium_sats.values().collect::<Vec<_>>(),
         "iridium_rings": d.iridium_rings.values().collect::<Vec<_>>(),
+        "iridium_devices": d.iridium_devices.values().collect::<Vec<_>>(),
         "iridium_beam_cells": d.beams.project(now_s() as f64, SAT_EXPIRE_S as f64),
         "messages": d.recent.iter().rev().take(100).collect::<Vec<_>>(),
         "totals": d.totals,

--- a/src/outputs/http.rs
+++ b/src/outputs/http.rs
@@ -391,4 +391,41 @@ mod tests {
         assert_eq!(snap["iridium_rings"][0]["sat"], 77);
         assert_eq!(snap["iridium_rings"][0]["beam"], 5);
     }
+
+    fn mt_position(lat: f64, lon: f64) -> Message {
+        Message {
+            mode: Mode::Iridium,
+            timestamp: chrono::Utc::now(),
+            frequency_hz: 1_622_000_000,
+            signal: Default::default(),
+            decode: Default::default(),
+            body: MessageBody::Iridium {
+                kind: "mt-position".into(),
+                details: json!({
+                    "type": "mt-position", "msg_type": "7605",
+                    "lat": lat, "lon": lon, "alt_km": 0,
+                }),
+            },
+            raw: None,
+            source: Provenance {
+                station: StationIdentity::new("T"),
+                app: AppInfo::xng(),
+                sdr: None,
+                channel: None,
+            },
+        }
+    }
+
+    #[test]
+    fn maps_iridium_terminal_positions() {
+        let mut d = Dash::default();
+        update(&mut d, &mt_position(37.78, -122.50));
+        update(&mut d, &mt_position(37.781, -122.501)); // same ~0.01° cell → coalesces
+        update(&mut d, &mt_position(39.01, -123.79)); // distinct terminal
+        assert_eq!(d.iridium_devices.len(), 2, "two distinct terminal cells");
+        let snap: Value = serde_json::from_str(&snapshot(&mut d)).unwrap();
+        assert_eq!(snap["iridium_devices"].as_array().unwrap().len(), 2);
+        // mt-position must NOT leak into the beam-footprint (spot beam) layer.
+        assert_eq!(snap["iridium_rings"].as_array().unwrap().len(), 0);
+    }
 }


### PR DESCRIPTION
## What

Prompted by a sharp question: *"Are ring-alerts being misclassified as spot beams? Aren't these customer devices?"*

The answer is **no, the spot beams are correct** — a ring-alert's low-altitude position is the satellite **beam footprint** (boresight ground point), confirmed against both references (beam-plotter reconstructs the 48-beam pattern from these; iridium-sniffer labels them "~200 km beam estimate"). A ring-alert *pages* customer devices (the `pages=N` field — 140/194 of our spot beams page 1–12 devices) but does **not** carry their location, only which beam.

**But the question surfaced a real gap.** The actual device positions *are* decoded — `mt-position` frames: the geocentric self-reported positions of Iridium customer terminals (vessels/aircraft/handhelds). We log **~1,200/session** here (terminals around the NorCal coast) — and then dropped them at the map layer. So the only Iridium dots on the map were beam footprints, which are easy to mistake for devices.

## Change

Add an **"📟 Iridium terminals"** map layer: each `mt-position` becomes an amber dot, keyed by quantized lat/lon (stationary terminals coalesce; moving ones leave recent fixes), expired like the ring footprints. This is the map form of the sniffer's `mtpos_ida_cb` / `web_map` device markers, and makes the device-vs-beam distinction explicit:

- 🛰 satellites · ◎ spot beams (footprints) · ⬡ beam pattern · **📟 terminals (real devices)**

## Verification
Built clean; http bucket test passes. Deployed to the live station to confirm `iridium_devices` populates from real `mt-position` traffic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an Iridium mobile terminals layer to the dashboard map. Terminals are displayed as markers with position and altitude information. Layer visibility can be toggled on/off and is remembered between sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->