### PR TITLE
Dashboard: beam pattern — active cells bright, rest muted, hover-link to satellite

### DIFF
--- a/src/beam.rs
+++ b/src/beam.rs
@@ -53,6 +53,10 @@ const MIN_OBS: u32 = 2;
 /// clamped to a plausible beam footprint range.
 const CELL_RADIUS_MIN_KM: f64 = 40.0;
 const CELL_RADIUS_MAX_KM: f64 = 600.0;
+/// A beam counts as "active" (currently illuminating, drawn bright) if this
+/// satellite was seen on it within this many seconds; older beams stay in
+/// the pattern but render muted.
+const ACTIVE_WINDOW_S: f64 = 30.0;
 
 /// How an IRA altitude reading is interpreted.
 pub enum AltClass {
@@ -159,16 +163,22 @@ impl Pattern {
     }
 }
 
-/// Tracks each satellite's latest high-altitude fix and travel direction.
+/// Tracks each satellite's latest high-altitude fix and travel direction,
+/// plus when each of its beams was last seen illuminating the ground (so a
+/// projected cell can be marked active vs merely reconstructed).
 struct SatTrack {
     pos: [f64; 3],
     z_prev: f64,
     north: i8,
     time: f64,
+    /// beam id -> last footprint time observed for THIS satellite.
+    seen_beams: HashMap<u8, f64>,
 }
 
 /// One projected beam cell, with the reconstructed footprint radius (m) so
-/// the map can draw each beam at its actual extent.
+/// the map can draw each beam at its actual extent. `active` is true when
+/// this satellite was seen illuminating this beam within ACTIVE_WINDOW_S
+/// (so the map can brighten live beams and mute the rest of the pattern).
 #[derive(Serialize)]
 pub struct Cell {
     pub sat: u64,
@@ -176,6 +186,7 @@ pub struct Cell {
     pub lat: f64,
     pub lon: f64,
     pub radius_m: f64,
+    pub active: bool,
 }
 
 /// Live reconstructor: fed every ring-alert frame, accumulates the pattern,
@@ -218,16 +229,31 @@ impl BeamReconstructor {
                     // First fix or a long gap (likely a new pass): unknown.
                     _ => 0,
                 };
-                self.tracks.insert(sat, SatTrack { pos: ecef, z_prev: ecef[2], north, time });
+                // Preserve the per-beam observation history across fixes.
+                let e = self.tracks.entry(sat).or_insert_with(|| SatTrack {
+                    pos: ecef,
+                    z_prev: ecef[2],
+                    north,
+                    time,
+                    seen_beams: HashMap::new(),
+                });
+                e.pos = ecef;
+                e.z_prev = ecef[2];
+                e.north = north;
+                e.time = time;
             }
             AltClass::Footprint => {
-                if let Some(t) = self.tracks.get(&sat) {
-                    if t.north != 0 && time - t.time < FRESH_S {
-                        let (cross, along) = to_sat_frame(t.pos, ecef, t.north);
-                        let pat = if t.north < 0 { &mut self.south } else { &mut self.north };
-                        pat.add(beam, cross, along);
-                    }
+                // Read what we need from the track, then borrow the pattern.
+                let (north, pos) = match self.tracks.get(&sat) {
+                    Some(t) if t.north != 0 && time - t.time < FRESH_S => (t.north, t.pos),
+                    _ => return,
+                };
+                let (cross, along) = to_sat_frame(pos, ecef, north);
+                if let Some(t) = self.tracks.get_mut(&sat) {
+                    t.seen_beams.insert(beam, time); // mark this beam active
                 }
+                let pat = if north < 0 { &mut self.south } else { &mut self.north };
+                pat.add(beam, cross, along);
             }
             AltClass::Implausible => {}
         }
