### PR TITLE
Iridium beam map: gap-free tiling + spot-beam → pattern linking

### DIFF
--- a/src/beam.rs
+++ b/src/beam.rs
@@ -73,11 +73,7 @@ const TIER_BOUND_KM: [f64; 5] = [0.0, 251.0, 547.0, 1109.0, 1841.0];
 /// would leave corner gaps). Real Iridium beams overlap this much — usable
 /// coverage runs well past the −3 dB contour — so coverage is contiguous and
 /// gap-free.
-const BEAM_OVERLAP_F: f64 = 1.45;
-/// A canonical slot counts as decoded (drawn solid) when a reconstructed beam
-/// sits within this distance of it; otherwise it renders faint as a
-/// not-yet-decoded beam.
-const DECODE_MATCH_KM: f64 = 280.0;
+const BEAM_OVERLAP_F: f64 = 1.5;
 /// A beam counts as "active" (currently illuminating, drawn bright) if this
 /// satellite was seen on it within this many seconds; older beams stay in
 /// the pattern but render muted.
@@ -132,16 +128,6 @@ fn lat_lon(p: [f64; 3]) -> (f64, f64) {
     (p[2].atan2((p[0] * p[0] + p[1] * p[1]).sqrt()), p[1].atan2(p[0]))
 }
 
-/// Which of the 4 concentric tiers a beam at ground distance `d` (km) from
-/// nadir belongs to (nearest tier radius).
-fn nearest_tier(d: f64) -> usize {
-    (0..4)
-        .min_by(|&a, &b| {
-            (d - TIER_RADIUS_KM[a]).abs().total_cmp(&(d - TIER_RADIUS_KM[b]).abs())
-        })
-        .unwrap()
-}
-
 /// A tier's beam footprint as (radial semi-axis, azimuthal semi-axis) in km.
 /// Radial = half the tier's radial band (so tiers tile inward/outward);
 /// azimuthal = half the chord to the adjacent beam in the same tier. Outer
@@ -149,7 +135,10 @@ fn nearest_tier(d: f64) -> usize {
 fn tier_axes(tier: usize) -> (f64, f64) {
     let r = TIER_RADIUS_KM[tier];
     let radial = (r - TIER_BOUND_KM[tier]).max(TIER_BOUND_KM[tier + 1] - r);
-    let azim = r * (std::f64::consts::PI / TIER_COUNT[tier] as f64).sin();
+    // Azimuthal half-width taken at the tier's OUTER edge — the widest part of
+    // the wedge-shaped cell — so the ellipse covers the outer corners where
+    // azimuthally-adjacent beams would otherwise leave a gap.
+    let azim = TIER_BOUND_KM[tier + 1] * (std::f64::consts::PI / TIER_COUNT[tier] as f64).sin();
     (radial * BEAM_OVERLAP_F, azim * BEAM_OVERLAP_F)
 }
 
@@ -398,57 +387,43 @@ impl BeamReconstructor {
                 }
             }
 
-            // Match each decoded beam to its single nearest canonical slot
-            // (within DECODE_MATCH_KM); those slots are then "decoded" and not
-            // redrawn as faint, so one decoded beam frees exactly one slot.
+            // Snap each decoded beam to its nearest canonical slot, then emit
+            // exactly one cell per slot so the 48 beams tile cleanly, gap-free.
+            // The canonical model is the accurate beam layout; the measured
+            // positions are noisy samples of it, so snapping removes the tiling
+            // gaps that scatter would cause. A slot with a beam assigned draws
+            // solid (and takes that beam's id/active state); the rest draw faint
+            // as not-yet-decoded.
             let slots = slots_at(phase);
