### PR TITLE
Iridium: correct spot-beam coverage circle size (was ~75% too large)

### DIFF
--- a/src/beam.rs
+++ b/src/beam.rs
@@ -61,7 +61,7 @@ const BEAM_OVERLAP: f64 = 0.62;
 const CELL_RADIUS_MIN_KM: f64 = 150.0;
 const CELL_RADIUS_MAX_KM: f64 = 450.0;
 /// Radius for a beam with no reconstructed neighbour yet (≈ footprint/48).
-const DEFAULT_BEAM_RADIUS_KM: f64 = 340.0;
+const DEFAULT_BEAM_RADIUS_KM: f64 = 200.0;
 /// A beam counts as "active" (currently illuminating, drawn bright) if this
 /// satellite was seen on it within this many seconds; older beams stay in
 /// the pattern but render muted.

--- a/src/outputs/assets/dashboard.html
+++ b/src/outputs/assets/dashboard.html
@@ -276,12 +276,13 @@ const shipIcon = (cog, type) => {
     iconSize: [16, 16], iconAnchor: [8, 8] });
 };
 const IRIDIUM = '#73daca';
-// Spot-beam coverage cell: an Iridium spot beam lights ~350 km of ground
-// (the 48 beams tile a ~4700 km footprint), hue per beam id (1–48) so the
-// cells under a satellite read as a coloured tiling. The reconstructed
-// beam-pattern cells size themselves per-beam from neighbour spacing; this
-// fixed radius is for the observed-footprint markers.
-const BEAM_RADIUS_M = 350000;
+// Spot-beam coverage cell: an Iridium spot beam covers ~400 km of ground
+// (~200 km radius); the 48 beams tile the ~4700 km footprint, hue per beam
+// id (1–48) so the cells under a satellite read as a coloured tiling. Real
+// beams vary (smaller near nadir, larger at the edge), so a live ring
+// footprint prefers its reconstructed per-beam radius when the beam pattern
+// has resolved that beam; this nominal radius is the fallback.
+const BEAM_RADIUS_M = 200000;
 // Full Iridium satellite footprint (~4700 km diameter): the 48 spot beams
 // tile this disc. A single ground station only reconstructs the beams that
 // sweep over it (one cross-track side, ~20 of 48), so the pattern looks
@@ -351,11 +352,17 @@ function syncIridium(s) {
     if (fp) { patternLayer.removeLayer(fp); footprintMarkers.delete(k); }
   }
 
+  // Per-beam reconstructed radius (sat-beam → m) so a live spot-beam
+  // footprint is drawn at the same size as its reconstructed pattern cell,
+  // rather than a one-size-fits-all circle.
+  const cellRad = new Map();
+  for (const c of (s.iridium_beam_cells || [])) cellRad.set(c.sat + '-' + c.beam, c.radius_m);
   const seenRing = new Set();
   for (const r of (s.iridium_rings || [])) {
     const key = r.sat + '-' + r.beam;
     seenRing.add(key);
     const col = beamColor(r.beam);
+    const rad = cellRad.get(key) || BEAM_RADIUS_M;
     const popup = entityPopup('', escapeHtml(`spot beam S${r.sat}/B${r.beam}`), [
       ['sat id', r.sat],
       ['beam', r.beam],
@@ -366,12 +373,13 @@ function syncIridium(s) {
     if (!m) {
       // The spot beam projected on the ground: a geographic coverage cell
       // (scales with zoom), coloured by beam id, labelled at its center.
-      m = L.circle([r.lat, r.lon], { radius: BEAM_RADIUS_M, color: col, weight: 1, fillColor: col, fillOpacity: 0.08 }).addTo(ringLayer);
+      m = L.circle([r.lat, r.lon], { radius: rad, color: col, weight: 1, fillColor: col, fillOpacity: 0.08 }).addTo(ringLayer);
       m.bindTooltip(`B${r.beam}`, { permanent: true, direction: 'center', className: 'lbl' });
       m.bindPopup(popup);
       ringMarkers.set(key, m);
     } else {
       m.setLatLng([r.lat, r.lon]);
+      m.setRadius(rad);
       m.setStyle({ color: col, fillColor: col });
       m.setPopupContent(popup);
     }
@@ -394,7 +402,7 @@ function syncIridium(s) {
     const key = c.sat + '-' + c.beam;
     seenCell.add(key);
     const col = beamColor(c.beam);
-    const rad = c.radius_m || 130000;
+    const rad = c.radius_m || 200000;
     const style = c.active
       ? { color: col, fillColor: col, weight: 2, opacity: 0.85, fillOpacity: 0.28, dashArray: null }
       : { color: col, fillColor: col, weight: 1, opacity: 0.35, fillOpacity: 0.03, dashArray: '2 5' };


### PR DESCRIPTION
Answers "are the coverage circle sizes correct?" — two of three were, one was not.

## Findings (780 km orbit geometry)
| Layer | Was | Correct? |
|---|---|---|
| Satellite footprint disc | 2350 km radius (4700 km dia) | ✓ standard Iridium service footprint (~8° min elevation) |
| Beam-pattern cells | per-beam ~200 km (empirical, 185–281) | ✓ matches the published ~400-km-dia cell, data-driven |
| **Spot beams** | **fixed 350 km** | ✗ ~75% too big; same physical beam as the cells but drawn larger |

The iridium-toolkit reference only scatter-plots beam **centers** in the satellite frame (no ground coverage circles), so these radii are ours to get right from the geometry.

## Fix
- Spot-beam rings now use the **reconstructed per-beam radius** for that sat-beam when the pattern has resolved it, else a nominal **200 km** (≈400 km dia) instead of 350.
- Lowered the reconstruction lone-cell default (`DEFAULT_BEAM_RADIUS_KM`) and the dashboard cell fallback from 340/130 to **200 km** (the measured median).
- Footprint disc unchanged (2350 km is correct).

## Verification
- Rendered radii read back from Leaflet: matched ring `== its cell (185000)`, unmatched ring `== 200000` fallback, cells per-beam `[185000,200000,281000]`, footprint `2350000`.
- `beam::` tests green (radius stays within the [150,450] km bounds); dashboard JS parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)