### PR TITLE
Iridium beam map: uniform cell size + fainter estimated beams

### DIFF
--- a/src/beam.rs
+++ b/src/beam.rs
@@ -299,22 +299,34 @@ impl BeamReconstructor {
             let means: Vec<(u8, f64, f64)> = (1..=48u8)
                 .filter_map(|b| pat.mean(b, MIN_OBS).map(|(c, a)| (b, c, a)))
                 .collect();
-            // Emit one cell, sizing its radius from the spacing to the nearest
-            // neighbouring beam (beams tile the footprint, so a little over
-            // half the centre-to-centre spacing is the cell's real ground
-            // coverage). Takes `out` by ref so the closure doesn't conflict
+            // One uniform cell radius for the whole pattern, from the MEDIAN
+            // nearest-neighbour spacing of the reconstructed beams (× overlap,
+            // clamped). Beams tile the footprint at roughly one size, so a
+            // single representative radius keeps every cell consistent —
+            // reconstructed, mirrored estimate, and the spot-beam markers that
+            // reuse these radii. (Per-cell nearest-neighbour sizing made the
+            // mirrored cells balloon to the clamp, since their nearest *real*
+            // neighbour sits clear across the pattern.)
+            let mut nns: Vec<f64> = means
+                .iter()
+                .map(|&(beam, cross, along)| {
+                    means
+                        .iter()
+                        .filter(|&&(b2, _, _)| b2 != beam)
+                        .map(|&(_, c2, a2)| ((cross - c2).powi(2) + (along - a2).powi(2)).sqrt())
+                        .fold(f64::INFINITY, f64::min)
+                })
+                .filter(|x| x.is_finite())
+                .collect();
+            nns.sort_by(|a, b| a.partial_cmp(b).unwrap());
+            let radius_km = if nns.is_empty() {
+                DEFAULT_BEAM_RADIUS_KM
+            } else {
+                (nns[nns.len() / 2] * BEAM_OVERLAP).clamp(CELL_RADIUS_MIN_KM, CELL_RADIUS_MAX_KM)
+            };
+            // Emit one cell. Takes `out` by ref so the closure doesn't conflict
             // with the loops feeding it.
             let emit = |out: &mut Vec<Cell>, beam: u8, cross: f64, along: f64, active: bool, estimated: bool| {
-                let nn = means
-                    .iter()
-                    .filter(|&&(b2, _, _)| b2 != beam)
-                    .map(|&(_, c2, a2)| ((cross - c2).powi(2) + (along - a2).powi(2)).sqrt())
-                    .fold(f64::INFINITY, f64::min);
-                let radius_km = if nn.is_finite() {
-                    (nn * BEAM_OVERLAP).clamp(CELL_RADIUS_MIN_KM, CELL_RADIUS_MAX_KM)
-                } else {
-                    DEFAULT_BEAM_RADIUS_KM
-                };
                 let (lat, lon) = lat_lon(to_ecef(t.pos, cross, along, t.north));
                 out.push(Cell {
                     sat,

--- a/src/outputs/assets/dashboard.html
+++ b/src/outputs/assets/dashboard.html
@@ -428,7 +428,7 @@ function syncIridium(s) {
     const col = est ? '#8b93b3' : beamColor(c.beam);
     const rad = c.radius_m || 200000;
     const style = est
-      ? { color: col, fillColor: col, weight: 1, opacity: 0.25, fillOpacity: 0.015, dashArray: '1 6' }
+      ? { color: col, fillColor: col, weight: 1, opacity: 0.14, fillOpacity: 0, dashArray: '1 8' }
       : (c.active
         ? { color: col, fillColor: col, weight: 2, opacity: 0.85, fillOpacity: 0.28, dashArray: null }
         : { color: col, fillColor: col, weight: 1, opacity: 0.35, fillOpacity: 0.03, dashArray: '2 5' });
@@ -446,8 +446,12 @@ function syncIridium(s) {
       ? `sat ${c.sat} · estimated beam<br>mirror of the reconstructed pattern (this side is not heard from one station)`
       : `sat ${c.sat} · beam ${c.beam}${c.active ? ' · active' : ' · reconstructed'}`,
       { offset: [0, -4] });
-    if (!patternBySat.has(c.sat)) patternBySat.set(c.sat, []);
-    patternBySat.get(c.sat).push(m);
+    // Only reconstructed cells join the hover/pin highlight; estimates stay
+    // faint so the unobserved side never dominates.
+    if (!est) {
+      if (!patternBySat.has(c.sat)) patternBySat.set(c.sat, []);
+      patternBySat.get(c.sat).push(m);
+    }
   }
   for (const [k, m] of patternMarkers) if (!seenCell.has(k)) {
     patternLayer.removeLayer(m);


### PR DESCRIPTION
Follow-ups to #160 from live review (the reconstructed/estimated/spot-beam circles were different sizes, and the estimated side was too prominent).

## Uniform cell size
Per-cell nearest-neighbour sizing made cells vary with local reconstruction density — and **blew the mirrored estimates up to the 450 km clamp**, because a mirrored cell's nearest *real* neighbour sits clear across the pattern. Live the spread was 184–283 km (reconstructed) vs **209–450 km (estimated, median pegged at the clamp)**.

`project()` now uses **one radius for the whole pattern = the median neighbour spacing × overlap** (clamped). Reconstructed cells, mirrored estimates, and the spot-beam markers that reuse these radii all render at the same size. Live after: **every cell 203 km**.

## Fainter estimated side
Estimated cells lose their fill, dim to opacity 0.14, and are **excluded from the hover/pin highlight**, so the unobserved half stays faint and never dominates.

## Verification
- `beam::` suite green (incl. `cell_radius_tracks_beam_spacing`, `unobserved_half_is_mirror_estimated`).
- Dashboard JS parses; verified live: all cells 203 km, estimated muted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)