### PR TITLE
v0.18.0: Iridium — full off-air decode, beam map, multi-threaded

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3990,7 +3990,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "xng"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4034,7 +4034,7 @@ dependencies = [
 
 [[package]]
 name = "xng-acars"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "base64",
  "crc",
@@ -4046,7 +4046,7 @@ dependencies = [
 
 [[package]]
 name = "xng-dsp"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "crc",
  "num-complex",
@@ -4055,7 +4055,7 @@ dependencies = [
 
 [[package]]
 name = "xng-mode-acars"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "chrono",
  "num-complex",
@@ -4067,7 +4067,7 @@ dependencies = [
 
 [[package]]
 name = "xng-mode-adsb"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "chrono",
  "num-complex",
@@ -4078,7 +4078,7 @@ dependencies = [
 
 [[package]]
 name = "xng-mode-aero"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "chrono",
  "num-complex",
@@ -4092,7 +4092,7 @@ dependencies = [
 
 [[package]]
 name = "xng-mode-ais"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "chrono",
  "num-complex",
@@ -4103,7 +4103,7 @@ dependencies = [
 
 [[package]]
 name = "xng-mode-hfdl"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "chrono",
  "num-complex",
@@ -4116,7 +4116,7 @@ dependencies = [
 
 [[package]]
 name = "xng-mode-iridium"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "chrono",
  "crc",
@@ -4132,7 +4132,7 @@ dependencies = [
 
 [[package]]
 name = "xng-mode-stdc"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "chrono",
  "num-complex",
@@ -4145,7 +4145,7 @@ dependencies = [
 
 [[package]]
 name = "xng-mode-vdl2"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "chrono",
  "num-complex",
@@ -4158,7 +4158,7 @@ dependencies = [
 
 [[package]]
 name = "xng-proto"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "chrono",
  "prost",
@@ -4169,7 +4169,7 @@ dependencies = [
 
 [[package]]
 name = "xng-sdr"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "num-complex",
  "pkg-config",
@@ -4180,7 +4180,7 @@ dependencies = [
 
 [[package]]
 name = "xng-types"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "chrono",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["legacy"]
 resolver = "2"
 
 [workspace.package]
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/airframesio/xng"


### PR DESCRIPTION
**xng v0.18.0 — the Iridium release.** Native off-air Iridium goes from "ITL only" to a full frame decoder with a live satellite/beam map, and the wideband front end is now multi-threaded so an Airspy R2 can cover the whole band in real time.

## Iridium decode (native, off-air)
- **Canonical symbol order** so RA/IBC/LCW/IDA/IMS frames actually decode — the bit-order fix that unblocked everything beyond ITL (#133)
- Real off-air **wideband** decode: per-channel DDC + noise-floor seeding + ITL classification (#127), proven/hardened at the station's 6 MS/s (#126), duplex/LCW frames (#128), all-zero burst rejection (#129)
- **ITL** satellite / orbital-plane / message decode via PRS tables (#130)
- **IBC** full sub-block decode + **LCW** control words + U3/U6/generic frames (#134); **U3** RS8/RS6 inner decode → I38/I36 (#135)
- **IDA application layer**: mobile-terminal positions + GSM CC/MM/SMS signalling (#136)
- **SBD transport**: frequency-keyed reassembly for the wideband path (#131), transport-header decode (IMEI/MOMSN/MTMSN/packets/backlog) + ISY sync quality (#142), 0x20-subtype IMEI/MOMSN gating (#143), readable text for non-ACARS payloads (#154)
- **GSMTAP** output — Iridium GSM frames to Wireshark over UDP (#137)
- **satmap** — label ring alerts with the broadcasting satellite via SGP4 + auto-fetched TLEs (#138)

## Iridium map & beam pattern (dashboard)
- Optional **satellite + ring-location** layers (#139) and **spot-beam** ground-coverage cells (#140)
- Full **48-beam pattern reconstruction** + geographic projection (#141), sized to real beam coverage via nearest-neighbour spacing (#147, #151)
- Pattern quality: reject impossible-altitude decodes + confidence gate (#144), crash-safe persistence (#145), sticky travel direction (#146), heading from sparse fixes — fixes chronic empty pattern (#150)
- **Active vs muted** live cells + hover/click-to-pin satellite→pattern link (#149, #151)
- **Mobile-terminal** device positions layer — the actual customer terminals (#148)

## Performance
- **Multi-threaded wideband decode** (parallel per-frame FFT + per-burst demod, byte-identical output) — chunk drop ~30% → ~0% at 10 MS/s on an Airspy R2 covering the full band. Configurable via `--decode-threads N`; default auto = all cores (#153)

## Robustness & tooling
- **Graceful SIGTERM shutdown** — fixes the Airspy wedge-on-restart (#132)
- **`xng status`** — live per-session table for a running station (#124)
- **`xng survey`** — `--duration` now bounds the whole run (gain sweep included) and the report/`--out` file always writes on Ctrl-C (#152)
- Dashboard: resizable panes, collapsible log, relocated mode chips (#125); vessel silhouettes tinted by AIS ship type (#123)
- BENCHMARKS: AIS soft-bit list repair falsified at the noise floor (#122)