@@ -247,12 +273,17 @@ impl BeamReconstructor {
                 if let Some((cross, along, radius_km)) = pat.mean(beam, MIN_OBS) {
                     let e = to_ecef(t.pos, cross, along, t.north);
                     let (lat, lon) = lat_lon(e);
+                    let active = t
+                        .seen_beams
+                        .get(&beam)
+                        .is_some_and(|&ts| now - ts < ACTIVE_WINDOW_S);
                     out.push(Cell {
                         sat,
                         beam,
                         lat: lat.to_degrees(),
                         lon: lon.to_degrees(),
                         radius_m: radius_km * 1000.0,
+                        active,
                     });
                 }
             }
@@ -412,6 +443,23 @@ mod tests {
         r.observe(3, 780.0, ecef(40.0, -120.0, R_EARTH_KM + 780.0), 0, t2);
         r.observe(3, 16.0, ecef(40.5, -119.0, R_EARTH_KM), 14, t2 + 1.0);
         assert_eq!(r.beams_known(), 1, "no new beam after a direction reset");
+    }
+
+    #[test]
+    fn active_flag_reflects_recent_footprint() {
+        let mut r = BeamReconstructor::new();
+        let t0 = 1000.0;
+        r.observe(2, 780.0, ecef(40.0, -120.0, R_EARTH_KM + 780.0), 0, t0);
+        r.observe(2, 780.0, ecef(41.0, -120.0, R_EARTH_KM + 780.0), 0, t0 + 1.0);
+        r.observe(2, 16.0, ecef(41.5, -119.0, R_EARTH_KM), 7, t0 + 2.0);
+        r.observe(2, 16.0, ecef(41.5, -119.0, R_EARTH_KM), 7, t0 + 3.0);
+        // Seen ~1 s ago → active.
+        let c = r.project(t0 + 4.0, 600.0).into_iter().find(|c| c.beam == 7).expect("beam 7");
+        assert!(c.active, "recently-seen beam must be active");
+        // Long past the active window but track still current → still in the
+        // pattern, but muted (inactive).
+        let c = r.project(t0 + 50.0, 600.0).into_iter().find(|c| c.beam == 7).expect("still present");
+        assert!(!c.active, "beam not seen for >30 s must be muted");
     }
 
     #[test]

