### PR TITLE
Iridium wideband: multi-threaded decode (FFT + burst demod), configurable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -490,6 +490,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "crossterm"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2161,6 +2186,26 @@ dependencies = [
  "time",
  "unicode-segmentation",
  "unicode-width",
+]
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -3954,6 +3999,7 @@ dependencies = [
  "prost",
  "quinn",
  "ratatui",
+ "rayon",
  "rcgen",
  "rumqttc",
  "rustfft",
@@ -4075,6 +4121,7 @@ dependencies = [
  "chrono",
  "crc",
  "num-complex",
+ "rayon",
  "rustfft",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ chrono = { version = "0.4", features = ["serde"] }
 crc = "3"
 crossbeam-channel = "0.8"
 num-complex = "0.4"
+rayon = "1"
 rustfft = "6"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -72,6 +73,7 @@ airspyhf = ["xng-sdr/airspyhf"]
 
 [dependencies]
 anyhow.workspace = true
+rayon.workspace = true
 rumqttc.workspace = true
 toml = "0.8"
 sgp4 = "2"

--- a/crates/xng-mode-iridium/Cargo.toml
+++ b/crates/xng-mode-iridium/Cargo.toml
@@ -11,6 +11,7 @@ authors.workspace = true
 chrono.workspace = true
 crc.workspace = true
 num-complex.workspace = true
+rayon.workspace = true
 rustfft.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/xng-mode-iridium/src/wideband.rs
+++ b/crates/xng-mode-iridium/src/wideband.rs
@@ -7,6 +7,7 @@
 use crate::demod::IridiumDemod;
 use crate::CHANNEL_RATE;
 use num_complex::Complex;
+use rayon::prelude::*;
 use rustfft::Fft;
 use std::sync::Arc;
 use xng_dsp::Ddc;
@@ -116,23 +117,44 @@ impl IridiumWideband {
     /// their frequency offsets).
     pub fn process(&mut self, input: &[Complex<f32>]) -> Vec<WidebandBurst> {
         self.buf.extend_from_slice(input);
-        let mut out = Vec::new();
+        // Bursts that finish this call; demodulated in parallel below. The
+        // detection loop stays sequential (the noise-floor EMA is stateful),
+        // but per-burst extract is independent and the heavy part (DDC +
+        // demod over a whole burst at the input rate), so it parallelizes.
+        let mut to_extract: Vec<ActiveBurst> = Vec::new();
         let frame_len = self.nfft as u64;
 
-        loop {
-            let frame_start = self.next_frame * frame_len;
-            if frame_start + frame_len > self.start_abs + self.buf.len() as u64 {
-                break;
+        // Each frame's windowed FFT magnitude spectrum is an independent
+        // computation, and the FFTs dominate the per-frame cost at high
+        // capture rates. Compute them all in parallel up front; the stateful
+        // noise-floor + burst detection below then runs sequentially over
+        // them in frame order, so the result is identical to the previous
+        // inline single-threaded version.
+        let buf_end = self.start_abs + self.buf.len() as u64;
+        let frame_rels: Vec<usize> = {
+            let mut rels = Vec::new();
+            let mut nf = self.next_frame;
+            while nf * frame_len + frame_len <= buf_end {
+                rels.push((nf * frame_len - self.start_abs) as usize);
+                nf += 1;
             }
-            let rel = (frame_start - self.start_abs) as usize;
-            let mut spec: Vec<Complex<f32>> = self.buf[rel..rel + self.nfft]
-                .iter()
-                .zip(&self.window)
-                .map(|(s, &w)| s * w)
-                .collect();
-            self.fft.process(&mut spec);
-            let mag: Vec<f32> = spec.iter().map(|c| c.norm_sqr()).collect();
+            rels
+        };
+        let (fft, samples, window, nfft) = (&self.fft, &self.buf, &self.window, self.nfft);
+        let mags: Vec<Vec<f32>> = frame_rels
+            .par_iter()
+            .map(|&rel| {
+                let mut spec: Vec<Complex<f32>> = samples[rel..rel + nfft]
+                    .iter()
+                    .zip(window)
+                    .map(|(s, &w)| s * w)
+                    .collect();
+                fft.process(&mut spec);
+                spec.iter().map(|c| c.norm_sqr()).collect()
+            })
+            .collect();
 
+        for mag in &mags {
             // Update the per-bin noise floor. Warm up with a running
             // mean over the first WARMUP_FRAMES (no detection yet), then
             // track with the slow EMA. Detecting before the floor is
@@ -241,13 +263,19 @@ impl IridiumWideband {
                 if self.recent.len() > 8 {
                     self.recent.remove(0);
                 }
-                if let Some(burst) = self.extract(&b) {
-                    out.push(burst);
-                }
+                to_extract.push(b);
             }
 
             self.next_frame += 1;
         }
+
+        // Demodulate finished bursts in parallel (extract is &self, reads the
+        // sample buffer immutably; par_iter().collect() preserves order, so
+        // the output is identical to the previous inline single-threaded
+        // extraction). Done before the buffer is drained below.
+        let this = &*self;
+        let out: Vec<WidebandBurst> =
+            to_extract.par_iter().filter_map(|b| this.extract(b)).collect();
 
         // Drop samples no longer needed: everything before the earliest
         // active burst (minus pre-roll) or the current frame.

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,12 @@ struct Cli {
     #[arg(short, long, action = clap::ArgAction::Count, global = true)]
     verbose: u8,
 
+    /// Decode worker threads for parallel channelization / burst demod
+    /// (Iridium wideband FFT + per-burst extract, and other parallel decode
+    /// paths). Default: auto — all available CPU cores.
+    #[arg(long, global = true)]
+    decode_threads: Option<usize>,
+
     #[command(subcommand)]
     command: Command,
 }
@@ -543,6 +549,20 @@ fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
     init_logging(cli.verbose);
     tracing::info!("xng v{}", env!("CARGO_PKG_VERSION"));
+
+    // Size the decode worker pool (parallel channelization / burst demod).
+    // Left unset, rayon lazily uses all logical cores ("auto"); an explicit
+    // --decode-threads pins the count. build_global is one-shot, so only
+    // call it when overriding.
+    if let Some(n) = cli.decode_threads {
+        let n = n.max(1);
+        if rayon::ThreadPoolBuilder::new().num_threads(n).build_global().is_ok() {
+            tracing::info!("decode worker threads: {n}");
+        }
+    } else {
+        let auto = std::thread::available_parallelism().map(|p| p.get()).unwrap_or(1);
+        tracing::info!("decode worker threads: auto ({auto} cores)");
+    }
 
     match cli.command {
         Command::Devices { filter } => commands::devices::run(&filter),


### PR DESCRIPTION
## What

Makes the Iridium wideband decode use multiple cores, so the Airspy R2 at 10 MS/s (full-band) no longer overruns a single core.

## Problem

At 10 MS/s the wideband decode was single-threaded — xng pegged ~1.1 of 12 cores and the SDR dropped **~30% of chunks** (`chan_dropped`) before they could be decoded (USB was clean, `usb_dropped=0`). 11 cores sat idle.

## Change

Two independent, parallelizable parts of `wideband.rs::process`, both done with rayon:

1. **Per-frame FFT magnitudes** are computed in parallel, then the **stateful** noise-floor EMA + burst detection runs **sequentially** over them in frame order. Because the sequential stage sees the exact same magnitudes in the same order, the output is **byte-identical** to the old inline path.
2. **Finished bursts** are demodulated (DDC + decode) in parallel — `extract` is `&self`, and `par_iter().collect()` preserves order.

## Measured (live R2 station @ 10 MS/s)

| Config | chunk drop |
|--------|-----------|
| Serial (before) | ~30% |
| Extract parallel only | ~14% |
| **FFT + extract parallel** | **~0%** (72-frame startup transient, then flat) |

Decode output unchanged — all 27 iridium unit tests + the off-air oracle/wideband integration tests pass.

## Configurable + auto

`--decode-threads N` (global flag) pins the worker count; left unset it auto-uses all logical cores (rayon's default). The log prints the chosen count. This rayon pool is the shared infrastructure for further parallel decode paths — e.g. the multi-channel decoder loop (ACARS/VDL2/AIS), which isn't CPU-bound at 2.4 MS/s today but can move onto the same pool next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)