### PR TITLE
survey/auto-tune: fix RTL-SDR ADS-B center, device-aware rate, clean Ctrl-C

### DIFF
--- a/crates/xng-sdr/src/soapy.rs
+++ b/crates/xng-sdr/src/soapy.rs
@@ -29,6 +29,21 @@ pub fn enumerate(filter: &str) -> Result<Vec<DeviceSummary>, SdrError> {
         .collect())
 }
 
+/// Advertised RX sample-rate ranges for the device `args` selects, as
+/// `(min, max, step)` tuples in Hz (`step == 0.0` means the range is
+/// continuous — the common case for RTL-SDR/HackRF/SDRplay). Returns an empty
+/// vec when the device can't be opened or reports nothing, so callers fall
+/// back to the mode's plan rate. Opens the device briefly (no RX stream) and
+/// closes it on return.
+pub fn sample_rate_ranges(args: &str) -> Vec<(f64, f64, f64)> {
+    let Ok(dev) = soapysdr::Device::new(args) else {
+        return Vec::new();
+    };
+    dev.get_sample_rate_range(soapysdr::Direction::Rx, 0)
+        .map(|ranges| ranges.iter().map(|r| (r.minimum, r.maximum, r.step)).collect())
+        .unwrap_or_default()
+}
+
 /// A single-channel RX capture from a SoapySDR device.
 pub struct SoapyIqSource {
     stream: soapysdr::RxStream<Complex<f32>>,

--- a/src/commands/scan.rs
+++ b/src/commands/scan.rs
@@ -97,22 +97,83 @@ pub(crate) fn channel_rate(mode: Mode) -> f64 {
     }
 }
 
