### PR TITLE
dsp: resample any capture rate to any channel rate (full multi-mode on Airspy R2)

### DIFF
--- a/crates/xng-dsp/src/ddc.rs
+++ b/crates/xng-dsp/src/ddc.rs
@@ -4,6 +4,7 @@
 
 use crate::fir::{lowpass_taps, Fir};
 use crate::nco::Nco;
+use crate::resample::Resampler;
 use crate::IqSample;
 
 /// Required stopband attenuation drives taps ≈ 5.5 / normalized transition
@@ -14,15 +15,23 @@ const MAX_TAPS: usize = 8192;
 pub struct Ddc {
     nco: Nco,
     stages: Vec<Fir>,
+    /// Present when the capture rate is not an integer multiple of the output
+    /// rate: the FIR stages decimate to just above the output rate and this
+    /// corrects the leftover fraction to land exactly on it.
+    resampler: Option<Resampler>,
     /// Mixed copy of the input (the caller's buffer is left untouched so
     /// several channels can share one capture block).
     scratch: Vec<IqSample>,
     /// Intermediate buffer between stages (reused across calls).
     inter: Vec<IqSample>,
+    /// FIR-stage output, fed to the resampler (reused across calls).
+    decimated: Vec<IqSample>,
 }
 
 impl Ddc {
-    /// * `input_rate` / `output_rate` — must divide to an integer factor.
+    /// * `input_rate` / `output_rate` — any ratio ≥ 1. A non-integer ratio is
+    ///   handled by decimating to just above `output_rate` and resampling the
+    ///   leftover fraction, so any SDR sample rate feeds any channel rate.
     /// * `freq_offset_hz` — channel center relative to the capture center.
     /// * `passband_hz` — one-sided width of the signal to preserve.
     pub fn new(
@@ -32,10 +41,13 @@ impl Ddc {
         passband_hz: f64,
     ) -> Result<Self, String> {
         let ratio = input_rate / output_rate;
-        let decim = ratio.round() as usize;
-        if decim == 0 || (ratio - decim as f64).abs() > 1e-6 {
+        // Integer-decimate by the floor of the ratio (never below the output
+        // rate), then resample the remainder. An exact integer ratio leaves no
+        // remainder and skips the resampler entirely (unchanged fast path).
+        let decim = ratio.floor() as usize;
+        if decim == 0 {
             return Err(format!(
-                "input rate {input_rate} is not an integer multiple of output rate {output_rate}"
+                "input rate {input_rate} is below output rate {output_rate}"
             ));
         }
         if output_rate < 2.0 * passband_hz {
@@ -43,6 +55,13 @@ impl Ddc {
                 "output rate {output_rate} cannot carry a ±{passband_hz} Hz passband"
             ));
         }
+        // Rate after integer decimation; equals output_rate for integer ratios.
+        let inter_rate = input_rate / decim as f64;
+        let resampler = if (inter_rate - output_rate).abs() > 1e-6 {
+            Some(Resampler::new(inter_rate, output_rate))
+        } else {
+            None
+        };
 
         // Split a large decimation into two stages: a cheap coarse stage and
         // a sharp final stage at the low rate.
@@ -81,25 +100,41 @@ impl Ddc {
         Ok(Self {
             nco: Nco::new(freq_offset_hz, input_rate),
             stages,
+            resampler,
             scratch: Vec::new(),
             inter: Vec::new(),
+            decimated: Vec::new(),
         })
     }
 
-    /// Mix + filter + decimate `input`, appending baseband output to `out`.
+    /// Mix + filter + decimate `input` (resampling to the exact output rate
+    /// when needed), appending baseband output to `out`.
     pub fn process(&mut self, input: &[IqSample], out: &mut Vec<IqSample>) {
         self.scratch.clear();
         self.scratch.extend_from_slice(input);
         self.nco.mix(&mut self.scratch);
+
+        // Integer-decimate through the FIR stage(s). With no resampler the
+        // output rate is already exact, so write straight to `out`.
+        let sink = if self.resampler.is_some() {
+            self.decimated.clear();
+            &mut self.decimated
+        } else {
+            &mut *out
+        };
         match self.stages.len() {
-            1 => self.stages[0].process(&self.scratch, out),
+            1 => self.stages[0].process(&self.scratch, sink),
             _ => {
                 // Two stages is the max produced by `new`.
                 self.inter.clear();
                 let (first, rest) = self.stages.split_at_mut(1);
                 first[0].process(&self.scratch, &mut self.inter);
-                rest[0].process(&self.inter, out);
+                rest[0].process(&self.inter, sink);
             }
+        }
+
+        if let Some(rs) = &mut self.resampler {
+            rs.process(&self.decimated, out);
         }
     }
 }
@@ -153,7 +188,43 @@ mod tests {
     }
 
     #[test]
-    fn rejects_non_integer_ratio() {
-        assert!(Ddc::new(2_048_000.0, 24_000.0, 0.0, 5_000.0).is_err());
+    fn resamples_non_integer_ratio() {
+        // 2.048 MS/s is not an integer multiple of 24 kHz (ratio 85.33): the
+        // DDC now decimates by 85 and resamples the remainder to land exactly
+        // on 24 kHz, instead of rejecting the rate.
+        let fs = 2_048_000.0;
+        let out_rate = 24_000.0;
+        let mut ddc = Ddc::new(fs, out_rate, 0.0, 5_000.0).unwrap();
+        let input = vec![IqSample::new(0.0, 0.0); 2_048_000];
+        let mut out = Vec::new();
+        ddc.process(&input, &mut out);
+        // ~1 s of capture → ~24000 output samples (within edge effects).
+        assert!((out.len() as i64 - 24_000).abs() <= 4, "got {}", out.len());
+    }
+
+    #[test]
+    fn resamples_in_channel_tone_at_non_integer_ratio() {
+        // Airspy R2 case: extract a 24 kHz ACARS channel from 2.5 MS/s, which
+        // 24 kHz does not divide. The in-channel tone must survive at unit
+        // gain; an adjacent channel must still be rejected.
+        let fs = 2_500_000.0;
+        let out_rate = 24_000.0;
+        let offset = 50_000.0;
+
+        let mut ddc = Ddc::new(fs, out_rate, offset, 5_000.0).unwrap();
+        let input = tone(offset + 1_000.0, fs, 2_500_000);
+        let mut out = Vec::new();
+        ddc.process(&input, &mut out);
+        let settled = &out[out.len() / 2..];
+        let amp = settled.iter().map(|s| s.norm()).sum::<f32>() / settled.len() as f32;
+        assert!((amp - 1.0).abs() < 0.05, "in-channel gain should be ~1, got {amp}");
+
+        let mut ddc = Ddc::new(fs, out_rate, offset, 5_000.0).unwrap();
+        let input = tone(offset + 50_000.0, fs, 2_500_000);
+        let mut out = Vec::new();
+        ddc.process(&input, &mut out);
+        let settled = &out[out.len() / 2..];
+        let amp = settled.iter().map(|s| s.norm()).sum::<f32>() / settled.len() as f32;
+        assert!(amp < 0.02, "adjacent channel should be rejected, got {amp}");
     }
 }

--- a/crates/xng-dsp/src/lib.rs
+++ b/crates/xng-dsp/src/lib.rs
@@ -9,6 +9,7 @@ pub mod checksum;
 pub mod ddc;
 pub mod fir;
 pub mod nco;
+pub mod resample;
 pub mod rs;
 pub mod scramble;
 pub mod viterbi;
@@ -18,5 +19,6 @@ pub use channelizer::PfbChannelizer;
 pub use ddc::Ddc;
 pub use fir::{lowpass_taps, Fir};
 pub use nco::Nco;
+pub use resample::Resampler;
 
 pub type IqSample = num_complex::Complex<f32>;

--- a/crates/xng-dsp/src/resample.rs
+++ b/crates/xng-dsp/src/resample.rs
@@ -1,0 +1,139 @@
+//! Arbitrary-ratio resampler (4-point Catmull-Rom interpolation).
+//!
+//! The [`Ddc`](crate::Ddc) integer-decimates a wideband capture down to just
+//! above the target channel rate, then this stage corrects the small leftover
+//! fraction to land on the exact channel rate. That makes any SDR sample rate
+//! usable for any mode — e.g. an Airspy R2 (10 / 2.5 MS/s only) can feed the
+//! 24 kHz ACARS or 48 kHz AIS channelizers, whose rates divide neither.
+//!
+//! Because the input is already band-limited to the channel passband and the
+//! resample ratio is near unity (the integer stage does the heavy lifting),
+//! cubic interpolation is well below the demodulators' noise floor. Integer
+//! ratios skip this stage entirely.
+
+use crate::IqSample;
+
+/// Pull-based fractional resampler. Holds the few input samples straddling a
+/// block boundary plus the running fractional read position, so a stream fed
+/// in arbitrary-sized blocks resamples seamlessly.
+pub struct Resampler {
+    /// Input samples consumed per output sample (`in_rate / out_rate`).
+    step: f64,
+    /// Read position of the next output sample, in samples from the start of
+    /// `carry`. Kept in `[1, 2)` between calls so index `i-1` always exists.
+    pos: f64,
+    /// Tail of the previous block needed for continuity (the 4-point kernel
+    /// reaches one sample back and two forward).
+    carry: Vec<IqSample>,
+}
+
+impl Resampler {
+    /// Resample from `in_rate` to `out_rate` (both Hz, `in_rate >= out_rate`
+    /// in practice, though any positive ratio works).
+    pub fn new(in_rate: f64, out_rate: f64) -> Self {
+        Self { step: in_rate / out_rate, pos: 1.0, carry: Vec::new() }
+    }
+
+    /// Resample `input`, appending output samples to `out`.
+    pub fn process(&mut self, input: &[IqSample], out: &mut Vec<IqSample>) {
+        // Work on the carried tail followed by the new block.
+        let mut buf = std::mem::take(&mut self.carry);
+        buf.extend_from_slice(input);
+        let n = buf.len();
+        // Need indices i-1 .. i+2, with i = floor(pos): require pos < n-2.
+        if n < 4 {
+            self.carry = buf;
+            return;
+        }
+        let mut pos = self.pos;
+        while pos < (n - 2) as f64 {
+            let i = pos.floor() as usize;
+            let mu = (pos - i as f64) as f32;
+            out.push(cubic(buf[i - 1], buf[i], buf[i + 1], buf[i + 2], mu));
+            pos += self.step;
+        }
+        // Retain from one sample before the next read position so the kernel's
+        // `i-1` tap survives into the next call; rebase `pos` onto the carry.
+        let keep_from = (pos.floor() as usize).saturating_sub(1).min(n);
+        self.carry = buf.split_off(keep_from);
+        self.pos = pos - keep_from as f64;
+    }
+}
+
+/// 4-point Catmull-Rom interpolation at fractional offset `mu` in `[0, 1)`
+/// between `y0` and `y1` (with `ym1`/`y2` as the outer control points).
+#[inline]
+fn cubic(ym1: IqSample, y0: IqSample, y1: IqSample, y2: IqSample, mu: f32) -> IqSample {
+    let mu2 = mu * mu;
+    let mu3 = mu2 * mu;
+    let c_m1 = -0.5 * mu + mu2 - 0.5 * mu3;
+    let c_0 = 1.0 - 2.5 * mu2 + 1.5 * mu3;
+    let c_1 = 0.5 * mu + 2.0 * mu2 - 1.5 * mu3;
+    let c_2 = -0.5 * mu2 + 0.5 * mu3;
+    ym1.scale(c_m1) + y0.scale(c_0) + y1.scale(c_1) + y2.scale(c_2)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::f64::consts::TAU;
+
+    fn tone(freq: f64, fs: f64, n: usize) -> Vec<IqSample> {
+        (0..n)
+            .map(|i| {
+                let ph = TAU * freq * i as f64 / fs;
+                IqSample::new(ph.cos() as f32, ph.sin() as f32)
+            })
+            .collect()
+    }
+
+    #[test]
+    fn kernel_hits_control_points() {
+        let (a, b, c, d) = (
+            IqSample::new(1.0, 0.0),
+            IqSample::new(2.0, 0.0),
+            IqSample::new(3.0, 0.0),
+            IqSample::new(4.0, 0.0),
+        );
+        // mu = 0 → y0, mu → 1 → y1.
+        assert!((cubic(a, b, c, d, 0.0) - b).norm() < 1e-6);
+        assert!((cubic(a, b, c, d, 1.0) - c).norm() < 1e-6);
+        // A straight line stays linear at the midpoint.
+        assert!((cubic(a, b, c, d, 0.5) - IqSample::new(2.5, 0.0)).norm() < 1e-6);
+    }
+
+    #[test]
+    fn output_rate_is_exact() {
+        // 24038.46.. → 24000 (the ACARS leftover after decimating 2.5 MS/s).
+        let mut rs = Resampler::new(2_500_000.0 / 104.0, 24_000.0);
+        let mut out = Vec::new();
+        // Feed ~1 s of input in uneven blocks; expect ~24000 output samples.
+        let input = tone(1_000.0, 2_500_000.0 / 104.0, 24_038);
+        for chunk in input.chunks(257) {
+            rs.process(chunk, &mut out);
+        }
+        // Within a couple of samples of the ideal 24000 (edge effects).
+        assert!((out.len() as i64 - 24_000).abs() <= 3, "got {}", out.len());
+    }
+
+    #[test]
+    fn preserves_an_in_band_tone() {
+        // A 1 kHz tone resampled near unity keeps its frequency and amplitude.
+        let in_rate = 24_038.0;
+        let out_rate = 24_000.0;
+        let mut rs = Resampler::new(in_rate, out_rate);
+        let input = tone(1_000.0, in_rate, 48_000);
+        let mut out = Vec::new();
+        for chunk in input.chunks(512) {
+            rs.process(chunk, &mut out);
+        }
+        let settled = &out[out.len() / 4..out.len() * 3 / 4];
+        let amp = settled.iter().map(|s| s.norm()).sum::<f32>() / settled.len() as f32;
+        assert!((amp - 1.0).abs() < 0.02, "amplitude drifted: {amp}");
+        // Frequency check: the phase should advance by 2π·1000/24000 per output.
+        let expected_dphi = (TAU * 1_000.0 / out_rate) as f32;
+        let mid = out.len() / 2;
+        let dphi = (out[mid + 1] * out[mid].conj()).arg();
+        assert!((dphi - expected_dphi).abs() < 1e-3, "freq drifted: {dphi} vs {expected_dphi}");
+    }
+}

--- a/crates/xng-mode-acars/src/lib.rs
+++ b/crates/xng-mode-acars/src/lib.rs
@@ -33,7 +33,9 @@ pub struct AcarsChannelDecoder {
 }
 
 impl AcarsChannelDecoder {
-    /// `input_rate` must be an integer multiple of 24 kHz (e.g. 2.4 MS/s).
+    /// `input_rate` is any capture rate ≥ the 24 kHz channel rate; a
+    /// non-integer multiple (e.g. an Airspy's 2.5 MS/s) is resampled by the DDC
+    /// (an integer multiple like 2.4 MS/s skips the resampler).
     /// `freq_offset_hz` is the channel center relative to the capture center.
     pub fn new(input_rate: f64, freq_offset_hz: f64) -> Result<Self, String> {
         let ddc = if (input_rate - CHANNEL_RATE).abs() < 1e-6 && freq_offset_hz.abs() < 1e-6 {

--- a/crates/xng-mode-ais/src/lib.rs
+++ b/crates/xng-mode-ais/src/lib.rs
@@ -53,7 +53,9 @@ pub struct AisChannelDecoder {
 }
 
 impl AisChannelDecoder {
-    /// `input_rate` must be an integer multiple of 48 kHz (e.g. 2.4 MS/s).
+    /// `input_rate` is any capture rate ≥ the 48 kHz channel rate; a
+    /// non-integer multiple (e.g. an Airspy's 2.5 MS/s) is resampled by the
+    /// DDC (an integer multiple like 2.4 MS/s skips the resampler).
     /// `freq_offset_hz` is the channel center relative to the capture
     /// center; `frequency_hz` the absolute channel frequency (for the
     /// NMEA channel designator).

--- a/crates/xng-mode-iridium/src/lib.rs
+++ b/crates/xng-mode-iridium/src/lib.rs
@@ -250,7 +250,8 @@ pub struct IridiumWidebandDecoder {
 }
 
 impl IridiumWidebandDecoder {
-    /// `input_rate` must be an integer multiple of 250 kHz.
+    /// `input_rate` is the wideband capture rate; per sub-channel DDCs resample
+    /// to the 250 kHz channel rate when it is not an integer divisor.
     pub fn new(input_rate: f64) -> Result<Self, String> {
         Ok(Self {
             wb: wideband::IridiumWideband::new(input_rate)?,

--- a/src/commands/scan.rs
+++ b/src/commands/scan.rs
@@ -127,9 +127,11 @@ pub(crate) fn choose_rate(caps: &RateCaps, mode: Mode, plan_rate: f64) -> f64 {
 }
 
 /// Expand advertised rate ranges into discrete candidate rates aligned to the
-/// mode's per-channel rate (so every candidate is a clean DDC multiple).
-/// Whole-capture modes (channel rate 1.0: Mode S) have no DDC grid, so a
-/// coarse 250 kHz step is used just to enumerate sensible widths.
+/// mode's per-channel rate (so each is a clean DDC multiple needing no
+/// resampling). Whole-capture modes (channel rate 1.0: Mode S) have no DDC
+/// grid, so a coarse 250 kHz step enumerates sensible widths. The range
+/// endpoints are added too: if a (narrow or discrete-point) device offers no
+/// aligned rate, the DDC can still resample from an endpoint.
 fn candidates_from_ranges(ranges: &[(f64, f64, f64)], mode: Mode) -> Vec<u32> {
     let ch = channel_rate(mode);
     let unit = if ch > 1.0 { ch } else { 250_000.0 };
@@ -146,6 +148,10 @@ fn candidates_from_ranges(ranges: &[(f64, f64, f64)], mode: Mode) -> Vec<u32> {
             r += unit;
             n += 1;
         }
+        // Endpoints as resampling fallbacks (also captures min==max discrete
+        // points some SoapySDR drivers report as zero-width ranges).
+        out.push(lo.round() as u32);
+        out.push(hi.round() as u32);
     }
     out.sort_unstable();
     out.dedup();
@@ -195,15 +201,28 @@ pub(crate) fn pick_auto_rate(advertised: &[u32], mode: Mode, plan_rate: f64) -> 
             return r;
         }
     }
-    // Smallest supported, clean-multiple rate at or above the plan rate —
-    // never narrower than the mode was designed for.
+    // Prefer a clean integer-ratio rate at or above the plan: the DDC
+    // integer-decimates, no resampling, and never narrower than the mode needs.
     if let Some(&r) = rates.iter().find(|&&r| r >= plan_rate - 1e-9 && divides(r)) {
         return r;
     }
-    // Nothing clean at/above the plan: take the widest clean multiple offered
-    // (best effort), else the plan rate so the device surfaces a clear error
-    // rather than silently mis-tuning.
-    rates.iter().rev().copied().find(|&r| divides(r)).unwrap_or(plan_rate)
+    // No clean multiple at or above the plan: take the smallest supported rate
+    // there and let the DDC resample to the channel rate. This is what makes,
+    // e.g., a full multi-mode station work on an Airspy R2 — its 10/2.5 MS/s
+    // are integer multiples of neither the 24 kHz (ACARS) nor 48 kHz (AIS)
+    // channel rate, so without resampling those modes had no usable rate.
+    if let Some(&r) = rates.iter().find(|&&r| r >= plan_rate - 1e-9) {
+        return r;
+    }
+    // Nothing at or above the plan: the widest rate offered (DDC resamples),
+    // preferring a clean multiple if one exists.
+    rates
+        .iter()
+        .rev()
+        .copied()
+        .find(|&r| divides(r))
+        .or_else(|| rates.last().copied())
+        .unwrap_or(plan_rate)
 }
 
 /// A one-line hint to show after auto-selecting a rate, when the user might
@@ -640,6 +659,32 @@ mod tests {
         // multiple (2.5 MS/s) — the even-integer preference is Mode S only.
         let r2 = RateCaps::Discrete(vec![10_000_000, 2_500_000]);
         assert_eq!(choose_rate(&r2, Mode::Iridium, 2_400_000.0), 2_500_000.0);
+    }
+
+    #[test]
+    fn airspy_r2_runs_all_modes_via_resampling() {
+        // R2 (10 / 2.5 MS/s) divides neither 24 kHz (ACARS), 48 kHz (AIS) nor
+        // 12 kHz (StdC); without resampling these had no usable rate. Now the
+        // picker returns the smallest rate >= plan and the DDC resamples.
+        let r2 = RateCaps::Discrete(vec![10_000_000, 2_500_000]);
+        assert_eq!(choose_rate(&r2, Mode::AcarsPoa, 2_400_000.0), 2_500_000.0);
+        assert_eq!(choose_rate(&r2, Mode::Ais, 2_400_000.0), 2_500_000.0);
+        assert_eq!(choose_rate(&r2, Mode::StdC, 2_400_000.0), 2_500_000.0);
+        // VDL2 (50 kHz) and Iridium (250 kHz) DO divide 2.5 MS/s → clean
+        // integer path, same rate, no resampling.
+        assert_eq!(choose_rate(&r2, Mode::Vdl2, 2_400_000.0), 2_500_000.0);
+        assert_eq!(choose_rate(&r2, Mode::Iridium, 2_400_000.0), 2_500_000.0);
+        // ADS-B takes the even-integer 10 MS/s (integer demod path).
+        assert_eq!(choose_rate(&r2, Mode::Adsb, 2_000_000.0), 10_000_000.0);
+    }
+
+    #[test]
+    fn ranges_resample_when_no_aligned_rate_fits() {
+        // A device whose only band is a narrow window containing no 24 kHz
+        // multiple still yields a usable (resampled) rate from an endpoint.
+        let narrow = RateCaps::Ranges(vec![(2_450_000.0, 2_460_000.0, 0.0)]);
+        let r = choose_rate(&narrow, Mode::AcarsPoa, 2_400_000.0);
+        assert!((2_450_000.0..=2_460_000.0).contains(&r), "got {r}");
     }
 
     #[test]


### PR DESCRIPTION
Follow-up to #169: "the R2 is fully capable of all of these modes, so let's make it possible."

## Why it wasn't possible
The DDC only did **integer decimation** — the capture rate had to be an exact integer multiple of the mode's channel rate. The Airspy R2 offers only **10 and 2.5 MS/s**, and neither is an integer multiple of:
- 24 kHz (ACARS) — 2.5M/24k = 104.17, 10M/24k = 416.67
- 48 kHz (AIS) — 2.5M/48k = 52.08
- 12 kHz (STD-C) — 2.5M/12k = 208.33

So those modes had no usable rate on an R2, and auto-tune fell through to the unsupported 2.4 MS/s plan rate (device-open failure). (VDL2 @ 50 kHz and Iridium @ 250 kHz divide 2.5M cleanly, and ADS-B uses the whole capture, so only the audio-channel modes were stuck.)

## The fix: a resampler in the DDC
New `Resampler` in `xng-dsp` (4-point Catmull-Rom). The DDC now:
1. NCO-mixes and **integer-decimates by `floor(input/output)`** (the existing cheap FIR stages) down to *just above* the channel rate, and
2. **resamples the small remainder** to land exactly on the channel rate.

The resample ratio is near unity (e.g. 2.5M→24k decimates by 104 to 24038 Hz, then resamples 24038→24000, ratio 1.0016), and the signal is already band-limited to the channel passband, so interpolation error is far below the demods' noise floor.

**Exact integer ratios skip the resampler entirely** — the fast path is byte-for-byte unchanged. The real-capture `offair`/`e2e` oracle tests for every mode confirm zero regression.

## Rate selection
`choose_rate` still prefers a clean integer-ratio rate ≥ the plan (no resampling), but when none exists it now takes the smallest supported rate ≥ the plan and lets the DDC resample. SoapySDR range expansion keeps band endpoints too, so discrete-point devices also get a resampling fallback.

Result on an R2:
| Mode | Rate | Path |
|---|---|---|
| ACARS / AIS / STD-C | 2.5 MS/s | resampled to 24/48/12 kHz |
| VDL2 / Iridium | 2.5 MS/s | clean integer decimation |
| ADS-B | 10 MS/s | whole-capture integer demod path |

## Testing
- `resample`: kernel control points, exact output rate, in-band tone preservation (amplitude + frequency).
- `ddc`: non-integer ratio resamples (in-channel unit gain, adjacent channel rejected); integer ratio unchanged.
- `scan`: `airspy_r2_runs_all_modes_via_resampling`, `ranges_resample_when_no_aligned_rate_fits`.
- Full workspace test suite green; release build clean (`--features airspy,airspyhf`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for non-integer sample-rate ratio conversions across all decoders, enabling flexible capture rates.
  * Enhanced rate selection to prefer aligned rates while gracefully handling arbitrary capture rates via resampling.

* **Documentation**
  * Updated decoder documentation to clarify support for any capture rate at or above the required channel rate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->