-            let mut matched = vec![false; slots.len()];
-            for &(_, c, a) in &means {
-                let mut best = (DECODE_MATCH_KM, None);
+            let mut slot_beam = vec![0u8; slots.len()];
+            for &(b, c, a) in &means {
+                let mut bi = 0usize;
+                let mut bd = f64::INFINITY;
                 for (i, &(_, sc, sa)) in slots.iter().enumerate() {
-                    let d = ((c - sc).powi(2) + (a - sa).powi(2)).sqrt();
-                    if d < best.0 {
-                        best = (d, Some(i));
+                    let d = (c - sc).powi(2) + (a - sa).powi(2);
+                    if d < bd {
+                        bd = d;
+                        bi = i;
                     }
                 }
-                if let Some(i) = best.1 {
-                    matched[i] = true;
-                }
+                slot_beam[bi] = b;
             }
-            // Decoded beams: drawn solid at their measured positions, sized by
-            // the tier their distance-from-nadir falls in.
-            for &(beam, cross, along) in &means {
-                let (a_rad, b_az) = tier_axes(nearest_tier((cross * cross + along * along).sqrt()));
-                let active = t.seen_beams.get(&beam).is_some_and(|&ts| now - ts < ACTIVE_WINDOW_S);
-                let (lat, lon) = lat_lon(to_ecef(t.pos, cross, along, t.north));
-                out.push(Cell {
-                    sat,
-                    beam,
-                    lat: lat.to_degrees(),
-                    lon: lon.to_degrees(),
-                    radius_m: (a_rad + b_az) / 2.0 * 1000.0,
-                    poly: ellipse_poly(t.pos, t.north, cross, along, a_rad, b_az),
-                    active,
-                    decoded: true,
-                });
-            }
-            // Not-yet-decoded slots: every unmatched canonical slot, drawn
-            // faint so the full 48-beam pattern is visible.
             for (i, &(tier, sc, sa)) in slots.iter().enumerate() {
-                if matched[i] {
-                    continue;
-                }
+                let beam_id = slot_beam[i];
+                let decoded = beam_id != 0;
+                let active =
+                    decoded && t.seen_beams.get(&beam_id).is_some_and(|&ts| now - ts < ACTIVE_WINDOW_S);
                 let (a_rad, b_az) = tier_axes(tier);
                 let (lat, lon) = lat_lon(to_ecef(t.pos, sc, sa, t.north));
                 out.push(Cell {
                     sat,
-                    beam: 0,
+                    beam: beam_id,
                     lat: lat.to_degrees(),
                     lon: lon.to_degrees(),
                     radius_m: (a_rad + b_az) / 2.0 * 1000.0,
                     poly: ellipse_poly(t.pos, t.north, sc, sa, a_rad, b_az),
-                    active: false,
-                    decoded: false,
+                    active,
+                    decoded,
                 });
             }
         }
@@ -557,9 +532,11 @@ mod tests {
         assert_eq!(r.beams_known(), 1);
         let cells = r.project(t0 + 4.0, 60.0);
         let c = cells.iter().find(|c| c.beam == 12).expect("beam 12 projected");
-        // Re-projected under the same (still-current) satellite → original.
-        assert!((c.lat - 41.5).abs() < 0.1, "lat {}", c.lat);
-        assert!((c.lon - (-119.0)).abs() < 0.1, "lon {}", c.lon);
+        // Beam 12 snaps to its nearest canonical slot (the fit aligns that slot
+        // to the observation), so it lands near — not exactly on — the measured
+        // footprint, offset by the tier-radius snap.
+        assert!((c.lat - 41.5).abs() < 1.0, "lat {}", c.lat);
+        assert!((c.lon - (-119.0)).abs() < 1.0, "lon {}", c.lon);
     }
 
     #[test]
@@ -616,9 +593,8 @@ mod tests {
         r.observe(5, 16.0, ecef(41.2, -116.0, R_EARTH_KM), 20, t0 + 2.0);
         r.observe(5, 16.0, ecef(41.2, -116.0, R_EARTH_KM), 20, t0 + 3.0);
         let cells = r.project(t0 + 4.0, 60.0);
-        // 48-beam pattern: decoded beam frees its one nearest slot (48), or
-        // none if it's too far from any (49).
-        assert!((47..=49).contains(&cells.len()), "full pattern, got {}", cells.len());
+        // Exactly the 48-beam pattern (one cell per canonical slot).
+        assert_eq!(cells.len(), 48, "full 48-beam pattern");
         assert!(cells.iter().any(|c| c.decoded && c.beam == 20), "decoded beam is solid");
         assert!(cells.iter().any(|c| !c.decoded && c.beam == 0), "undecoded slots fill the rest");
         assert!(cells.iter().all(|c| c.poly.len() >= 8), "every beam has a footprint polygon");
@@ -688,7 +664,7 @@ mod tests {
         );
         for c in [inner, outer] {
             assert!(
-                (80_000.0..=450_000.0).contains(&c.radius_m),
+                (80_000.0..=600_000.0).contains(&c.radius_m),
                 "plausible footprint, got {}",
                 c.radius_m
             );

--- a/src/outputs/assets/dashboard.html
+++ b/src/outputs/assets/dashboard.html
@@ -148,9 +148,28 @@ const satMarkers = new Map();  // sat id -> {marker, trail}
 const ringMarkers = new Map(); // "sat-beam" -> coverage-cell L.circle
 const patternMarkers = new Map(); // "sat-beam" -> projected pattern cell
 const patternBySat = new Map(); // sat id -> [pattern cell markers] (for hover link)
+const cellByBeam = new Map(); // "sat-beam" -> decoded pattern cell marker (spot-beam link)
 const footprintMarkers = new Map(); // sat id -> full-footprint coverage disc
 const deviceMarkers = new Map(); // "lat,lon" -> terminal marker
 let pinnedSat = null; // satellite whose pattern stays highlighted (click)
+let spotLink = null; // "sat-beam" of a clicked spot beam, linked to its cell
+let linkLine = null; // connector polyline from a spot beam to its pattern cell
+
+// Link a clicked spot beam (a measured boresight point) to its beam in the
+// pattern: brighten that cell and draw a dotted connector to it. Re-run each
+// tick (the pattern cells are rebuilt) so the highlight + line persist.
+function renderLink() {
+  if (linkLine) { map.removeLayer(linkLine); linkLine = null; }
+  if (!spotLink) return;
+  const ring = ringMarkers.get(spotLink);
+  const cell = cellByBeam.get(spotLink);
+  if (!ring || !cell) return;
+  cell.setStyle({ weight: 3, opacity: 1, fillOpacity: 0.4 });
+  if (!map.hasLayer(patternLayer)) patternLayer.addTo(map);
+  const cc = cell.getBounds().getCenter();
+  linkLine = L.polyline([ring._ll, [cc.lat, cc.lng]],
+    { color: '#fff', weight: 1.5, opacity: 0.8, dashArray: '4 5', interactive: false }).addTo(map);
+}
 
 // Light up (or restore) a satellite's whole beam pattern — the visual link
 // between a satellite and the cells it projects.
@@ -279,13 +298,7 @@ const shipIcon = (cog, type) => {
     iconSize: [16, 16], iconAnchor: [8, 8], popupAnchor: [0, -10] });
 };
 const IRIDIUM = '#73daca';
-// Spot-beam coverage cell: an Iridium spot beam covers ~400 km of ground
-// (~200 km radius); the 48 beams tile the ~4700 km footprint, hue per beam
-// id (1–48) so the cells under a satellite read as a coloured tiling. Real
-// beams vary (smaller near nadir, larger at the edge), so a live ring
-// footprint prefers its reconstructed per-beam radius when the beam pattern
-// has resolved that beam; this nominal radius is the fallback.
-const BEAM_RADIUS_M = 200000;
+// Beam colour by id (1–48), so a satellite's beams read as a coloured tiling.
 const beamColor = b => `hsl(${((b || 0) * 360 / 48) | 0},70%,55%)`;
 const satIcon = () => L.divIcon({ className: '', html:
   `<div style="font-size:18px;line-height:18px;color:${IRIDIUM};text-shadow:0 0 4px #000">&#128752;</div>`,
@@ -405,41 +418,41 @@ function syncIridium(s) {
     if (fp) { patternLayer.removeLayer(fp); footprintMarkers.delete(k); }
   }
 
-  // Per-beam reconstructed radius (sat-beam → m) so a live spot-beam
-  // footprint is drawn at the same size as its reconstructed pattern cell,
-  // rather than a one-size-fits-all circle.
-  const cellRad = new Map();
-  for (const c of (s.iridium_beam_cells || [])) cellRad.set(c.sat + '-' + c.beam, c.radius_m);
+  // Spot beams: where a beam's boresight was just spotted illuminating the
+  // ground (the live ring-alert footprint centre). A ring-alert is a POINT
+  // measurement, so draw it as a labelled dot — the beam's coverage SHAPE is
+  // its cell in the beam pattern. Click a dot to highlight that beam in the
+  // pattern and draw a connector to it.
   const seenRing = new Set();
   for (const r of (s.iridium_rings || [])) {
     const key = r.sat + '-' + r.beam;
     seenRing.add(key);
     const col = beamColor(r.beam);
-    const rad = cellRad.get(key) || BEAM_RADIUS_M;
     const popup = entityPopup('', escapeHtml(`spot beam S${r.sat}/B${r.beam}`), [
       ['sat id', r.sat],
       ['beam', r.beam],
-      ['center', `${r.lat.toFixed(2)}, ${r.lon.toFixed(2)}`],
+      ['boresight', `${r.lat.toFixed(2)}, ${r.lon.toFixed(2)}`],
       ['seen', `${fmtAge(s.now - r.seen)} ago`],
+      ['', 'click to link to its beam in the pattern'],
     ]);
     let m = ringMarkers.get(key);
     if (!m) {
-      // The spot beam projected on the ground: a geographic coverage cell
-      // (scales with zoom), coloured by beam id, labelled at its center.
-      m = L.circle([r.lat, r.lon], { radius: rad, color: col, weight: 1, fillColor: col, fillOpacity: 0.08 }).addTo(ringLayer);
-      m.bindTooltip(`B${r.beam}`, { permanent: true, direction: 'center', className: 'lbl' });
+      m = L.circleMarker([r.lat, r.lon], { radius: 5, color: col, weight: 2, fillColor: col, fillOpacity: 0.6 }).addTo(ringLayer);
+      m.bindTooltip(`B${r.beam}`, { permanent: true, direction: 'right', offset: [6, 0], className: 'lbl' });
       m.bindPopup(popup, { offset: [0, -6] });
+      m.on('click', () => { spotLink = spotLink === key ? null : key; renderLink(); });
       ringMarkers.set(key, m);
     } else {
       m.setLatLng([r.lat, r.lon]);
-      m.setRadius(rad);
       m.setStyle({ color: col, fillColor: col });
       m.setPopupContent(popup);
     }
+    m._ll = [r.lat, r.lon];
   }
   for (const [k, m] of ringMarkers) if (!seenRing.has(k)) {
     ringLayer.removeLayer(m);
     ringMarkers.delete(k);
+    if (spotLink === k) spotLink = null;
   }
 
   // Beam pattern: the full 48-beam canonical pattern (4 concentric tiers)
@@ -450,6 +463,7 @@ function syncIridium(s) {
   // so the whole intended pattern shows plus exactly what's been heard.
   // Polygons are cheap, so rebuild them each tick rather than diff.
   patternBySat.clear();
+  cellByBeam.clear();
   for (const m of patternMarkers.values()) patternLayer.removeLayer(m);
   patternMarkers.clear();
   (s.iridium_beam_cells || []).forEach((c, i) => {
@@ -467,14 +481,16 @@ function syncIridium(s) {
       : `sat ${c.sat} · beam not yet decoded (modelled from the 48-beam pattern)`,
       { offset: [0, -4] });
     patternMarkers.set(c.sat + '-' + i, m);
-    // Only decoded beams join the hover/pin highlight.
+    // Only decoded beams join the hover/pin highlight + the spot-beam link.
     if (c.decoded) {
       if (!patternBySat.has(c.sat)) patternBySat.set(c.sat, []);
       patternBySat.get(c.sat).push(m);
+      cellByBeam.set(c.sat + '-' + c.beam, m);
     }
   });
-  // Re-apply a pinned satellite's highlight after the per-tick rebuild.
+  // Re-apply a pinned satellite's highlight + any spot-beam link after rebuild.
   if (pinnedSat !== null) highlightSatPattern(pinnedSat, true);
+  renderLink();
 
   // Iridium mobile terminals: customer devices that reported their own
   // position (the real device locations, vs the beam footprints above).


### PR DESCRIPTION
## Gaps (the cells still showed gaps)
Two causes, both fixed:
1. **Outer-corner gaps**: I sized each ellipse's azimuthal axis from the beam-*centre* radius, but the wedge cells are **wider at their outer edge**, so the corners where azimuthally-adjacent beams meet stayed uncovered. Now sized from the tier's **outer edge**.
2. **Scatter gaps**: decoded beams drawn at noisy *measured* positions broke the tiling. Now **every beam snaps to the canonical grid** (exactly 48 cells, one per slot) with overlap factor 1.5 → clean, gap-free tiling. The canonical model is the accurate layout; measured positions are noisy samples of it, so snapping is also *more* accurate — and it fixes the "50/48" overcount at the source (now always ≤ 48).

## Spot beams (answering your question)
You were right that spot beams = beams that were spotted and should relate to the pattern — with one refinement: a ring-alert is a **point** measurement (the beam's boresight ground position at a moment), not a coverage shape. So:
- Spot beams now draw as **labelled dots** (not mismatched circles); the beam's coverage **shape** is its cell in the beam pattern.
- **Click a spot-beam dot** → it highlights that beam in the pattern and draws a **dotted connector** to it, linking the measured point to its modelled cell.

## Verified
- 48-cell gap-free pattern; clicking spot beam B9 drew the connector + highlighted its cell (confirmed live).
- 10 `beam::` tests green; dashboard JS parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)