-/// Choose a capture rate the device can actually do: the smallest
-/// advertised rate that divides the mode's channel rate cleanly (CPU
-/// scales with rate). Falls back to the plan rate when nothing matches
-/// or nothing was probed.
-pub(crate) fn pick_auto_rate(advertised: &[u32], mode: Mode, plan_rate: f64) -> f64 {
+/// What an SDR can do for sample rate. Native backends (airspy/airspyhf)
+/// report an exact discrete set; SoapySDR devices (RTL-SDR, HackRF, SDRplay…)
+/// report inclusive ranges; `Unknown` when we couldn't ask — callers then
+/// trust the mode's plan rate.
+#[derive(Debug, Clone)]
+pub(crate) enum RateCaps {
+    Discrete(Vec<u32>),
+    /// `(min, max, step)` Hz; `step == 0.0` means continuous.
+    Ranges(Vec<(f64, f64, f64)>),
+    Unknown,
+}
+
+/// Pick a capture rate the device supports for `mode`, given what it can do.
+/// Prefers the mode's plan rate; otherwise the smallest supported rate that is
+/// **at least** the plan rate and (for DDC modes) a clean integer multiple of
+/// the per-channel rate. The "at least" floor keeps a device with a wide rate
+/// menu (e.g. RTL-SDR's 0.25–3.2 MS/s) from stranding a mode at a too-narrow
+/// capture. Falls back to the plan rate when nothing fits or support is
+/// unknown.
+pub(crate) fn choose_rate(caps: &RateCaps, mode: Mode, plan_rate: f64) -> f64 {
+    match caps {
+        RateCaps::Unknown => plan_rate,
+        RateCaps::Discrete(rates) => pick_auto_rate(rates, mode, plan_rate),
+        RateCaps::Ranges(ranges) => {
+            pick_auto_rate(&candidates_from_ranges(ranges, mode), mode, plan_rate)
+        }
+    }
+}
+
+/// Expand advertised rate ranges into discrete candidate rates aligned to the
+/// mode's per-channel rate (so every candidate is a clean DDC multiple).
+/// Whole-capture modes (channel rate 1.0: Mode S) have no DDC grid, so a
+/// coarse 250 kHz step is used just to enumerate sensible widths.
+fn candidates_from_ranges(ranges: &[(f64, f64, f64)], mode: Mode) -> Vec<u32> {
     let ch = channel_rate(mode);
-    let mut rates: Vec<u32> = advertised.to_vec();
-    rates.sort_unstable();
-    if rates.iter().any(|&r| r as f64 == plan_rate && (plan_rate / ch).fract().abs() < 1e-9) {
+    let unit = if ch > 1.0 { ch } else { 250_000.0 };
+    let mut out: Vec<u32> = Vec::new();
+    for &(lo, hi, _step) in ranges {
+        if hi < lo {
+            continue;
+        }
+        // First multiple of `unit` at or above the range floor, then step up.
+        let mut r = (lo / unit).ceil() * unit;
+        let mut n = 0;
+        while r <= hi + 1e-6 && n < 4096 {
+            out.push(r as u32);
+            r += unit;
+            n += 1;
+        }
+    }
+    out.sort_unstable();
+    out.dedup();
+    out
+}
+
+/// Choose a capture rate from a discrete advertised set (see [`choose_rate`]).
+pub(crate) fn pick_auto_rate(advertised: &[u32], mode: Mode, plan_rate: f64) -> f64 {
+    if advertised.is_empty() {
         return plan_rate;
     }
-    rates
-        .iter()
-        .map(|&r| r as f64)
-        .find(|r| (r / ch).fract().abs() < 1e-9)
-        .unwrap_or(plan_rate)
+    let ch = channel_rate(mode);
+    let divides = |r: f64| (r / ch).fract().abs() < 1e-9;
+    let mut rates: Vec<f64> = advertised.iter().map(|&r| r as f64).collect();
+    rates.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    // The plan rate is authoritative when the device offers it exactly.
+    if rates.iter().any(|&r| (r - plan_rate).abs() < 1e-9) {
+        return plan_rate;
+    }
+    // Smallest supported, clean-multiple rate at or above the plan rate —
+    // never narrower than the mode was designed for.
+    if let Some(&r) = rates.iter().find(|&&r| r >= plan_rate - 1e-9 && divides(r)) {
+        return r;
+    }
+    // Nothing clean at/above the plan: take the widest clean multiple offered
+    // (best effort), else the plan rate so the device surfaces a clear error
+    // rather than silently mis-tuning.
+    rates.iter().rev().copied().find(|&r| divides(r)).unwrap_or(plan_rate)
 }
 
 /// Cluster channels into capture-width groups.
@@ -137,8 +198,15 @@ pub(crate) fn group_channels(channels: &[u64], sample_rate: f64, passband: f64) 
         .into_iter()
         .map(|g| {
             let center = (g[0] + g[g.len() - 1]) / 2;
-            // Avoid a channel landing exactly at DC.
-            let center = if g.iter().any(|&c| c == center) { center + 25_000 } else { center };
+            // Avoid a channel landing exactly at DC — except whole-capture
+            // modes (passband 0: Mode S), whose core consumes the entire
+            // capture and requires the channel AT the center. A 25 kHz nudge
+            // there makes the offset non-zero and the decoder rejects it.
+            let center = if passband > 0.0 && g.iter().any(|&c| c == center) {
+                center + 25_000
+            } else {
+                center
+            };
             (center, g)
         })
         .collect()
@@ -206,19 +274,19 @@ pub fn run(
     let mut results: Vec<ChannelResult> = Vec::new();
     let mut groups_total = 0usize;
     let mut plans = Vec::new();
-    // Plan rates target common hardware (RTL-SDR); devices with a fixed
-    // rate list (Airspy) get the smallest advertised rate that divides
-    // the mode's channel rate.
-    let advertised = crate::probe_device_rates(sdr);
+    // Probe once: pick each mode's rate from what this device actually
+    // supports (Airspy's fixed list, a SoapySDR device's ranges), preferring
+    // the plan rate.
+    let caps = crate::probe_rate_caps(sdr);
     for &mode in modes {
         let (plan_rate, channels) = plan(mode);
         if channels.is_empty() {
             tracing::warn!("no built-in frequency plan for mode {mode}; skipping");
             continue;
         }
-        let rate = pick_auto_rate(&advertised, mode, plan_rate);
+        let rate = choose_rate(&caps, mode, plan_rate);
         if rate != plan_rate {
-            tracing::info!("{mode}: device prefers {} S/s over the plan's {} S/s", rate as u64, plan_rate as u64);
+            tracing::info!("{mode}: using {} S/s (device does not offer the plan's {} S/s)", rate as u64, plan_rate as u64);
         }
         let groups = group_channels(&channels, rate, passband(mode));
         groups_total += groups.len();
@@ -324,10 +392,15 @@ pub fn run(
         if active.is_empty() {
             continue;
         }
-        let rate = pick_auto_rate(&advertised, mode, plan(mode).0);
+        let rate = choose_rate(&caps, mode, plan(mode).0);
         let freqs: Vec<u64> = active.iter().map(|r| r.frequency_hz).collect();
         let center = (freqs.iter().min().unwrap() + freqs.iter().max().unwrap()) / 2;
-        let center = if freqs.contains(&center) { center + 25_000 } else { center };
+        // Whole-capture modes (passband 0) must keep the channel at center.
+        let center = if passband(mode) > 0.0 && freqs.contains(&center) {
+            center + 25_000
+        } else {
+            center
+        };
         let chans: Vec<String> =
             freqs.iter().map(|&f| format!("{:.3}", f as f64 / 1e6)).collect();
         proposals.push(format!(
@@ -459,8 +532,42 @@ mod tests {
         assert_eq!(pick_auto_rate(&[6_000_000, 3_000_000], Mode::AcarsPoa, 2_400_000.0), 3_000_000.0);
         // Device that advertises the plan rate keeps it.
         assert_eq!(pick_auto_rate(&[2_400_000], Mode::AcarsPoa, 2_400_000.0), 2_400_000.0);
-        // Nothing probed (SoapySDR path): plan rate.
+        // Nothing probed: plan rate.
         assert_eq!(pick_auto_rate(&[], Mode::AcarsPoa, 2_400_000.0), 2_400_000.0);
+    }
+
+    #[test]
+    fn choose_rate_from_rtl_ranges() {
+        // RTL-SDR advertises ~0.225–0.3 and ~0.9–3.2 MS/s (two continuous
+        // ranges with a gap), reported as ranges, not a discrete list.
+        let rtl = RateCaps::Ranges(vec![
+            (225_001.0, 300_000.0, 0.0),
+            (900_001.0, 3_200_000.0, 0.0),
+        ]);
+        // ADS-B (whole capture): plan 2.0 MS/s is in range → kept exactly so
+        // the channel stays at the capture center.
+        assert_eq!(choose_rate(&rtl, Mode::Adsb, 2_000_000.0), 2_000_000.0);
+        // ACARS: 2.4 MS/s is supported and a clean 24 kHz multiple → kept.
+        assert_eq!(choose_rate(&rtl, Mode::AcarsPoa, 2_400_000.0), 2_400_000.0);
+        // HFDL: plan 768 kS/s lands in the RTL gap; pick the smallest
+        // supported 12 kHz-multiple at or above it (never narrower).
+        let r = choose_rate(&rtl, Mode::Hfdl, 768_000.0);
+        assert!((r / 12_000.0).fract().abs() < 1e-9, "not a 12 kHz multiple: {r}");
+        assert!(r >= 900_001.0, "must land in the supported high range: {r}");
+    }
+
+    #[test]
+    fn choose_rate_unknown_keeps_plan() {
+        assert_eq!(choose_rate(&RateCaps::Unknown, Mode::AcarsPoa, 2_400_000.0), 2_400_000.0);
+    }
+
+    #[test]
+    fn choose_rate_floor_avoids_too_narrow_capture() {
+        // A device that also offers sub-plan rates must not strand the mode
+        // at a too-narrow capture just because the small rate "fits".
+        let caps = RateCaps::Discrete(vec![250_000, 1_000_000, 2_000_000, 2_400_000]);
+        assert_eq!(choose_rate(&caps, Mode::Adsb, 2_000_000.0), 2_000_000.0);
+        assert_eq!(choose_rate(&caps, Mode::AcarsPoa, 2_400_000.0), 2_400_000.0);
     }
 
     #[test]
@@ -483,8 +590,21 @@ mod tests {
     fn auto_window_handles_single_channel_modes() {
         let (center, chans) = auto_window(Mode::Adsb, 2_000_000.0, 8).unwrap();
         assert_eq!(chans, vec![1_090_000_000]);
-        // Center is nudged off the channel to keep it away from DC.
-        assert_ne!(center, 1_090_000_000);
+        // Mode S consumes the whole capture: the channel must sit AT the
+        // center (a DC nudge would make the offset non-zero and the core
+        // rejects it — "Mode S uses the whole capture").
+        assert_eq!(center, 1_090_000_000);
+    }
+
+    #[test]
+    fn group_channels_keeps_whole_capture_channel_at_center() {
+        // ADS-B (passband 0): the single 1090 MHz channel must land exactly
+        // at the capture center, not nudged 25 kHz off DC.
+        let groups = group_channels(&[1_090_000_000], 2_000_000.0, passband(Mode::Adsb));
+        assert_eq!(groups, vec![(1_090_000_000, vec![1_090_000_000])]);
+        // A DDC mode whose only channel is the midpoint still nudges off DC.
+        let groups = group_channels(&[131_550_000], 2_400_000.0, passband(Mode::AcarsPoa));
+        assert_eq!(groups[0].0, 131_575_000);
     }
 
     #[test]

--- a/src/commands/survey.rs
+++ b/src/commands/survey.rs
@@ -91,27 +91,38 @@ pub fn run(opts: SurveyOpts) -> anyhow::Result<()> {
     let rate = match opts.sample_rate {
         Some(r) => r,
         None => {
-            let advertised = crate::probe_device_rates(&opts.sdr);
-            let r = scan::pick_auto_rate(&advertised, mode, plan_rate);
+            let caps = crate::probe_rate_caps(&opts.sdr);
+            let r = scan::choose_rate(&caps, mode, plan_rate);
             if r != plan_rate {
-                println!("device prefers {} S/s over the plan's {} S/s", r as u64, plan_rate as u64);
+                println!("using {} S/s (device does not offer the plan's {} S/s)", r as u64, plan_rate as u64);
             }
             r
         }
     };
     let passband = scan::passband(mode);
 
-    // Ctrl-C ends the survey early but still produces the report.
+    // Ctrl-C ends the survey early but still produces the report. A second
+    // Ctrl-C forces an immediate exit: if a device open or stream read is
+    // wedged and never observes `abort`, the first signal can't get us out,
+    // and tokio swallows further signals once nothing is awaiting them — so
+    // we keep awaiting and hard-exit on the second.
     let abort = Arc::new(AtomicBool::new(false));
     {
         let abort = abort.clone();
         std::thread::spawn(move || {
-            let rt = tokio::runtime::Builder::new_current_thread().enable_io().build();
-            if let Ok(rt) = rt {
-                let _ = rt.block_on(tokio::signal::ctrl_c());
-                eprintln!("\ninterrupted — finishing up and reporting");
-                abort.store(true, Ordering::Relaxed);
-            }
+            let Ok(rt) = tokio::runtime::Builder::new_current_thread().enable_io().build() else {
+                return;
+            };
+            rt.block_on(async move {
+                if tokio::signal::ctrl_c().await.is_ok() {
+                    eprintln!("\ninterrupted — finishing up and reporting (Ctrl-C again to quit now)");
+                    abort.store(true, Ordering::Relaxed);
+                }
+                if tokio::signal::ctrl_c().await.is_ok() {
+                    eprintln!("\nforced quit");
+                    std::process::exit(130);
+                }
+            });
         });
     }
 
@@ -650,7 +661,12 @@ fn proposal_command(
         return None;
     }
     let center = (active.iter().min().unwrap() + active.iter().max().unwrap()) / 2;
-    let center = if active.contains(&center) { center + 25_000 } else { center };
+    // Whole-capture modes (passband 0: Mode S) keep the channel at center.
+    let center = if scan::passband(mode) > 0.0 && active.contains(&center) {
+        center + 25_000
+    } else {
+        center
+    };
     let chans: Vec<String> = active.iter().map(|&f| format!("{:.3}", f as f64 / 1e6)).collect();
     let gain_arg = gain.map(|g| format!(" --gain {g}")).unwrap_or_default();
     Some(format!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -457,11 +457,11 @@ fn resolve_tune_auto(
     let rate = match tune.sample_rate {
         Some(r) => r,
         None => {
-            let advertised = probe_device_rates(sdr);
-            let r = commands::scan::pick_auto_rate(&advertised, mode, plan_rate);
+            let caps = probe_rate_caps(sdr);
+            let r = commands::scan::choose_rate(&caps, mode, plan_rate);
             if r != plan_rate {
                 tracing::info!(
-                    "auto-tune: device prefers {} S/s over the plan's {} S/s",
+                    "auto-tune: using {} S/s (device does not offer the plan's {} S/s)",
                     r as u64,
                     plan_rate as u64
                 );
@@ -479,7 +479,7 @@ fn resolve_tune_auto(
             .collect::<anyhow::Result<Vec<u64>>>()?;
         let center = match &tune.center_freq {
             Some(c) => freq::parse_hz(c)?,
-            None => centroid_off_dc(&channels),
+            None => centroid_off_dc(&channels, commands::scan::passband(mode) > 0.0),
         };
         return Ok((mode, rate, center, channels));
     }
@@ -518,31 +518,50 @@ fn resolve_tune_auto(
     Ok((mode, rate, center, channels))
 }
 
-/// Advertised sample rates of the device `--sdr` selects, where a native
-/// backend can ask (empty when it can't — SoapySDR devices generally
-/// accept the plan rates).
-pub(crate) fn probe_device_rates(sdr: &str) -> Vec<u32> {
+/// Probe what sample rates the device `--sdr` selects can do. Native backends
+/// report an exact discrete set; SoapySDR devices (RTL-SDR, HackRF, SDRplay…)
+/// report advertised ranges; otherwise [`RateCaps::Unknown`] so callers fall
+/// back to the mode's plan rate.
+pub(crate) fn probe_rate_caps(sdr: &str) -> commands::scan::RateCaps {
+    use commands::scan::RateCaps;
     let args = sdr_args::SdrArgs::parse(sdr);
-    if args.force_soapy {
-        return Vec::new();
-    }
     let serial = || args.serial.as_deref().and_then(|s| sdr_args::parse_airspy_serial(s).ok());
     let _ = &serial; // used only by the cfg'd arms below
-    match args.driver.as_deref() {
-        #[cfg(feature = "airspy")]
-        Some("airspy") => xng_sdr::airspy::device_rates(serial()).unwrap_or_default(),
-        #[cfg(feature = "airspyhf")]
-        Some("airspyhf") => xng_sdr::airspyhf::device_rates(serial()).unwrap_or_default(),
-        _ => Vec::new(),
+    if !args.force_soapy {
+        match args.driver.as_deref() {
+            #[cfg(feature = "airspy")]
+            Some("airspy") => {
+                if let Ok(r) = xng_sdr::airspy::device_rates(serial()) {
+                    return RateCaps::Discrete(r);
+                }
+            }
+            #[cfg(feature = "airspyhf")]
+            Some("airspyhf") => {
+                if let Ok(r) = xng_sdr::airspyhf::device_rates(serial()) {
+                    return RateCaps::Discrete(r);
+                }
+            }
+            _ => {}
+        }
     }
+    #[cfg(feature = "soapy")]
+    {
+        let ranges = xng_sdr::soapy::sample_rate_ranges(&args.soapy);
+        if !ranges.is_empty() {
+            return RateCaps::Ranges(ranges);
+        }
+    }
+    RateCaps::Unknown
 }
 
-/// Midpoint of a channel set, nudged off any exact channel so no carrier
-/// sits at DC.
-fn centroid_off_dc(channels: &[u64]) -> u64 {
+/// Midpoint of a channel set. For DDC modes (`avoid_dc`) the midpoint is
+/// nudged off any exact channel so no carrier sits at DC; whole-capture
+/// modes (Mode S) require the channel AT the center, so they pass
+/// `avoid_dc = false`.
+fn centroid_off_dc(channels: &[u64], avoid_dc: bool) -> u64 {
     let center =
         (channels.iter().min().unwrap() + channels.iter().max().unwrap()) / 2;
-    if channels.contains(&center) { center + 25_000 } else { center }
+    if avoid_dc && channels.contains(&center) { center + 25_000 } else { center }
 }
 
 fn main() -> anyhow::Result<()> {

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -496,6 +496,22 @@ async fn shutdown_signal() {
     }
 }
 
+/// Spawn the interrupt handler: the first signal sets `stop` for a graceful
+/// drain (sources close cleanly so the device isn't left wedged); a second
+/// signal forces an immediate exit. The escape hatch matters when the decode
+/// loop is blocked in a device read that never observes `stop` — without it a
+/// wedged SDR traps the process until SIGKILL/SIGQUIT.
+fn spawn_interrupt_handler(stop: Arc<AtomicBool>, what: &'static str) {
+    tokio::spawn(async move {
+        shutdown_signal().await;
+        tracing::info!("interrupt received, stopping {what} (signal again to force quit)");
+        stop.store(true, Ordering::Relaxed);
+        shutdown_signal().await;
+        eprintln!("forced quit");
+        std::process::exit(130);
+    });
+}
+
 /// Run a decode session until the source ends or `stop` is set.
 pub fn run_session(mut source: Box<dyn IqSource>, cfg: SessionConfig) -> anyhow::Result<()> {
     let sample_rate = source.sample_rate();
@@ -548,15 +564,8 @@ pub fn run_session(mut source: Box<dyn IqSource>, cfg: SessionConfig) -> anyhow:
             vec![session_descriptor(&cfg.sdr, cfg.mode, capture_center, &cfg.channels_hz, sample_rate)];
         let output_tasks = spawn_outputs(&bus, &cfg.outputs, &station, &desc);
 
-        // Ctrl-C → graceful stop.
-        tokio::spawn({
-            let stop = stop.clone();
-            async move {
-                shutdown_signal().await;
-                tracing::info!("interrupt received, stopping session");
-                stop.store(true, Ordering::Relaxed);
-            }
-        });
+        // Ctrl-C / SIGTERM → graceful stop, second signal forces quit.
+        spawn_interrupt_handler(stop.clone(), "session");
 
         // DSP loop on a blocking thread.
         let decode = tokio::task::spawn_blocking({
@@ -795,14 +804,7 @@ pub fn run_station(sessions: Vec<(Box<dyn IqSource>, SessionConfig)>) -> anyhow:
         }
         let output_tasks = spawn_outputs(&bus, &prepared[0].cfg.outputs, &station, &sessions_desc);
 
-        tokio::spawn({
-            let stop = stop.clone();
-            async move {
-                shutdown_signal().await;
-                tracing::info!("interrupt received, stopping station");
-                stop.store(true, Ordering::Relaxed);
-            }
-        });
+        spawn_interrupt_handler(stop.clone(), "station");
 
         let mut decode_tasks = Vec::new();
         for mut prep in prepared {


### PR DESCRIPTION
Three issues a colleague (Fritz) hit running on Linux with an RTL-SDR:

```
xng survey --sdr driver=rtlsdr --mode adsb --tune-gain --duration 120 --interim 30
...
   12.0 dB: failed (channel 1090.000 MHz: Mode S uses the whole capture: tune -c to 1090.000M and pass --channels 1090)
^C^C^C^C^\Quit (core dumped)
```

## A) ADS-B survey gain sweep fails (`Mode S uses the whole capture`)
The capture center was nudged +25 kHz off DC (→ `1090.025 MHz`) to keep carriers away from the DC spike. But Mode S consumes the **whole** capture and requires the channel to sit **at** the center (offset 0), so the decoder rejected every dwell.

The DC-avoidance nudge now applies only to **DDC modes** (`passband > 0`); whole-capture modes (Mode S) keep the channel at center. Fixed at all four nudge sites: `group_channels`, the `scan` and `survey` proposal builders, and `resolve_tune_auto`'s centroid. The test that *asserted* the buggy nudge (`auto_window_handles_single_channel_modes`) is corrected, and a new `group_channels` test pins the behavior.

## B) Ctrl-C didn't stop the run (needed SIGQUIT → core dump)
The first `^C` printed "finishing up" and set the abort flag, but tokio then swallowed every further signal (nothing was awaiting them), so a wedged/looping device trapped the process until `^\` (SIGQUIT) killed it with a core dump.

The interrupt handler is now **two-stage** everywhere — survey, `listen`/`run_session`, and `station`: the first signal drains gracefully (sources close cleanly), a second forces `process::exit(130)`. This is the escape hatch when the decode loop is blocked in a device read that never observes the stop flag.

## C) Auto rate selection never checked device support
`probe_device_rates` returned an empty list for **every** SoapySDR device (RTL-SDR/HackRF/SDRplay), so auto-tune fell back to the mode plan rate blind. That happened to work for ADS-B/ACARS on RTL but not for e.g. HFDL's 768 kS/s, which lands in RTL-SDR's unsupported rate gap.

Now `probe_rate_caps` reports a `RateCaps` enum:
- **Discrete** — native airspy/airspyhf exact list (unchanged)
- **Ranges** — SoapySDR `getSampleRateRange()` (min/max/step)
- **Unknown** — can't ask → trust the plan rate

`choose_rate` picks the smallest **supported** rate `>=` the mode's plan rate that is a clean DDC multiple (for DDC modes), so it never strands a mode at a too-narrow capture. New tests cover RTL-like ranges (keeps 2.0 MS/s for ADS-B, 2.4 for ACARS, climbs out of the gap for HFDL).

## Testing
- Full workspace test suite green (`cargo test --workspace --features airspy,airspyhf`).
- New unit tests: `group_channels_keeps_whole_capture_channel_at_center`, `choose_rate_from_rtl_ranges`, `choose_rate_unknown_keeps_plan`, `choose_rate_floor_avoids_too_narrow_capture`, plus the corrected `auto_window_handles_single_channel_modes`.
- Release build clean (`--features airspy,airspyhf`).
- Hardware: the running Airspy Iridium station uses an explicit-rate config (no auto-probe), so it's unaffected. Fritz can re-run the exact RTL command to confirm A/B/C end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)