### PR TITLE
feat(outputs): add ZMQ PUB sink for the native JSON message format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,6 +98,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -128,6 +146,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "asynchronous-codec"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a860072022177f903e59730004fb5dc13db9275b79bb2aef7ba8ce831956c233"
+dependencies = [
+ "bytes",
+ "futures-sink",
+ "futures-util",
+ "memchr",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -426,6 +457,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -504,6 +544,15 @@ name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -811,12 +860,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -824,6 +889,44 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "futures-sink"
@@ -843,9 +946,13 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -967,6 +1074,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -1670,6 +1783,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1850,6 +1969,20 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -2435,12 +2568,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "saa"
+version = "5.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f5acb362a0e75c2a963532fa7fabf13dff81626dc494df16488d30befcbea0"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "scc"
+version = "3.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5581cd5dd2cb79cbe9d8137071d67f62f0db926e83a07b4d14561c5b7d423776"
+dependencies = [
+ "saa",
+ "sdd",
 ]
 
 [[package]]
@@ -2457,6 +2606,15 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sdd"
+version = "4.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5f0e40a01b94e35d1dacbcfbe5bfd3d31e37d9590b2e6d86a82b0e87bd4f551"
+dependencies = [
+ "saa",
+]
 
 [[package]]
 name = "security-framework"
@@ -2958,6 +3116,7 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2 0.6.4",
@@ -2995,6 +3154,7 @@ checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "pin-project-lite",
  "tokio",
@@ -3568,6 +3728,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "win_uds"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd30a1a28a3799479cbf4e17284a220ea9ff6bad098a9d0224543a5d1efe1da"
+dependencies = [
+ "async-io",
+ "futures-io",
+ "socket2 0.6.4",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4042,6 +4213,7 @@ dependencies = [
  "xng-proto",
  "xng-sdr",
  "xng-types",
+ "zeromq",
 ]
 
 [[package]]
@@ -4421,6 +4593,31 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zeromq"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efb2c254fd8f366755335c9e43b865f8484fe3bd717d65ffe7c3f28852863030"
+dependencies = [
+ "async-trait",
+ "asynchronous-codec",
+ "bytes",
+ "crossbeam-queue",
+ "futures",
+ "log",
+ "num-traits",
+ "once_cell",
+ "parking_lot",
+ "rand 0.9.4",
+ "regex",
+ "scc",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-util",
+ "uuid",
+ "win_uds",
+]
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ rcgen = "0.13"
 rustls-pemfile = "2"
 tokio-stream = "0.1"
 webpki-roots = "0.26"
+zeromq = { version = "0.6.0", default-features = false, features = ["tokio-runtime", "tcp-transport", "ipc-transport"] }
 
 # DSP loopback tests are too slow unoptimized.
 [profile.test]
@@ -134,3 +135,4 @@ rcgen.workspace = true
 rustls-pemfile.workspace = true
 tokio-stream.workspace = true
 webpki-roots.workspace = true
+zeromq.workspace = true

--- a/README.md
+++ b/README.md
@@ -496,6 +496,7 @@ Every mode and every command shares the same output options:
 --nmea-tag-blocks                              # prefix NMEA with \s:<station>,c:<ts>*HH\
 --mqtt mqtt://user:pass@broker:1883            # MQTT (JSON to <prefix>/<mode>)
 --mqtt-topic xng                               # MQTT topic prefix
+--zmq tcp://0.0.0.0:5555                        # ZMQ PUB ([mode, json]; repeatable; connect: to connect)
 --asf2-grpc http://ingest:6001                 # asf-2.0 over gRPC
 --asf2-quic ingest:6011                        # asf-2.0 over QUIC (TLS verified)
 ```

--- a/contrib/station.example.toml
+++ b/contrib/station.example.toml
@@ -8,6 +8,10 @@ jsonl = "/var/log/xng/messages.jsonl"
 metrics = "0.0.0.0:9090"
 http = "0.0.0.0:8080"          # live web dashboard (map + messages)
 # mqtt = "mqtt://user:pass@broker:1883"
+# zmq = ["tcp://0.0.0.0:5555"] # ZMQ PUB; [mode, json] frames; one socket fans
+                               # out to every listed endpoint. Each binds by
+                               # default; prefix connect: to connect instead,
+                               # e.g. ["tcp://0.0.0.0:5555", "connect:tcp://collector:5555"]
 # sbs = "0.0.0.0:30003"        # Mode S BaseStation TCP
 # beast = "0.0.0.0:30005"      # Mode S Beast TCP (mlat-client compatible)
 # nmea-tcp = "0.0.0.0:10110"   # AIS NMEA TCP

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -96,7 +96,7 @@ xng/
 │   │                      #   selftest, tui, station, status, ingest, extern, config)
 │   ├── runtime.rs, bus.rs # session supervisor + message bus
 │   ├── outputs/           # console, JSON/JSONL, acarsdec UDP, dumpvdl2 UDP/TCP,
-│   │                      #   Airframes, Prometheus, SBS/Beast, NMEA, MQTT, asf-2.0,
+│   │                      #   Airframes, Prometheus, SBS/Beast, NMEA, MQTT, ZMQ, asf-2.0,
 │   │                      #   and the web dashboard (map + geo export)
 │   ├── tui.rs             # ratatui TUI
 │   ├── beam.rs, satmap.rs # Iridium beam-pattern reconstruction + satellite naming
@@ -124,7 +124,7 @@ serves five carriers.
 
 Every mode and command shares one output set: pretty console, JSON/JSONL,
 acarsdec-compatible UDP, Airframes feeding, Prometheus `/metrics`,
-SBS/Beast (Mode S), NMEA AIVDM (AIS), MQTT, and **asf-2.0** — one
+SBS/Beast (Mode S), NMEA AIVDM (AIS), MQTT, ZMQ, and **asf-2.0** — one
 protobuf schema multiplexing every channel/SDR/mode over a single gRPC
 (tonic/HTTP/2) or QUIC (quinn) connection, with the raw payload always
 preserved for server-side re-decode. `xng ingest` is the reference

--- a/src/commands/scan.rs
+++ b/src/commands/scan.rs
@@ -596,6 +596,7 @@ pub(crate) fn scan_group(
             http: None,
             mqtt: None,
             mqtt_topic: "xng".into(),
+            zmq: Vec::new(),
             airframes: None,
             own_ship_mmsi: None,
         },

--- a/src/commands/station.rs
+++ b/src/commands/station.rs
@@ -68,6 +68,11 @@ pub struct OutputsToml {
     pub aircraft_db: Option<PathBuf>,
     pub mqtt: Option<String>,
     pub mqtt_topic: Option<String>,
+    /// ZMQ PUB endpoints; emits `[mode, json]` multipart frames. One shared
+    /// PUB socket attaches to every endpoint (fan-out). Each binds by default
+    /// (`tcp://…`/`ipc://…`); prefix `connect:` to connect instead.
+    #[serde(default)]
+    pub zmq: Vec<String>,
     /// Own-ship MMSI: emit an AIVDO position report for the station's own
     /// `receiver-pos` so chart plotters show the receiver (AIS-5c).
     pub own_ship_mmsi: Option<u32>,

--- a/src/commands/survey.rs
+++ b/src/commands/survey.rs
@@ -474,6 +474,7 @@ fn dwell(
             http: None,
             mqtt: None,
             mqtt_topic: "xng".into(),
+            zmq: Vec::new(),
             airframes: None,
             own_ship_mmsi: None,
         },

--- a/src/main.rs
+++ b/src/main.rs
@@ -169,6 +169,11 @@ struct OutputOpts {
     /// MQTT topic prefix; messages publish to <prefix>/<mode>
     #[arg(long, default_value = "xng")]
     mqtt_topic: String,
+    /// Publish messages as [mode, json] over a ZMQ PUB socket (repeatable; one
+    /// socket fans out to all). Each binds by default (e.g. tcp://0.0.0.0:5555
+    /// or ipc:///tmp/xng.sock); prefix with connect: to connect to a collector
+    #[arg(long)]
+    zmq: Vec<String>,
 }
 
 impl OutputOpts {
@@ -226,6 +231,7 @@ impl OutputOpts {
                 http: self.http.clone(),
                 mqtt: self.mqtt.clone(),
                 mqtt_topic: self.mqtt_topic.clone(),
+                zmq: self.zmq.clone(),
                 // Set per-session by the caller once the mode is known.
                 airframes: None,
                 own_ship_mmsi: None,
@@ -762,6 +768,7 @@ fn main() -> anyhow::Result<()> {
                         http: None,
                         mqtt: None,
                         mqtt_topic: "xng".into(),
+                        zmq: Vec::new(),
                         airframes: None,
                         own_ship_mmsi: None,
                     },
@@ -804,6 +811,7 @@ fn run_station_cmd(config: &std::path::Path) -> anyhow::Result<()> {
         http: st.outputs.http.clone(),
         mqtt: st.outputs.mqtt.clone(),
         mqtt_topic: st.outputs.mqtt_topic.clone().unwrap_or_else(|| "xng".into()),
+        zmq: st.outputs.zmq.clone(),
         airframes: Some(commands::station::airframes_router(&st)),
         own_ship_mmsi: st.outputs.own_ship_mmsi,
     };

--- a/src/outputs/mod.rs
+++ b/src/outputs/mod.rs
@@ -19,3 +19,4 @@ pub mod mqtt;
 pub mod nmea_tcp;
 pub mod nmea_udp;
 pub mod sbs;
+pub mod zmq;

--- a/src/outputs/zmq.rs
+++ b/src/outputs/zmq.rs
@@ -149,8 +149,9 @@ mod tests {
     #[tokio::test]
     async fn pub_sub_roundtrip() {
         // Bind a PUB sink on an ephemeral port, connect a SUB, and assert the
-        // [mode, json] frames arrive and the JSON deserializes back into a
-        // Message (the guarantee a consumer relies on).
+        // [mode, json] frames arrive. The contract is that frame 1 is exactly
+        // the shared `serde_json::to_vec(&Message)` bytes the other sinks emit,
+        // so assert byte-equality (not merely that it deserializes).
         let mut pubs = PubSocket::new();
         let endpoint = pubs.bind("tcp://127.0.0.1:0").await.unwrap();
         let addr = endpoint.to_string();
@@ -162,8 +163,10 @@ mod tests {
         // (PUB drops messages with no connected subscribers).
         tokio::time::sleep(Duration::from_millis(200)).await;
 
+        let msg = Arc::new(sample_message());
+        let expected_json = serde_json::to_vec(&*msg).unwrap();
         let (tx, rx) = broadcast::channel(8);
-        tx.send(Arc::new(sample_message())).unwrap();
+        tx.send(msg).unwrap();
         drop(tx); // close the bus so publish_loop returns after draining
 
         publish_loop(rx, &mut pubs).await;
@@ -174,29 +177,25 @@ mod tests {
             .expect("recv failed");
         assert_eq!(frame.len(), 2, "expected [mode, json] multipart");
         assert_eq!(&frame.get(0).unwrap()[..], b"vdl2");
-        let decoded: Message = serde_json::from_slice(frame.get(1).unwrap()).unwrap();
-        assert_eq!(decoded.mode, Mode::Vdl2);
-        assert_eq!(decoded.frequency_hz, 136_975_000);
+        assert_eq!(&frame.get(1).unwrap()[..], &expected_json[..]);
     }
 
     #[tokio::test]
     async fn run_fans_out_to_multiple_endpoints() {
         // `run` with a two-endpoint list binds one PUB socket to both; a SUB
         // connected to each must receive the same message (the fan-out).
-        use std::net::TcpListener;
-        // Grab two free ports by binding then dropping the listeners.
-        let free_port = || {
-            TcpListener::bind("127.0.0.1:0")
-                .unwrap()
-                .local_addr()
-                .unwrap()
-                .port()
-        };
-        let (p1, p2) = (free_port(), free_port());
-        let (a1, a2) = (
-            format!("tcp://127.0.0.1:{p1}"),
-            format!("tcp://127.0.0.1:{p2}"),
-        );
+        // Use unique IPC endpoints rather than ephemeral TCP ports: allocating
+        // a port via a throwaway TcpListener and rebinding it later is racy
+        // (the port is free between drop and rebind). A per-test-run temp path
+        // has no such window.
+        let dir = std::env::temp_dir().join(format!(
+            "xng-zmq-fanout-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = |name: &str| format!("ipc://{}", dir.join(name).display());
+        let (a1, a2) = (path("a"), path("b"));
 
         let (tx, rx) = broadcast::channel(8);
         let endpoints = vec![a1.clone(), a2.clone()];
@@ -225,6 +224,7 @@ mod tests {
 
         drop(tx); // close the bus so `run` returns
         handle.await.unwrap().unwrap();
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[tokio::test]

--- a/src/outputs/zmq.rs
+++ b/src/outputs/zmq.rs
@@ -1,0 +1,235 @@
+//! ZMQ output: publish each normalized message as a two-frame multipart
+//! `[mode, json]` over a ZeroMQ `PUB` socket. The first frame is the mode
+//! string (e.g. `vdl2`) so `SUB` consumers can filter broker-side
+//! (`SUBSCRIBE vdl2`); the second frame is the same JSON `Message` the MQTT
+//! and JSONL sinks emit. `SUBSCRIBE ""` receives everything.
+//!
+//! One PUB socket is shared for the whole process and attached to one or more
+//! ZeroMQ endpoints; every published message fans out to all of them. Each
+//! endpoint is a ZeroMQ endpoint string that by default *binds* (acting as a
+//! PUB server consumers connect to); prefix an endpoint with `connect:` to
+//! *connect* to a known XSUB/collector instead. Bind and connect endpoints can
+//! be mixed freely:
+//!
+//! - `tcp://0.0.0.0:5555`          — bind (default)
+//! - `ipc:///tmp/xng.sock`         — bind
+//! - `connect:tcp://collector:5555` — connect
+
+use std::sync::Arc;
+use tokio::sync::broadcast;
+use xng_types::Message;
+use zeromq::{PubSocket, Socket, SocketSend, ZmqMessage};
+
+/// How the PUB socket attaches to its endpoint.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Attach {
+    Bind,
+    Connect,
+}
+
+/// Split an optional `connect:` prefix off the endpoint, returning the attach
+/// mode and the bare ZeroMQ endpoint string. The scheme is validated to be one
+/// the sink supports (`tcp://` or `ipc://`).
+fn parse_endpoint(endpoint: &str) -> anyhow::Result<(Attach, &str)> {
+    let (attach, addr) = match endpoint.strip_prefix("connect:") {
+        Some(rest) => (Attach::Connect, rest),
+        None => (Attach::Bind, endpoint),
+    };
+    anyhow::ensure!(
+        addr.starts_with("tcp://") || addr.starts_with("ipc://"),
+        "--zmq endpoint must be tcp://… or ipc://… (optionally prefixed with connect:)"
+    );
+    Ok((attach, addr))
+}
+
+/// Consume the bus until it closes, publishing each message as `[mode, json]`
+/// to every configured endpoint. All endpoints share one `PUB` socket, so a
+/// published message fans out to all of them.
+pub async fn run(
+    rx: broadcast::Receiver<Arc<Message>>,
+    endpoints: Vec<String>,
+) -> anyhow::Result<()> {
+    anyhow::ensure!(
+        !endpoints.is_empty(),
+        "zmq output requires at least one endpoint"
+    );
+    // Validate every endpoint up front so a typo fails fast rather than after
+    // some endpoints are already attached.
+    let parsed = endpoints
+        .iter()
+        .map(|e| parse_endpoint(e))
+        .collect::<anyhow::Result<Vec<_>>>()?;
+    let mut socket = PubSocket::new();
+    for (attach, addr) in parsed {
+        match attach {
+            Attach::Bind => {
+                socket.bind(addr).await?;
+                tracing::info!("zmq PUB bound on {addr}");
+            }
+            Attach::Connect => {
+                socket.connect(addr).await?;
+                tracing::info!("zmq PUB connected to {addr}");
+            }
+        }
+    }
+    publish_loop(rx, &mut socket).await;
+    Ok(())
+}
+
+/// The send loop, split out so it can be exercised against any `SocketSend`.
+async fn publish_loop<S: SocketSend>(mut rx: broadcast::Receiver<Arc<Message>>, socket: &mut S) {
+    loop {
+        match rx.recv().await {
+            Ok(msg) => match serde_json::to_vec(&*msg) {
+                Ok(payload) => {
+                    let mut frame = ZmqMessage::from(msg.mode.as_str().to_owned());
+                    frame.push_back(payload.into());
+                    if let Err(e) = socket.send(frame).await {
+                        tracing::warn!("zmq publish: {e}");
+                    }
+                }
+                Err(e) => tracing::warn!("zmq encode: {e}"),
+            },
+            Err(broadcast::error::RecvError::Lagged(n)) => {
+                tracing::warn!("zmq output lagged, dropped {n} messages");
+            }
+            Err(broadcast::error::RecvError::Closed) => break,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+    use xng_types::{
+        AppInfo, DecodeQuality, MessageBody, Mode, Provenance, SignalQuality, StationIdentity,
+    };
+    use zeromq::{SocketRecv, SubSocket};
+
+    #[test]
+    fn endpoint_forms() {
+        assert_eq!(
+            parse_endpoint("tcp://0.0.0.0:5555").unwrap(),
+            (Attach::Bind, "tcp://0.0.0.0:5555")
+        );
+        assert_eq!(
+            parse_endpoint("connect:tcp://host:5555").unwrap(),
+            (Attach::Connect, "tcp://host:5555")
+        );
+        assert_eq!(
+            parse_endpoint("ipc:///tmp/xng.sock").unwrap(),
+            (Attach::Bind, "ipc:///tmp/xng.sock")
+        );
+        assert!(parse_endpoint("udp://x").is_err());
+        assert!(parse_endpoint("connect:udp://x").is_err());
+    }
+
+    fn sample_message() -> Message {
+        Message {
+            mode: Mode::Vdl2,
+            timestamp: chrono::Utc::now(),
+            frequency_hz: 136_975_000,
+            signal: SignalQuality::default(),
+            decode: DecodeQuality::default(),
+            body: MessageBody::Vdl2 {
+                kind: "xid".to_owned(),
+                details: serde_json::json!({ "test": true }),
+            },
+            raw: None,
+            source: Provenance {
+                station: StationIdentity::new("XNG-TEST"),
+                app: AppInfo::xng(),
+                sdr: None,
+                channel: None,
+            },
+        }
+    }
+
+    #[tokio::test]
+    async fn pub_sub_roundtrip() {
+        // Bind a PUB sink on an ephemeral port, connect a SUB, and assert the
+        // [mode, json] frames arrive and the JSON deserializes back into a
+        // Message (the guarantee a consumer relies on).
+        let mut pubs = PubSocket::new();
+        let endpoint = pubs.bind("tcp://127.0.0.1:0").await.unwrap();
+        let addr = endpoint.to_string();
+
+        let mut sub = SubSocket::new();
+        sub.connect(&addr).await.unwrap();
+        sub.subscribe("").await.unwrap();
+        // Give the SUB connection a moment to establish before publishing
+        // (PUB drops messages with no connected subscribers).
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        let (tx, rx) = broadcast::channel(8);
+        tx.send(Arc::new(sample_message())).unwrap();
+        drop(tx); // close the bus so publish_loop returns after draining
+
+        publish_loop(rx, &mut pubs).await;
+
+        let frame = tokio::time::timeout(Duration::from_secs(2), sub.recv())
+            .await
+            .expect("recv timed out")
+            .expect("recv failed");
+        assert_eq!(frame.len(), 2, "expected [mode, json] multipart");
+        assert_eq!(&frame.get(0).unwrap()[..], b"vdl2");
+        let decoded: Message = serde_json::from_slice(frame.get(1).unwrap()).unwrap();
+        assert_eq!(decoded.mode, Mode::Vdl2);
+        assert_eq!(decoded.frequency_hz, 136_975_000);
+    }
+
+    #[tokio::test]
+    async fn run_fans_out_to_multiple_endpoints() {
+        // `run` with a two-endpoint list binds one PUB socket to both; a SUB
+        // connected to each must receive the same message (the fan-out).
+        use std::net::TcpListener;
+        // Grab two free ports by binding then dropping the listeners.
+        let free_port = || {
+            TcpListener::bind("127.0.0.1:0")
+                .unwrap()
+                .local_addr()
+                .unwrap()
+                .port()
+        };
+        let (p1, p2) = (free_port(), free_port());
+        let (a1, a2) = (
+            format!("tcp://127.0.0.1:{p1}"),
+            format!("tcp://127.0.0.1:{p2}"),
+        );
+
+        let (tx, rx) = broadcast::channel(8);
+        let endpoints = vec![a1.clone(), a2.clone()];
+        let handle = tokio::spawn(run(rx, endpoints));
+        // Let `run` bind both endpoints before connecting subscribers.
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        let mut sub1 = SubSocket::new();
+        sub1.connect(&a1).await.unwrap();
+        sub1.subscribe("").await.unwrap();
+        let mut sub2 = SubSocket::new();
+        sub2.connect(&a2).await.unwrap();
+        sub2.subscribe("").await.unwrap();
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        tx.send(Arc::new(sample_message())).unwrap();
+
+        for sub in [&mut sub1, &mut sub2] {
+            let frame = tokio::time::timeout(Duration::from_secs(2), sub.recv())
+                .await
+                .expect("recv timed out")
+                .expect("recv failed");
+            assert_eq!(frame.len(), 2);
+            assert_eq!(&frame.get(0).unwrap()[..], b"vdl2");
+        }
+
+        drop(tx); // close the bus so `run` returns
+        handle.await.unwrap().unwrap();
+    }
+
+    #[tokio::test]
+    async fn run_rejects_empty_endpoint_list() {
+        let (_tx, rx) = broadcast::channel::<Arc<Message>>(1);
+        assert!(run(rx, vec![]).await.is_err());
+    }
+}

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -68,6 +68,10 @@ pub struct OutputConfig {
     pub mqtt: Option<String>,
     /// MQTT topic prefix (messages publish to `<prefix>/<mode>`).
     pub mqtt_topic: String,
+    /// ZMQ PUB endpoints; emits `[mode, json]` multipart frames. One shared
+    /// PUB socket attaches to every endpoint (fan-out). Each binds by default
+    /// (`tcp://…`/`ipc://…`); prefix `connect:` to connect instead.
+    pub zmq: Vec<String>,
     /// Per-mode Airframes feed router (legacy per-port native-format push;
     /// asf-2.0 multiplexes every mode separately under the canonical ident).
     pub airframes: Option<crate::outputs::airframes::AirframesRouter>,
@@ -857,6 +861,16 @@ fn spawn_outputs(
         output_tasks.push(tokio::spawn(async move {
             if let Err(e) = crate::outputs::mqtt::run(rx, url, topic, ident).await {
                 tracing::error!("mqtt output: {e}");
+            }
+            Ok(())
+        }));
+    }
+    if !outputs.zmq.is_empty() {
+        let rx = bus.subscribe();
+        let endpoints = outputs.zmq.clone();
+        output_tasks.push(tokio::spawn(async move {
+            if let Err(e) = crate::outputs::zmq::run(rx, endpoints).await {
+                tracing::error!("zmq output: {e}");
             }
             Ok(())
         }));


### PR DESCRIPTION
## Summary

Adds a ZeroMQ `PUB` output sink that publishes the native normalized
`Message` JSON to one or more consumers, alongside the existing MQTT/JSONL
outputs.

Each message is sent as a **two-frame multipart** `[mode, json]`:

- **frame 0** — the mode string (e.g. `vdl2`, `acars`), so `SUB` consumers
  can filter broker-side (`SUBSCRIBE vdl2`; `SUBSCRIBE ""` receives all);
- **frame 1** — the same JSON `Message` the MQTT and JSONL sinks emit
  (byte-identical), so a consumer deserializes it the same way regardless
  of sink.

## Configuration

The output is a process-wide `[outputs]` entry, shared across all sessions
(like `mqtt`/`http`/`sbs`). It accepts a **list** of endpoints — one shared
`PUB` socket attaches to every endpoint and fans out — mirroring the
existing repeatable `--udp` pattern. Each endpoint **binds by default**
(`tcp://` or `ipc://`); a `connect:` prefix connects to a collector
instead, and bind/connect may be mixed.

```
CLI:  --zmq tcp://0.0.0.0:5555 --zmq connect:tcp://collector:5555
TOML: zmq = ["tcp://0.0.0.0:5555", "connect:tcp://collector:5555"]
```

## Implementation notes

- Uses the pure-Rust `zeromq` crate — **no `libzmq` system dependency**.
- New sink `src/outputs/zmq.rs` follows the existing output pattern
  (module registration, `OutputConfig` field, `spawn_outputs` wiring, CLI
  flag, station TOML key).
- Docs updated: `contrib/station.example.toml`, `README.md`,
  `docs/ARCHITECTURE.md`.

## Tests

`src/outputs/zmq.rs` adds:

- `endpoint_forms` — endpoint parsing (bind/connect, scheme validation);
- `pub_sub_roundtrip` — single endpoint, asserts `[mode, json]` arrives and
  the JSON round-trips back into a `Message`;
- `run_fans_out_to_multiple_endpoints` — two endpoints on one socket, both
  subscribers receive the message;
- `run_rejects_empty_endpoint_list`.

Full bin test suite: **115 passed, 0 failed**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ZeroMQ output support for publishing messages over ZMQ PUB sockets.
  * Added a new `--zmq` option and configuration support for one or more endpoints, including `connect:` handling.
  * Updated examples and architecture docs to reflect the new output endpoint.

* **Bug Fixes**
  * Ensured ZMQ output defaults are initialized consistently across modes, avoiding missing configuration when unused.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->