--- a/src/outputs/assets/dashboard.html
+++ b/src/outputs/assets/dashboard.html
@@ -122,7 +122,21 @@ map.on('overlayadd overlayremove', () => {
 const satMarkers = new Map();  // sat id -> {marker, trail}
 const ringMarkers = new Map(); // "sat-beam" -> coverage-cell L.circle
 const patternMarkers = new Map(); // "sat-beam" -> projected pattern cell
+const patternBySat = new Map(); // sat id -> [pattern cell markers] (for hover link)
 const deviceMarkers = new Map(); // "lat,lon" -> terminal marker
+
+// Hover a satellite to light up its whole beam pattern (the visual link
+// between a satellite and the cells it projects); mouse-out restores each
+// cell to its active/muted base style.
+function highlightSatPattern(satId, on) {
+  const cells = patternBySat.get(satId);
+  if (!cells) return;
+  for (const m of cells) {
+    if (on && m._base) m.setStyle({ weight: m._base.weight + 2, opacity: 1,
+      fillOpacity: Math.min(m._base.fillOpacity + 0.18, 0.5) });
+    else if (m._base) m.setStyle(m._base);
+  }
+}
 
 // Aircraft silhouettes: PlaneWatch pw-silhouettes (CC BY-NC-SA 4.0,
 // used with permission). Resolved by ICAO type designator via the
@@ -256,6 +270,9 @@ function syncIridium(s) {
       e = { marker: L.marker([sat.lat, sat.lon], { icon: satIcon() }).addTo(satLayer) };
       e.marker.bindTooltip(label, { permanent: true, direction: 'right', offset: [10, 0], className: 'lbl' });
       e.marker.bindPopup(popup);
+      const sid = sat.sat; // link this satellite to its beam pattern on hover
+      e.marker.on('mouseover', () => highlightSatPattern(sid, true));
+      e.marker.on('mouseout', () => highlightSatPattern(sid, false));
       satMarkers.set(sat.sat, e);
     } else {
       e.marker.setLatLng([sat.lat, sat.lon]);
@@ -303,27 +320,36 @@ function syncIridium(s) {
     ringMarkers.delete(k);
   }
 
-  // Reconstructed beam pattern: all 48 cells projected under each tracked
-  // satellite. Each cell is drawn at its reconstructed footprint radius
+  // Reconstructed beam pattern: the full set of reconstructed cells under
+  // each tracked satellite, each drawn at its reconstructed footprint radius
   // (the scatter of its de-rotated observations, as iridium-toolkit's
-  // beam-plotter sizes each cell), with a sparse fill so the tiling reads
-  // under the spot-beam cells.
+  // beam-plotter sizes each cell). Currently-illuminated beams (active)
+  // render bright in their per-beam colour; the rest of the pattern is kept
+  // but muted (faint dashed outline) so you see the whole pattern without it
+  // overpowering the live beams. Hover a satellite to light up its pattern.
   const seenCell = new Set();
+  patternBySat.clear();
   for (const c of (s.iridium_beam_cells || [])) {
     const key = c.sat + '-' + c.beam;
     seenCell.add(key);
     const col = beamColor(c.beam);
     const rad = c.radius_m || 130000;
+    const style = c.active
+      ? { color: col, fillColor: col, weight: 2, opacity: 0.85, fillOpacity: 0.28, dashArray: null }
+      : { color: col, fillColor: col, weight: 1, opacity: 0.35, fillOpacity: 0.03, dashArray: '2 5' };
     let m = patternMarkers.get(key);
     if (!m) {
-      m = L.circle([c.lat, c.lon], { radius: rad, color: col, weight: 1, fillColor: col, fillOpacity: 0.05 }).addTo(patternLayer);
-      m.bindPopup(`pattern: sat ${c.sat} / beam ${c.beam}`);
+      m = L.circle([c.lat, c.lon], { radius: rad, ...style }).addTo(patternLayer);
       patternMarkers.set(key, m);
     } else {
       m.setLatLng([c.lat, c.lon]);
       m.setRadius(rad);
-      m.setStyle({ color: col, fillColor: col });
+      m.setStyle(style);
     }
+    m._base = style;
+    m.bindPopup(`pattern: sat ${c.sat} / beam ${c.beam}${c.active ? ' · active' : ' · muted'}`);
+    if (!patternBySat.has(c.sat)) patternBySat.set(c.sat, []);
+    patternBySat.get(c.sat).push(m);
   }
   for (const [k, m] of patternMarkers) if (!seenCell.has(k)) {
     patternLayer.removeLayer(m);


### PR DESCRIPTION
## What

Makes the reconstructed beam pattern read like iridium-toolkit's beam visualization while keeping our per-beam colouring. Two capabilities:

### Active vs muted (the "show the full pattern but mute non-detected spots" ask)
Each satellite track now records when it last saw each beam illuminating the ground (`seen_beams`). A projected `Cell` carries an `active` flag (beam seen within 30 s). The map draws **active beams bright** in their per-beam colour and keeps the rest of the reconstructed pattern but **mutes it** (faint dashed outline). So you see the whole 48-cell pattern at once without the historical cells drowning out the beams currently illuminating.

### Satellite link
**Hovering a satellite marker lights up its entire beam pattern** (the cells it projects), making the satellite→pattern association explicit and unambiguous when several satellites overlap.

## Implementation
- `beam.rs`: `SatTrack.seen_beams` (preserved across high-fixes), `Cell.active`, `ACTIVE_WINDOW_S = 30`.
- `dashboard.html`: per-cell active/muted style (keeps `beamColor`), `patternBySat` index + `highlightSatPattern` bound to satellite marker hover.

## Tests
New `active_flag_reflects_recent_footprint` (active right after a footprint, muted >30 s later while still in the pattern). 8 beam tests pass.

## Note
Stacked on #148 (merged); rebased onto master. The cell *sizing* (per-beam spread) and *coverage* (drop bad-decode positions, confidence gate) landed earlier in #144/#147.

🤖 Generated with [Claude Code](https://claude.com/claude-code)