### PR TITLE
perf(acars): shared multi-channel downconverter front end (per-channel DDC → channelizer)

### DIFF
--- a/bench/cpu.sh
+++ b/bench/cpu.sh
@@ -21,6 +21,20 @@ if [ ! -f /tmp/bench_modes1_x20.cu8 ]; then
   for i in $(seq 20); do cat bench/data/modes1.cu8; done > /tmp/bench_modes1_x20.cu8
 fi
 run adsb /tmp/bench_modes1_x20.cu8 cu8 adsb 2000000 1090000000 1090 3.57
+
+# ACARS: no vendored off-air fixture, so synthesize a multi-channel 2.4 MS/s
+# capture (cf32) from the crate's modulator and loop it to a few seconds. The
+# CPU cost is per *requested* channel (the DDC runs whether or not a burst is
+# present), so decode it across 8 VHF ACARS channels — the realistic
+# acarsdec-replacement load that the per-channel front end has to keep up with.
+if [ ! -f /tmp/bench_acars_8ch.cf32 ]; then
+  cargo run --release -q -p xng-mode-acars --example gen_capture -- /tmp/bench_acars_1x.cf32 >/dev/null 2>&1
+  for i in $(seq 5); do cat /tmp/bench_acars_1x.cf32; done > /tmp/bench_acars_8ch.cf32
+fi
+# gen_capture writes ~0.47 s at 2.4 MS/s; ×5 ≈ 2.36 s. 8 channels across the
+# US ACARS plan around the 131.500 capture center.
+run acars /tmp/bench_acars_8ch.cf32 cf32 acars 2400000 131500000 \
+  131.425,131.450,131.475,131.525,131.550,131.575,131.725,131.825 2.36
 [ -f bench/data/ais_96k.cs16 ] && run ais bench/data/ais_96k.cs16 cs16 ais 96000 162000000 161.975,162.025 300
 [ -f bench/data/vdl2_105k_conj.s16 ] && run vdl2 bench/data/vdl2_105k_conj.s16 cs16 vdl2 105000 136975000 136.975 46.9
 [ -f bench/data/hfdl_48k.cs16 ] && run hfdl bench/data/hfdl_48k.cs16 cs16 hfdl 48000 21931000 21931k 127.3

--- a/bench/cpu.sh
+++ b/bench/cpu.sh
@@ -27,10 +27,10 @@ run adsb /tmp/bench_modes1_x20.cu8 cu8 adsb 2000000 1090000000 1090 3.57
 # CPU cost is per *requested* channel (the DDC runs whether or not a burst is
 # present), so decode it across 8 VHF ACARS channels — the realistic
 # acarsdec-replacement load that the per-channel front end has to keep up with.
-if [ ! -f /tmp/bench_acars_8ch.cf32 ]; then
-  cargo run --release -q -p xng-mode-acars --example gen_capture -- /tmp/bench_acars_1x.cf32 >/dev/null 2>&1
-  for i in $(seq 5); do cat /tmp/bench_acars_1x.cf32; done > /tmp/bench_acars_8ch.cf32
-fi
+# Regenerate the fixture every run (cheap, ~0.5 s) so a change to gen_capture
+# can never leave a stale /tmp capture skewing the comparison.
+cargo run --release -q -p xng-mode-acars --example gen_capture -- /tmp/bench_acars_1x.cf32 >/dev/null 2>&1
+for _ in $(seq 5); do cat /tmp/bench_acars_1x.cf32; done > /tmp/bench_acars_8ch.cf32
 # gen_capture writes ~0.47 s at 2.4 MS/s; ×5 ≈ 2.36 s. 8 channels across the
 # US ACARS plan around the 131.500 capture center.
 run acars /tmp/bench_acars_8ch.cf32 cf32 acars 2400000 131500000 \

--- a/crates/xng-dsp/src/channelized_ddc.rs
+++ b/crates/xng-dsp/src/channelized_ddc.rs
@@ -76,9 +76,16 @@ impl ChannelizedDdc {
             let bin = k_round.rem_euclid(m as f64) as usize;
             let bin_center = bin_offset_hz(bin, m, input_rate);
             let residual = off - bin_center;
-            if residual.abs() > bin_rate / 2.0 + 1.0 {
+            // The channel must fit inside the selected bin: not just its center
+            // within ±½ bin, but its whole ±passband. A channel whose passband
+            // reaches past the bin edge would be silently attenuated, so reject
+            // it here and let the caller fall back to SharedDdc. `choose_num_bins`
+            // sizes the bins (≥ 2.4·passband) so the real airband raster passes;
+            // this guards pathological rate/offset sets.
+            let max_safe_residual = bin_rate / 2.0 - passband_hz;
+            if residual.abs() > max_safe_residual {
                 return Err(format!(
-                    "channel offset {off} Hz does not map onto the {m}-bin grid"
+                    "channel offset {off} Hz is too close to a {m}-bin channelizer edge"
                 ));
             }
             let resampler = if (bin_rate - output_rate).abs() > 1e-6 {

--- a/crates/xng-dsp/src/channelized_ddc.rs
+++ b/crates/xng-dsp/src/channelized_ddc.rs
@@ -1,0 +1,264 @@
+//! Channelizer-based multi-channel downconverter.
+//!
+//! A drop-in alternative to [`SharedDdc`](crate::SharedDdc) with the same
+//! interface, but built on the polyphase [`PfbChannelizer`](crate::PfbChannelizer):
+//! one shared polyphase + FFT pass produces every channel at once, so the cost
+//! is **independent of how many channels are requested and of how far apart
+//! they are** — unlike a shared decimation, whose coarse stage can only
+//! decimate as far as the *widest* channel allows.
+//!
+//! How a requested channel is served:
+//!  1. The capture is split into `M` evenly spaced bins of `fs / M` each.
+//!  2. Each requested channel snaps to its nearest bin (within ±½ bin).
+//!  3. A small residual NCO removes the leftover offset (channel center − bin
+//!     center) at the low bin rate.
+//!  4. A resampler corrects the bin rate (`fs / M`) to the exact channel rate.
+//!
+//! `M` is chosen so each bin comfortably carries the channel passband and the
+//! bin rate is a small integer-ish multiple of the output rate (cheap final
+//! resample).
+
+use crate::channelizer::PfbChannelizer;
+use crate::nco::Nco;
+use crate::resample::Resampler;
+use crate::IqSample;
+
+/// One requested channel's mapping onto the bin grid + its cheap back end.
+struct Channel {
+    /// Which channelizer bin carries this channel.
+    bin: usize,
+    /// Residual NCO removing (channel center − bin center) at the bin rate.
+    nco: Nco,
+    resampler: Option<Resampler>,
+    /// The selected bin's samples for this block (NCO-mixed in place).
+    binbuf: Vec<IqSample>,
+}
+
+pub struct ChannelizedDdc {
+    pfb: PfbChannelizer,
+    /// All `M` bin outputs (only the selected bins are consumed downstream,
+    /// but the polyphase step fills every bin — that is the shared work).
+    bins: Vec<Vec<IqSample>>,
+    channels: Vec<Channel>,
+}
+
+impl ChannelizedDdc {
+    /// Same signature as [`SharedDdc::new`](crate::SharedDdc::new).
+    pub fn new(
+        input_rate: f64,
+        output_rate: f64,
+        offsets: &[f64],
+        passband_hz: f64,
+    ) -> Result<Self, String> {
+        if offsets.is_empty() {
+            return Err("ChannelizedDdc needs at least one channel".to_string());
+        }
+        if output_rate < 2.0 * passband_hz {
+            return Err(format!(
+                "output rate {output_rate} cannot carry a ±{passband_hz} Hz passband"
+            ));
+        }
+
+        // Choose M (number of bins). Each bin must carry the full channel
+        // (its rate fs/M ≥ 2·passband with margin) and we want fs/M close to
+        // a small multiple of output_rate so the final resample is gentle.
+        // Target a bin rate of ~output_rate (critically sampled at the channel
+        // rate is too tight for the channel filter, so allow up to ~2×).
+        let m = choose_num_bins(input_rate, output_rate, passband_hz, offsets)?;
+        let bin_rate = input_rate / m as f64;
+        let pfb = PfbChannelizer::new(m, 12);
+
+        let mut channels = Vec::with_capacity(offsets.len());
+        for &off in offsets {
+            // Snap to the nearest bin: bin index k maps to k·fs/M, with
+            // k > M/2 wrapping to negative frequencies (FFT bin convention).
+            let k_round = (off / bin_rate).round();
+            let bin = k_round.rem_euclid(m as f64) as usize;
+            let bin_center = bin_offset_hz(bin, m, input_rate);
+            let residual = off - bin_center;
+            if residual.abs() > bin_rate / 2.0 + 1.0 {
+                return Err(format!(
+                    "channel offset {off} Hz does not map onto the {m}-bin grid"
+                ));
+            }
+            let resampler = if (bin_rate - output_rate).abs() > 1e-6 {
+                Some(Resampler::new(bin_rate, output_rate))
+            } else {
+                None
+            };
+            channels.push(Channel {
+                bin,
+                nco: Nco::new(residual, bin_rate),
+                resampler,
+                binbuf: Vec::new(),
+            });
+        }
+
+        Ok(Self {
+            pfb,
+            bins: vec![Vec::new(); m],
+            channels,
+        })
+    }
+
+    /// Number of channels.
+    pub fn num_channels(&self) -> usize {
+        self.channels.len()
+    }
+
+    /// Downconvert a wideband block into all channels (same contract as
+    /// [`SharedDdc::process`](crate::SharedDdc::process)).
+    pub fn process(&mut self, input: &[IqSample], out: &mut [Vec<IqSample>]) {
+        assert_eq!(out.len(), self.channels.len(), "out must have one vec per channel");
+
+        // --- Shared polyphase + FFT: fills every bin once. ---
+        for b in &mut self.bins {
+            b.clear();
+        }
+        self.pfb.process(input, &mut self.bins);
+
+        // --- Per channel: pull its bin, residual-mix, resample. ---
+        for (ch, out_buf) in self.channels.iter_mut().zip(out.iter_mut()) {
+            out_buf.clear();
+            ch.binbuf.clear();
+            ch.binbuf.extend_from_slice(&self.bins[ch.bin]);
+            ch.nco.mix(&mut ch.binbuf);
+            match &mut ch.resampler {
+                Some(rs) => rs.process(&ch.binbuf, out_buf),
+                None => out_buf.extend_from_slice(&ch.binbuf),
+            }
+        }
+    }
+}
+
+/// Center frequency of bin `i` relative to the capture center (FFT convention:
+/// bins above `M/2` are negative frequencies).
+fn bin_offset_hz(i: usize, m: usize, sample_rate: f64) -> f64 {
+    let idx = if i <= m / 2 { i as f64 } else { i as f64 - m as f64 };
+    idx * sample_rate / m as f64
+}
+
+/// Pick the bin count `M` (= channelizer bin grid `fs/M`).
+///
+/// A critically-sampled PFB bin only passes flat near its center; a channel
+/// sitting at the bin edge is scalloped down ~6 dB. Real VHF airband channels
+/// are all on a 25 kHz raster, so the right `M` puts every requested channel
+/// on (or very near) a bin center — zero residual, no scalloping. So we search
+/// for the `M` whose grid `fs/M` best lands every offset on a bin center,
+/// subject to the bin rate carrying the passband and staying ≥ the output
+/// rate (the resampler only trims down).
+fn choose_num_bins(
+    input_rate: f64,
+    output_rate: f64,
+    passband_hz: f64,
+    offsets: &[f64],
+) -> Result<usize, String> {
+    // Bin rate must clear the channel (≥ ~2.4·passband so ±passband sits in
+    // the flat center region) and not require upsampling.
+    let min_bin_rate = (2.4 * passband_hz).max(output_rate);
+    let max_m = (input_rate / min_bin_rate).floor() as usize;
+    if max_m < 2 {
+        return Err(format!(
+            "capture {input_rate} S/s too narrow to channelize ±{passband_hz} Hz at {output_rate} S/s"
+        ));
+    }
+    // Score each candidate M by the worst-case channel-to-bin-center distance
+    // as a fraction of the bin (0 = every channel dead-center, best). Prefer
+    // the largest M among the best-scoring (smallest FFT blocks per output
+    // sample, gentlest final resample). Cap the search for a small FFT.
+    let cap = max_m.min(256);
+    let mut best_m = 2usize;
+    let mut best_score = f64::INFINITY;
+    for m in 2..=cap {
+        let bin_rate = input_rate / m as f64;
+        let worst = offsets
+            .iter()
+            .map(|&off| {
+                let k = (off / bin_rate).round();
+                ((off - k * bin_rate) / bin_rate).abs()
+            })
+            .fold(0.0f64, f64::max);
+        // Tie-break toward larger M by subtracting a tiny m-proportional term.
+        let score = worst - (m as f64) * 1e-9;
+        if score < best_score {
+            best_score = score;
+            best_m = m;
+        }
+    }
+    Ok(best_m)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::f64::consts::TAU;
+
+    fn tone(freq: f64, fs: f64, n: usize) -> Vec<IqSample> {
+        (0..n)
+            .map(|i| {
+                let ph = TAU * freq * i as f64 / fs;
+                IqSample::new(ph.cos() as f32, ph.sin() as f32)
+            })
+            .collect()
+    }
+
+    #[test]
+    fn recovers_raster_channels() {
+        // Real VHF airband channels are all on a 25 kHz raster; the chosen M
+        // puts each on a bin center (zero scalloping). Offsets here are all
+        // 25 kHz multiples (e.g. 131.550/131.725/131.825 around a 131.500
+        // center → +50/+225/+325 kHz; and a negative one).
+        let fs = 2_400_000.0;
+        let out_rate = 24_000.0;
+        let offsets = [50_000.0, 225_000.0, 325_000.0, -75_000.0];
+        let mut cd = ChannelizedDdc::new(fs, out_rate, &offsets, 5_000.0).unwrap();
+
+        let n = 720_000;
+        // One tone per channel, each 1 kHz inside its channel.
+        let mut out: Vec<Vec<IqSample>> = vec![Vec::new(); offsets.len()];
+        for (k, &off) in offsets.iter().enumerate() {
+            let input = tone(off + 1_000.0, fs, n);
+            // Decode each channel's tone in isolation to assert per-channel
+            // gain without inter-tone leakage masking it.
+            let mut cd1 = ChannelizedDdc::new(fs, out_rate, &offsets, 5_000.0).unwrap();
+            let mut o: Vec<Vec<IqSample>> = vec![Vec::new(); offsets.len()];
+            cd1.process(&input, &mut o);
+            out[k] = std::mem::take(&mut o[k]);
+        }
+        let _ = &mut cd;
+
+        for (k, ch) in out.iter().enumerate() {
+            let settled = &ch[ch.len() / 2..];
+            let amp = settled.iter().map(|s| s.norm()).sum::<f32>() / settled.len() as f32;
+            assert!((amp - 1.0).abs() < 0.15, "channel {k} gain {amp}, expected ~1");
+        }
+    }
+
+    #[test]
+    fn rejects_neighbor_channel() {
+        let fs = 2_400_000.0;
+        let out_rate = 24_000.0;
+        let offsets = [0.0];
+        let mut cd = ChannelizedDdc::new(fs, out_rate, &offsets, 5_000.0).unwrap();
+        // A tone one full bin away should be rejected by the channelizer.
+        let bin_rate = fs / cd.bins.len() as f64;
+        let input = tone(bin_rate, fs, 480_000);
+        let mut out = vec![Vec::new()];
+        cd.process(&input, &mut out);
+        let settled = &out[0][out[0].len() / 2..];
+        let amp = settled.iter().map(|s| s.norm()).sum::<f32>() / settled.len() as f32;
+        assert!(amp < 0.2, "neighbor bin should be rejected, got {amp}");
+    }
+
+    #[test]
+    fn output_rate_is_correct() {
+        let fs = 2_400_000.0;
+        let out_rate = 24_000.0;
+        let mut cd = ChannelizedDdc::new(fs, out_rate, &[0.0], 5_000.0).unwrap();
+        let input = vec![IqSample::new(0.0, 0.0); 2_400_000];
+        let mut out = vec![Vec::new()];
+        cd.process(&input, &mut out);
+        // ~1 s of capture → ~24000 output samples (within edge effects).
+        assert!((out[0].len() as i64 - 24_000).abs() <= 50, "got {}", out[0].len());
+    }
+}

--- a/crates/xng-dsp/src/lib.rs
+++ b/crates/xng-dsp/src/lib.rs
@@ -4,6 +4,7 @@
 //! Proakis) and public standards documents — no code derived from
 //! GPL-licensed decoders. See `docs/ARCHITECTURE.md` §6 (provenance rules).
 
+pub mod channelized_ddc;
 pub mod channelizer;
 pub mod checksum;
 pub mod ddc;
@@ -16,6 +17,7 @@ pub mod shared_ddc;
 pub mod viterbi;
 pub mod window;
 
+pub use channelized_ddc::ChannelizedDdc;
 pub use channelizer::PfbChannelizer;
 pub use ddc::Ddc;
 pub use fir::{lowpass_taps, rrc_taps, Fir};

--- a/crates/xng-dsp/src/lib.rs
+++ b/crates/xng-dsp/src/lib.rs
@@ -12,6 +12,7 @@ pub mod nco;
 pub mod resample;
 pub mod rs;
 pub mod scramble;
+pub mod shared_ddc;
 pub mod viterbi;
 pub mod window;
 
@@ -20,5 +21,6 @@ pub use ddc::Ddc;
 pub use fir::{lowpass_taps, rrc_taps, Fir};
 pub use nco::Nco;
 pub use resample::Resampler;
+pub use shared_ddc::SharedDdc;
 
 pub type IqSample = num_complex::Complex<f32>;

--- a/crates/xng-dsp/src/shared_ddc.rs
+++ b/crates/xng-dsp/src/shared_ddc.rs
@@ -1,0 +1,359 @@
+//! Shared multi-channel digital downconverter.
+//!
+//! Extracts several narrowband channels that all share one capture, one
+//! output rate, and one passband (e.g. every VHF ACARS channel is 24 kHz /
+//! ±5 kHz) — but unlike running an independent [`Ddc`](crate::Ddc) per
+//! channel, the expensive *full-rate* anti-alias decimation is run **once**
+//! over the wideband stream and its low-rate output is shared by every
+//! channel's cheap final extraction. With N channels the per-channel [`Ddc`]
+//! does N full-rate convolutions per block; this does one, then N cheap
+//! convolutions at the (much lower) intermediate rate.
+//!
+//! Chain:
+//! ```text
+//!   wideband @ fs ── coarse decimating FIR (shared, run once) ──► inter @ fi
+//!   inter @ fi ──┬─ NCO(−off_0) ─ sharp FIR ─ resample ─► channel 0 @ fo
+//!                ├─ NCO(−off_1) ─ sharp FIR ─ resample ─► channel 1 @ fo
+//!                └─ …
+//! ```
+//!
+//! The coarse stage must preserve every channel's band, so it keeps the full
+//! span `max|offset| + passband` and decimates only far enough to stay safely
+//! above twice that span (no channel may alias). The per-channel sharp stage
+//! then realizes the narrow `passband` selectivity at the low rate.
+
+use crate::fir::{lowpass_taps, Fir};
+use crate::nco::Nco;
+use crate::resample::Resampler;
+use crate::IqSample;
+
+/// Same windowed-sinc transition sizing as [`Ddc`](crate::Ddc).
+const TAPS_PER_TRANSITION: f64 = 5.5;
+const MAX_TAPS: usize = 8192;
+
+/// One channel's cheap back end, operating at the shared intermediate rate.
+struct Channel {
+    nco: Nco,
+    fine: Fir,
+    resampler: Option<Resampler>,
+    /// NCO-mixed copy of the (shared) intermediate stream.
+    mixed: Vec<IqSample>,
+    /// Sharp-FIR output, fed to the resampler when present.
+    decimated: Vec<IqSample>,
+}
+
+pub struct SharedDdc {
+    /// Shared coarse stage(s): one decimating FIR over the full-rate stream.
+    coarse: Vec<Fir>,
+    /// Reusable buffers for the shared coarse output (and the inter-stage
+    /// buffer when the coarse stage is split in two).
+    inter: Vec<IqSample>,
+    coarse_inter: Vec<IqSample>,
+    channels: Vec<Channel>,
+}
+
+impl SharedDdc {
+    /// * `input_rate` — wideband capture rate.
+    /// * `output_rate` — per-channel rate (same for all channels).
+    /// * `offsets` — each channel's center relative to the capture center.
+    /// * `passband_hz` — one-sided width of each channel's signal.
+    pub fn new(
+        input_rate: f64,
+        output_rate: f64,
+        offsets: &[f64],
+        passband_hz: f64,
+    ) -> Result<Self, String> {
+        if offsets.is_empty() {
+            return Err("SharedDdc needs at least one channel".to_string());
+        }
+        if output_rate < 2.0 * passband_hz {
+            return Err(format!(
+                "output rate {output_rate} cannot carry a ±{passband_hz} Hz passband"
+            ));
+        }
+        // The coarse stage must pass every channel's band FLAT — the outermost
+        // channel edge is `max_off + passband`. A windowed-sinc lowpass rolls
+        // off before its cutoff, so the cutoff is placed beyond that edge with
+        // margin; the per-channel sharp stage provides the real selectivity.
+        let max_off = offsets.iter().fold(0.0f64, |m, &o| m.max(o.abs()));
+        let edge = max_off + passband_hz;
+        if input_rate < 2.0 * edge {
+            return Err(format!(
+                "capture {input_rate} S/s too narrow for channels spanning ±{edge} Hz"
+            ));
+        }
+
+        // Pick the coarse decimation: keep the intermediate rate above 2·edge
+        // so (a) no channel aliases and (b) a little room remains above the
+        // flat passband for the coarse filter's transition band. A 1.2 margin
+        // (inter ≥ 2.4·edge) is enough — the per-channel sharp stage provides
+        // the real selectivity, so the coarse transition can be wide/cheap.
+        // The bigger the decimation here, the cheaper every channel's finish.
+        // Never decimate below the output rate (the sharp stage does the rest).
+        let max_decim = (input_rate / (2.4 * edge)).floor().max(1.0);
+        let mut coarse_decim = (input_rate / output_rate).floor().min(max_decim) as usize;
+        coarse_decim = coarse_decim.max(1);
+        let inter_rate = input_rate / coarse_decim as f64;
+
+        // Coarse cutoff: halfway between the outermost channel edge and the
+        // Nyquist fold of the intermediate rate, so `edge` sits inside the
+        // flat passband and aliasing is still rejected by the fold.
+        let coarse_cutoff = 0.5 * (edge + inter_rate / 2.0);
+
+        // Build the coarse anti-alias stage(s) — split into two when the
+        // decimation is large (cheap coarse + sharp final), mirroring `Ddc`.
+        let coarse = build_decimation_stages(input_rate, coarse_decim, coarse_cutoff, edge)?;
+
+        // Each channel: mix to baseband at the intermediate rate, sharp-filter
+        // to the narrow passband, then resample any leftover fraction so the
+        // output lands exactly on `output_rate`.
+        let mut channels = Vec::with_capacity(offsets.len());
+        for &off in offsets {
+            let fine_decim = (inter_rate / output_rate).floor().max(1.0) as usize;
+            let post_rate = inter_rate / fine_decim as f64;
+            // Sharp lowpass realizing the narrow passband at the inter rate.
+            let trans = post_rate - 2.0 * passband_hz;
+            if trans <= 0.0 {
+                return Err(format!(
+                    "intermediate rate {inter_rate} too low for ±{passband_hz} Hz channel"
+                ));
+            }
+            let aa = ((TAPS_PER_TRANSITION * inter_rate / trans).ceil() as usize | 1).max(9);
+            let sharp =
+                ((TAPS_PER_TRANSITION * inter_rate / passband_hz).ceil() as usize | 1).max(9);
+            let ntaps = aa.max(sharp);
+            if ntaps > MAX_TAPS {
+                return Err(format!(
+                    "channel finish needs {ntaps} taps from {inter_rate} S/s; \
+                     choose a friendlier sample rate"
+                ));
+            }
+            let fine = Fir::with_decimation(
+                lowpass_taps(passband_hz / inter_rate, ntaps),
+                fine_decim,
+            );
+            let resampler = if (post_rate - output_rate).abs() > 1e-6 {
+                Some(Resampler::new(post_rate, output_rate))
+            } else {
+                None
+            };
+            channels.push(Channel {
+                nco: Nco::new(off, inter_rate),
+                fine,
+                resampler,
+                mixed: Vec::new(),
+                decimated: Vec::new(),
+            });
+        }
+
+        Ok(Self {
+            coarse,
+            inter: Vec::new(),
+            coarse_inter: Vec::new(),
+            channels,
+        })
+    }
+
+    /// Number of channels.
+    pub fn num_channels(&self) -> usize {
+        self.channels.len()
+    }
+
+    /// Downconvert a wideband block into all channels. `out` must hold one
+    /// vector per channel; each is cleared and filled with that channel's
+    /// output samples.
+    pub fn process(&mut self, input: &[IqSample], out: &mut [Vec<IqSample>]) {
+        assert_eq!(out.len(), self.channels.len(), "out must have one vec per channel");
+
+        // --- Shared coarse decimation, run ONCE over the full-rate stream. ---
+        self.inter.clear();
+        match self.coarse.len() {
+            1 => self.coarse[0].process(input, &mut self.inter),
+            _ => {
+                self.coarse_inter.clear();
+                let (first, rest) = self.coarse.split_at_mut(1);
+                first[0].process(input, &mut self.coarse_inter);
+                rest[0].process(&self.coarse_inter, &mut self.inter);
+            }
+        }
+
+        // --- Cheap per-channel finish at the intermediate rate. ---
+        for (ch, out_buf) in self.channels.iter_mut().zip(out.iter_mut()) {
+            out_buf.clear();
+            ch.mixed.clear();
+            ch.mixed.extend_from_slice(&self.inter);
+            ch.nco.mix(&mut ch.mixed);
+            if ch.resampler.is_some() {
+                ch.decimated.clear();
+                ch.fine.process(&ch.mixed, &mut ch.decimated);
+                if let Some(rs) = &mut ch.resampler {
+                    rs.process(&ch.decimated, out_buf);
+                }
+            } else {
+                ch.fine.process(&ch.mixed, out_buf);
+            }
+        }
+    }
+}
+
+/// Build the shared coarse decimating lowpass, split into a cheap coarse stage
+/// and a sharp final stage when the decimation is large (mirrors `Ddc::new`).
+///
+/// * `cutoff_hz` — the lowpass cutoff (placed beyond the outermost channel
+///   edge so every channel is in the flat passband).
+/// * `protect_hz` — the band that must NOT be aliased into (the channel edge);
+///   the stop band starts where energy would fold back below it.
+fn build_decimation_stages(
+    input_rate: f64,
+    decim: usize,
+    cutoff_hz: f64,
+    protect_hz: f64,
+) -> Result<Vec<Fir>, String> {
+    let factors: Vec<usize> = if decim <= 16 {
+        vec![decim]
+    } else {
+        match (2..=16).rev().find(|d| decim % d == 0) {
+            Some(d2) => vec![decim / d2, d2],
+            None => vec![decim],
+        }
+    };
+
+    let mut stages = Vec::new();
+    let mut rate = input_rate;
+    for &d in &factors {
+        let out = rate / d as f64;
+        // Aliases of the kept band fold around `out`; keep them out of the
+        // protected band: transition spans cutoff → (out − protect).
+        let transition = (out - protect_hz) - cutoff_hz;
+        if transition <= 0.0 {
+            return Err(format!(
+                "stage output rate {out} too low for a {cutoff_hz} Hz cutoff \
+                 protecting ±{protect_hz} Hz"
+            ));
+        }
+        let ntaps = ((TAPS_PER_TRANSITION * rate / transition).ceil() as usize | 1).max(9);
+        if ntaps > MAX_TAPS {
+            return Err(format!(
+                "decimation {decim} from {input_rate} S/s needs {ntaps} taps; \
+                 choose a friendlier sample rate"
+            ));
+        }
+        stages.push(Fir::with_decimation(lowpass_taps(cutoff_hz / rate, ntaps), d));
+        rate = out;
+    }
+    Ok(stages)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ddc::Ddc;
+    use std::f64::consts::TAU;
+
+    fn tone(freq: f64, fs: f64, n: usize) -> Vec<IqSample> {
+        (0..n)
+            .map(|i| {
+                let ph = TAU * freq * i as f64 / fs;
+                IqSample::new(ph.cos() as f32, ph.sin() as f32)
+            })
+            .collect()
+    }
+
+    #[test]
+    fn each_channel_recovers_its_own_tone() {
+        let fs = 2_400_000.0;
+        let out_rate = 24_000.0;
+        let offsets = [50_000.0, -75_000.0, 150_000.0];
+        let mut sd = SharedDdc::new(fs, out_rate, &offsets, 5_000.0).unwrap();
+
+        // One in-channel tone per channel (offset + 1 kHz), summed.
+        let n = 480_000;
+        let mut input = vec![IqSample::new(0.0, 0.0); n];
+        for &off in &offsets {
+            for (i, s) in tone(off + 1_000.0, fs, n).into_iter().enumerate() {
+                input[i] += s;
+            }
+        }
+
+        let mut out: Vec<Vec<IqSample>> = vec![Vec::new(); offsets.len()];
+        sd.process(&input, &mut out);
+
+        for (k, ch) in out.iter().enumerate() {
+            let settled = &ch[ch.len() / 2..];
+            let amp = settled.iter().map(|s| s.norm()).sum::<f32>() / settled.len() as f32;
+            // Each channel sees its own 1 kHz tone near unit gain; the other
+            // channels' tones (≥50 kHz away) are rejected by the sharp stage.
+            assert!((amp - 1.0).abs() < 0.1, "channel {k} gain {amp}, expected ~1");
+        }
+    }
+
+    #[test]
+    fn rejects_adjacent_channel() {
+        let fs = 2_400_000.0;
+        let out_rate = 24_000.0;
+        let offsets = [0.0];
+        let mut sd = SharedDdc::new(fs, out_rate, &offsets, 5_000.0).unwrap();
+        // A tone 25 kHz away from the only channel must be strongly rejected.
+        let input = tone(25_000.0, fs, 480_000);
+        let mut out = vec![Vec::new()];
+        sd.process(&input, &mut out);
+        let settled = &out[0][out[0].len() / 2..];
+        let amp = settled.iter().map(|s| s.norm()).sum::<f32>() / settled.len() as f32;
+        assert!(amp < 0.05, "adjacent channel should be rejected, got {amp}");
+    }
+
+    #[test]
+    fn matches_per_channel_ddc_closely() {
+        // The shared front end must produce essentially the same channel
+        // stream as an independent Ddc — same demod sees the same samples.
+        let fs = 2_400_000.0;
+        let out_rate = 24_000.0;
+        let off = 50_000.0;
+        let input = tone(off + 800.0, fs, 240_000);
+
+        let mut sd = SharedDdc::new(fs, out_rate, &[off], 5_000.0).unwrap();
+        let mut shared = vec![Vec::new()];
+        sd.process(&input, &mut shared);
+
+        let mut ddc = Ddc::new(fs, out_rate, off, 5_000.0).unwrap();
+        let mut single = Vec::new();
+        ddc.process(&input, &mut single);
+
+        // Compare the settled tail amplitude/frequency (group delays differ,
+        // so compare statistics, not sample-for-sample).
+        let stat = |v: &[IqSample]| {
+            let s = &v[v.len() / 2..];
+            let amp = s.iter().map(|x| x.norm()).sum::<f32>() / s.len() as f32;
+            let mid = s.len() / 2;
+            let dphi = (s[mid + 1] * s[mid].conj()).arg();
+            (amp, dphi)
+        };
+        let (a0, p0) = stat(&shared[0]);
+        let (a1, p1) = stat(&single);
+        assert!((a0 - a1).abs() < 0.05, "amplitude differs: {a0} vs {a1}");
+        assert!((p0 - p1).abs() < 1e-2, "tone freq differs: {p0} vs {p1}");
+    }
+
+    #[test]
+    fn streams_in_blocks_seamlessly() {
+        // Feeding the capture in arbitrary block sizes must give the same
+        // output count as one big block (state carries across calls).
+        let fs = 2_400_000.0;
+        let out_rate = 24_000.0;
+        let input = tone(1_000.0, fs, 240_000);
+
+        let mut whole = SharedDdc::new(fs, out_rate, &[0.0], 5_000.0).unwrap();
+        let mut a = vec![Vec::new()];
+        whole.process(&input, &mut a);
+
+        let mut chunked = SharedDdc::new(fs, out_rate, &[0.0], 5_000.0).unwrap();
+        let mut total = 0usize;
+        let mut b = vec![Vec::new()];
+        for blk in input.chunks(7919) {
+            chunked.process(blk, &mut b);
+            total += b[0].len();
+        }
+        // Within a couple of samples (decimation edge effects across blocks).
+        assert!((a[0].len() as i64 - total as i64).abs() <= 4, "{} vs {total}", a[0].len());
+    }
+}

--- a/crates/xng-mode-acars/src/lib.rs
+++ b/crates/xng-mode-acars/src/lib.rs
@@ -15,7 +15,7 @@ pub mod sublabel;
 
 use chrono::Utc;
 use num_complex::Complex;
-use xng_dsp::{Ddc, SharedDdc};
+use xng_dsp::{ChannelizedDdc, Ddc, SharedDdc};
 use xng_types::{
     AcarsCore, DecodeQuality, Message, MessageBody, Mode, Provenance, SignalQuality,
 };
@@ -117,14 +117,39 @@ impl ChannelBack {
     }
 }
 
+/// Shared multi-channel downconverter front end. Two implementations with the
+/// same `(input_rate, output_rate, offsets, passband) -> process` contract:
+///
+/// * [`Front::Channelized`] — a polyphase channelizer ([`xng_dsp::ChannelizedDdc`]):
+///   one FFT pass produces every channel, cost independent of channel count
+///   and span. The default.
+/// * [`Front::Shared`] — a shared decimation ([`xng_dsp::SharedDdc`]): one
+///   full-rate decimation feeds cheap per-channel finishes. The fallback; its
+///   win shrinks as the channels spread across the band.
+//
+// Reverting the channelizer commit removes the `Channelized` arm and the
+// `Front` indirection, leaving the decoder on `SharedDdc` directly.
+enum Front {
+    Channelized(ChannelizedDdc),
+    Shared(SharedDdc),
+}
+
+impl Front {
+    fn process(&mut self, input: &[Complex<f32>], out: &mut [Vec<Complex<f32>>]) {
+        match self {
+            Self::Channelized(c) => c.process(input, out),
+            Self::Shared(s) => s.process(input, out),
+        }
+    }
+}
+
 /// Decodes SEVERAL ACARS channels out of one wideband capture with a single
-/// shared downconverter front end ([`xng_dsp::SharedDdc`]): the expensive
-/// full-rate decimation runs once for all channels, then each channel does a
-/// cheap low-rate finish + the usual MSK demod / deframe. Equivalent output
-/// to N independent [`AcarsChannelDecoder`]s, far less CPU when the channel
-/// count is high (the acarsdec-replacement scenario).
+/// shared downconverter front end: the wideband-rate work is done once for all
+/// channels, then each channel does the usual MSK demod / deframe. Equivalent
+/// output to N independent [`AcarsChannelDecoder`]s, far less CPU when the
+/// channel count is high (the acarsdec-replacement scenario).
 pub struct AcarsMultiChannelDecoder {
-    ddc: SharedDdc,
+    front: Front,
     backs: Vec<ChannelBack>,
     channel_bufs: Vec<Vec<Complex<f32>>>,
 }
@@ -133,11 +158,31 @@ impl AcarsMultiChannelDecoder {
     /// `input_rate` is the wideband capture rate; `offsets` are each channel's
     /// center relative to the capture center (Hz). Requires `input_rate` ≥ the
     /// 24 kHz channel rate and wide enough to span every channel.
+    ///
+    /// Uses the polyphase channelizer front end (default), falling back to the
+    /// shared-decimation front end if the channelizer cannot be built for this
+    /// rate/offset set.
     pub fn new(input_rate: f64, offsets: &[f64]) -> Result<Self, String> {
-        let ddc = SharedDdc::new(input_rate, CHANNEL_RATE, offsets, CHANNEL_PASSBAND_HZ)?;
+        let front = match ChannelizedDdc::new(input_rate, CHANNEL_RATE, offsets, CHANNEL_PASSBAND_HZ)
+        {
+            Ok(c) => Front::Channelized(c),
+            Err(_) => {
+                Front::Shared(SharedDdc::new(input_rate, CHANNEL_RATE, offsets, CHANNEL_PASSBAND_HZ)?)
+            }
+        };
         let backs = offsets.iter().map(|_| ChannelBack::new()).collect();
         let channel_bufs = offsets.iter().map(|_| Vec::new()).collect();
-        Ok(Self { ddc, backs, channel_bufs })
+        Ok(Self { front, backs, channel_bufs })
+    }
+
+    /// Build with the shared-decimation front end explicitly (the fallback
+    /// path; used to compare front ends and as the revert target).
+    pub fn new_shared(input_rate: f64, offsets: &[f64]) -> Result<Self, String> {
+        let front =
+            Front::Shared(SharedDdc::new(input_rate, CHANNEL_RATE, offsets, CHANNEL_PASSBAND_HZ)?);
+        let backs = offsets.iter().map(|_| ChannelBack::new()).collect();
+        let channel_bufs = offsets.iter().map(|_| Vec::new()).collect();
+        Ok(Self { front, backs, channel_bufs })
     }
 
     /// Number of channels.
@@ -148,7 +193,7 @@ impl AcarsMultiChannelDecoder {
     /// Feed wideband IQ; returns the completed frames for channel `i` as
     /// `(i, frames)` for every channel that produced any.
     pub fn process(&mut self, input: &[Complex<f32>]) -> Vec<(usize, Vec<frame::AcarsFrame>)> {
-        self.ddc.process(input, &mut self.channel_bufs);
+        self.front.process(input, &mut self.channel_bufs);
         let mut out = Vec::new();
         for (i, (back, buf)) in self.backs.iter_mut().zip(self.channel_bufs.iter()).enumerate() {
             let frames = back.process(buf);

--- a/crates/xng-mode-acars/src/lib.rs
+++ b/crates/xng-mode-acars/src/lib.rs
@@ -166,9 +166,17 @@ impl AcarsMultiChannelDecoder {
         let front = match ChannelizedDdc::new(input_rate, CHANNEL_RATE, offsets, CHANNEL_PASSBAND_HZ)
         {
             Ok(c) => Front::Channelized(c),
-            Err(_) => {
-                Front::Shared(SharedDdc::new(input_rate, CHANNEL_RATE, offsets, CHANNEL_PASSBAND_HZ)?)
-            }
+            // On double failure report BOTH errors so an unusual capture
+            // config shows why the default channelizer was rejected too.
+            Err(chan_err) => Front::Shared(
+                SharedDdc::new(input_rate, CHANNEL_RATE, offsets, CHANNEL_PASSBAND_HZ).map_err(
+                    |shared_err| {
+                        format!(
+                            "channelizer rejected ({chan_err}); shared-decim also failed ({shared_err})"
+                        )
+                    },
+                )?,
+            ),
         };
         let backs = offsets.iter().map(|_| ChannelBack::new()).collect();
         let channel_bufs = offsets.iter().map(|_| Vec::new()).collect();

--- a/crates/xng-mode-acars/src/lib.rs
+++ b/crates/xng-mode-acars/src/lib.rs
@@ -15,7 +15,7 @@ pub mod sublabel;
 
 use chrono::Utc;
 use num_complex::Complex;
-use xng_dsp::Ddc;
+use xng_dsp::{Ddc, SharedDdc};
 use xng_types::{
     AcarsCore, DecodeQuality, Message, MessageBody, Mode, Provenance, SignalQuality,
 };
@@ -83,6 +83,90 @@ impl AcarsChannelDecoder {
     /// Channel noise-floor estimate in dBFS (envelope power over silence).
     pub fn noise_dbfs(&self) -> f32 {
         self.demod.noise_dbfs()
+    }
+}
+
+/// Per-channel demod + deframe back end (the part downstream of the DDC),
+/// shared by both the single-channel and multi-channel decoders.
+struct ChannelBack {
+    demod: demod::MskDemod,
+    deframer: frame::Deframer,
+    bit_buf: Vec<u8>,
+}
+
+impl ChannelBack {
+    fn new() -> Self {
+        Self {
+            demod: demod::MskDemod::new(),
+            deframer: frame::Deframer::new(),
+            bit_buf: Vec::new(),
+        }
+    }
+
+    /// Feed already-downconverted 24 kHz channel IQ; return completed frames.
+    fn process(&mut self, channel: &[Complex<f32>]) -> Vec<frame::AcarsFrame> {
+        self.bit_buf.clear();
+        self.demod.process(channel, &mut self.bit_buf);
+        let mut frames = Vec::new();
+        for &bit in &self.bit_buf {
+            if let Some(f) = self.deframer.push_bit(bit) {
+                frames.push(f);
+            }
+        }
+        frames
+    }
+}
+
+/// Decodes SEVERAL ACARS channels out of one wideband capture with a single
+/// shared downconverter front end ([`xng_dsp::SharedDdc`]): the expensive
+/// full-rate decimation runs once for all channels, then each channel does a
+/// cheap low-rate finish + the usual MSK demod / deframe. Equivalent output
+/// to N independent [`AcarsChannelDecoder`]s, far less CPU when the channel
+/// count is high (the acarsdec-replacement scenario).
+pub struct AcarsMultiChannelDecoder {
+    ddc: SharedDdc,
+    backs: Vec<ChannelBack>,
+    channel_bufs: Vec<Vec<Complex<f32>>>,
+}
+
+impl AcarsMultiChannelDecoder {
+    /// `input_rate` is the wideband capture rate; `offsets` are each channel's
+    /// center relative to the capture center (Hz). Requires `input_rate` ≥ the
+    /// 24 kHz channel rate and wide enough to span every channel.
+    pub fn new(input_rate: f64, offsets: &[f64]) -> Result<Self, String> {
+        let ddc = SharedDdc::new(input_rate, CHANNEL_RATE, offsets, CHANNEL_PASSBAND_HZ)?;
+        let backs = offsets.iter().map(|_| ChannelBack::new()).collect();
+        let channel_bufs = offsets.iter().map(|_| Vec::new()).collect();
+        Ok(Self { ddc, backs, channel_bufs })
+    }
+
+    /// Number of channels.
+    pub fn num_channels(&self) -> usize {
+        self.backs.len()
+    }
+
+    /// Feed wideband IQ; returns the completed frames for channel `i` as
+    /// `(i, frames)` for every channel that produced any.
+    pub fn process(&mut self, input: &[Complex<f32>]) -> Vec<(usize, Vec<frame::AcarsFrame>)> {
+        self.ddc.process(input, &mut self.channel_bufs);
+        let mut out = Vec::new();
+        for (i, (back, buf)) in self.backs.iter_mut().zip(self.channel_bufs.iter()).enumerate() {
+            let frames = back.process(buf);
+            if !frames.is_empty() {
+                out.push((i, frames));
+            }
+        }
+        out
+    }
+
+    /// Smoothed envelope level (dBFS) for channel `i`.
+    pub fn level_dbfs(&self, i: usize) -> f32 {
+        self.backs[i].demod.level_dbfs()
+    }
+
+    /// Channel noise-floor estimate (dBFS) for channel `i`.
+    pub fn noise_dbfs(&self, i: usize) -> f32 {
+        self.backs[i].demod.noise_dbfs()
     }
 }
 

--- a/crates/xng-mode-acars/tests/end_to_end.rs
+++ b/crates/xng-mode-acars/tests/end_to_end.rs
@@ -2,7 +2,7 @@
 
 use num_complex::Complex;
 use xng_mode_acars::modulate::{burst_iq, FrameSpec};
-use xng_mode_acars::AcarsChannelDecoder;
+use xng_mode_acars::{AcarsChannelDecoder, AcarsMultiChannelDecoder};
 use xng_types::{MessageBody, Provenance};
 
 fn downlink<'a>(text: &'a str, flight: &'a str) -> FrameSpec<'a> {
@@ -258,4 +258,60 @@ fn decodes_two_channels_from_wideband_capture() {
     assert_eq!(frames_b[0].text, "CHANNEL B PAYLOAD");
     assert_eq!(frames_a[0].flight.as_deref(), Some("XG0001"));
     assert_eq!(frames_b[0].flight.as_deref(), Some("XG0002"));
+}
+
+#[test]
+fn shared_front_end_decodes_many_channels() {
+    // The multi-channel decoder (one shared SharedDdc front end) must decode
+    // the same bursts the per-channel decoders do — the CPU optimization is
+    // output-equivalent. Three simultaneous channels at different offsets,
+    // one 2.4 MS/s capture.
+    let fs = 2_400_000.0;
+    let offsets = [50_000.0, -75_000.0, 150_000.0];
+    let specs = [
+        downlink("CHANNEL ONE PAYLOAD", "XG0001"),
+        downlink("CHANNEL TWO PAYLOAD", "XG0002"),
+        downlink("CHANNEL TRE PAYLOAD", "XG0003"),
+    ];
+    let bursts: Vec<Vec<Complex<f32>>> = specs
+        .iter()
+        .zip(offsets.iter())
+        .map(|(s, &off)| burst_iq(s, fs, off, 0.4))
+        .collect();
+
+    let delays = [0usize, 30_000, 60_000];
+    let total = bursts
+        .iter()
+        .zip(delays.iter())
+        .map(|(b, &d)| b.len() + d)
+        .max()
+        .unwrap()
+        + 10_000;
+    let mut iq = vec![Complex::new(0.0f32, 0.0f32); total];
+    for (b, &d) in bursts.iter().zip(delays.iter()) {
+        for (i, s) in b.iter().enumerate() {
+            iq[i + d] += s;
+        }
+    }
+    let mut noise = Noise(0x0bad_f00d_dead_beef);
+    for s in &mut iq {
+        *s += Complex::new(noise.next() * 0.01, noise.next() * 0.01);
+    }
+
+    let mut dec = AcarsMultiChannelDecoder::new(fs, &offsets).unwrap();
+    assert_eq!(dec.num_channels(), 3);
+    // Collect frames per channel index across streamed blocks.
+    let mut got: Vec<Vec<String>> = vec![Vec::new(); offsets.len()];
+    for chunk in iq.chunks(65_536) {
+        for (i, frames) in dec.process(chunk) {
+            for f in frames {
+                assert!(f.crc_ok, "channel {i} frame CRC failed: {f:?}");
+                got[i].push(f.text.clone());
+            }
+        }
+    }
+
+    assert_eq!(got[0], ["CHANNEL ONE PAYLOAD"], "channel 0");
+    assert_eq!(got[1], ["CHANNEL TWO PAYLOAD"], "channel 1");
+    assert_eq!(got[2], ["CHANNEL TRE PAYLOAD"], "channel 2");
 }

--- a/crates/xng-mode-acars/tests/end_to_end.rs
+++ b/crates/xng-mode-acars/tests/end_to_end.rs
@@ -315,3 +315,55 @@ fn shared_front_end_decodes_many_channels() {
     assert_eq!(got[1], ["CHANNEL TWO PAYLOAD"], "channel 1");
     assert_eq!(got[2], ["CHANNEL TRE PAYLOAD"], "channel 2");
 }
+
+#[test]
+fn both_front_ends_decode_equivalently() {
+    // The channelizer (default) and the shared-decimation fallback must both
+    // decode the same raster channels — the front end is a CPU choice, not a
+    // correctness one. Offsets are on the 25 kHz airband raster.
+    let fs = 2_400_000.0;
+    let offsets = [50_000.0, -75_000.0, 150_000.0];
+    let specs = [
+        downlink("FRONT END ONE", "XG0001"),
+        downlink("FRONT END TWO", "XG0002"),
+        downlink("FRONT END TRE", "XG0003"),
+    ];
+    let bursts: Vec<Vec<Complex<f32>>> = specs
+        .iter()
+        .zip(offsets.iter())
+        .map(|(s, &off)| burst_iq(s, fs, off, 0.4))
+        .collect();
+    let delays = [0usize, 30_000, 60_000];
+    let total =
+        bursts.iter().zip(delays.iter()).map(|(b, &d)| b.len() + d).max().unwrap() + 10_000;
+    let mut iq = vec![Complex::new(0.0f32, 0.0f32); total];
+    for (b, &d) in bursts.iter().zip(delays.iter()) {
+        for (i, s) in b.iter().enumerate() {
+            iq[i + d] += s;
+        }
+    }
+    let mut noise = Noise(0xfeed_face_cafe_d00d);
+    for s in &mut iq {
+        *s += Complex::new(noise.next() * 0.01, noise.next() * 0.01);
+    }
+
+    let decode = |mut dec: AcarsMultiChannelDecoder| -> Vec<Vec<String>> {
+        let mut got: Vec<Vec<String>> = vec![Vec::new(); offsets.len()];
+        for chunk in iq.chunks(65_536) {
+            for (i, frames) in dec.process(chunk) {
+                for f in frames {
+                    assert!(f.crc_ok);
+                    got[i].push(f.text.clone());
+                }
+            }
+        }
+        got
+    };
+
+    let channelized = decode(AcarsMultiChannelDecoder::new(fs, &offsets).unwrap());
+    let shared = decode(AcarsMultiChannelDecoder::new_shared(fs, &offsets).unwrap());
+    assert_eq!(channelized, shared, "front ends must decode identically");
+    assert_eq!(channelized[0], ["FRONT END ONE"]);
+    assert_eq!(channelized[1], ["FRONT END TWO"]);
+    assert_eq!(channelized[2], ["FRONT END TRE"]);
+}

--- a/docs/notes/ACARS.md
+++ b/docs/notes/ACARS.md
@@ -25,6 +25,39 @@ capture drives many channels (the acarsdec-replacement scenario; the
 end-to-end test decodes two simultaneous bursts at ±50/75 kHz from one
 2.4 MS/s stream).
 
+### Shared multi-channel front end (CPU)
+
+A per-channel `Ddc` runs a full-rate anti-alias decimation for **every**
+channel, so N channels do N full-rate convolutions over the same wideband
+stream — the dominant cost (~17× the bit demod, linear in channel count).
+When a session has ≥2 ACARS channels, `runtime.rs::collapse_shared_acars`
+replaces the N independent `AcarsChannelDecoder`s with one
+`AcarsMultiChannelDecoder` that does the wideband-rate work **once** for all
+channels, then runs the usual per-channel `MskDemod`/`Deframer`. Output is
+identical (a `cargo test` asserts both front ends decode the same frames);
+it is purely a CPU optimization.
+
+Two interchangeable front ends (same `(input_rate, output_rate, offsets,
+passband)` contract), selected in `AcarsMultiChannelDecoder::new`:
+
+- **`xng_dsp::ChannelizedDdc`** (default) — a polyphase channelizer: one
+  shared FFT pass produces every channel at once, so cost is **independent
+  of channel count and of how far apart the channels sit**. VHF airband
+  channels are all on a 25 kHz raster, so the bin grid `fs/M` is chosen to
+  land every requested channel on a bin center (no scalloping); a small
+  residual NCO + a gentle resampler land the exact 24 kHz channel rate.
+- **`xng_dsp::SharedDdc`** (fallback, `new_shared`) — one shared full-rate
+  decimation feeds cheap per-channel finishes. Its win shrinks as channels
+  spread across the band (the coarse stage can only decimate as far as the
+  widest channel allows), so the channelizer is preferred; `SharedDdc` is
+  the fallback when the channelizer cannot be built for a rate/offset set.
+
+Both live in `xng-dsp` and are general-purpose: they are intended to be
+adopted by the other narrowband multi-channel modes (VDL2, AIS, Aero,
+STD-C, which all use the same per-channel offset DDC) after the ACARS path
+is validated on live RF. See `bench/cpu.sh` for the per-channel-count
+×-realtime numbers.
+
 ## PHY / demod (`demod.rs`)
 
 ACARS is MSK at **2400 bd** carried as **AM** sidebands; tones 1200 Hz and

--- a/docs/notes/BENCHMARKS.md
+++ b/docs/notes/BENCHMARKS.md
@@ -253,6 +253,31 @@ traceback-matrix Viterbi (no O(n²) path clones), stride-2 template
 hunting with low-metric span skipping, and the `--demod-effort` knob
 (file decode = max, SDR commands = live).
 
+### ACARS shared multi-channel front end
+
+ACARS runs many narrowband channels from one wideband capture, so the
+per-channel downconverter front end (not the bit demod, which is ~17×
+cheaper) dominates and scales linearly with channel count. A shared front
+end downconverts all channels from one pass; the default is a polyphase
+channelizer whose cost is independent of channel count and channel spacing.
+
+×-realtime on an 8-channel synthetic 2.4 MS/s capture (`bench/cpu.sh`,
+32-core x86 dev box — *not* the M-series machine above, so not directly
+comparable to that table), decoding the front end three ways:
+
+| front end | 8 ch, tight cluster | 16 ch, wide span |
+|---|---|---|
+| per-channel DDC (old) | 3.7× | 1.9× |
+| shared decimation (`SharedDdc`) | 7.7× | 2.5× |
+| polyphase channelizer (`ChannelizedDdc`, default) | 27× | 18× |
+
+The channelizer is span-independent (the shared-decimation win shrinks as
+channels spread, because its coarse stage can only decimate as far as the
+widest channel allows). Both front ends produce byte-identical decodes (a
+`cargo test` asserts it); the choice is purely CPU. The same `xng-dsp`
+front ends are intended for VDL2/AIS/Aero/STD-C next (all use the same
+per-channel offset DDC today).
+
 ## Live-capture authenticity: phantom frames and ICAO confirmation
 
 Dense benchmark captures hide a defect that quiet live RF exposes: with

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -9,7 +9,7 @@ use num_complex::Complex;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
-use xng_mode_acars::AcarsChannelDecoder;
+use xng_mode_acars::{AcarsChannelDecoder, AcarsMultiChannelDecoder};
 use xng_mode_adsb::AdsbDecoder;
 use xng_mode_aero::{AeroBurstDecoder, AeroChannelDecoder};
 use xng_mode_ais::AisChannelDecoder;
@@ -328,6 +328,20 @@ impl LiveState {
 /// One mode-specific per-channel decoder.
 pub(crate) enum ModeChannel {
     Acars(AcarsChannelDecoder),
+    /// Several ACARS channels sharing one downconverter front end (the CPU
+    /// optimization). Carries the per-channel frequencies so each decoded
+    /// frame is tagged with the right channel. Unlike the single-channel
+    /// variants this one spans MANY channels, so it is special-cased in the
+    /// decode loop (see `process_shared`).
+    //
+    // TODO(perf): the decode loop currently assumes one (freq, ModeChannel)
+    // per channel and tags every message from a ModeChannel with one
+    // Provenance. This shared variant is special-cased in `decode_loop` to
+    // emit its own per-channel-tagged messages. When the shared front end is
+    // rolled out to vdl2/ais/aero/stdc (all use the same per-channel offset
+    // DDC), generalize the loop to natively drive multi-output decoders
+    // instead of special-casing ACARS here.
+    AcarsShared { dec: AcarsMultiChannelDecoder, freqs: Vec<u64> },
     Ais(AisChannelDecoder),
     Adsb(AdsbDecoder),
     Vdl2(Vdl2ChannelDecoder),
@@ -448,7 +462,7 @@ impl ModeChannel {
 
     fn channel_rate(&self) -> f64 {
         match self {
-            Self::Acars(_) => xng_mode_acars::CHANNEL_RATE,
+            Self::Acars(_) | Self::AcarsShared { .. } => xng_mode_acars::CHANNEL_RATE,
             Self::Ais(_) => xng_mode_ais::CHANNEL_RATE,
             Self::Vdl2(_) => xng_mode_vdl2::CHANNEL_RATE,
             Self::Aero(_) | Self::AeroBurst(_) => xng_mode_aero::CHANNEL_RATE,
@@ -475,6 +489,12 @@ impl ModeChannel {
     fn level(&self) -> f32 {
         match self {
             Self::Acars(d) => d.level_dbfs(),
+            // Shared ACARS is driven via `process_shared`; this scalar level
+            // accessor reports channel 0 (used only for single-channel
+            // displays, which the shared path does not take).
+            Self::AcarsShared { dec, .. } => {
+                if dec.num_channels() > 0 { dec.level_dbfs(0) } else { f32::NEG_INFINITY }
+            }
             Self::Ais(d) => d.level_dbfs(),
             Self::Adsb(d) => d.level_dbfs(),
             Self::Vdl2(d) => d.level_dbfs(),
@@ -503,6 +523,9 @@ impl ModeChannel {
     /// Returns (messages, frames_seen, frames_crc_ok).
     fn process(&mut self, iq: &[Complex<f32>], freq: u64, prov: &Provenance) -> (Vec<Message>, u64, u64) {
         match self {
+            // Shared ACARS spans many channels and cannot be tagged with one
+            // freq/provenance; the decode loop drives it via `process_shared`.
+            Self::AcarsShared { .. } => (Vec::new(), 0, 0),
             Self::Acars(dec) => {
                 let frames = dec.process(iq);
                 let seen = frames.len() as u64;
@@ -754,6 +777,61 @@ impl ModeChannel {
             }
         }
     }
+
+    /// Decode a capture chunk for a SHARED multi-channel decoder, producing one
+    /// result per channel that actually decoded a frame. Each result is tagged
+    /// with its own channel index, frequency, level, and provenance — the
+    /// per-channel work the decode loop does for single-channel decoders, done
+    /// here because one shared decoder spans many channels.
+    ///
+    /// Returns `(channel_index, freq, level, msgs, seen, ok)` per channel.
+    /// Only `Self::AcarsShared` produces output; other variants return empty.
+    fn process_shared(
+        &mut self,
+        iq: &[Complex<f32>],
+        base_prov: &SharedProvenance,
+    ) -> Vec<(usize, u64, f32, Vec<Message>, u64, u64)> {
+        let Self::AcarsShared { dec, freqs } = self else {
+            return Vec::new();
+        };
+        let mut out = Vec::new();
+        for (i, frames) in dec.process(iq) {
+            let freq = freqs[i];
+            let (level, noise) = (dec.level_dbfs(i), dec.noise_dbfs(i));
+            let prov = base_prov.for_channel(i, freq, xng_mode_acars::CHANNEL_RATE);
+            let seen = frames.len() as u64;
+            let ok = frames.iter().filter(|f| f.crc_ok).count() as u64;
+            let msgs: Vec<Message> = frames
+                .iter()
+                .map(|f| xng_mode_acars::to_message(f, freq, level, noise, prov.clone()))
+                .collect();
+            out.push((i, freq, level, msgs, seen, ok));
+        }
+        out
+    }
+}
+
+/// The provenance fields common to every channel of a session; the per-channel
+/// `ChannelInfo` is filled in per frame for shared decoders.
+pub(crate) struct SharedProvenance {
+    station: StationIdentity,
+    app: AppInfo,
+    sdr: Option<SdrInfo>,
+}
+
+impl SharedProvenance {
+    fn for_channel(&self, index: usize, freq: u64, channel_rate: f64) -> Provenance {
+        Provenance {
+            station: self.station.clone(),
+            app: self.app.clone(),
+            sdr: self.sdr.clone(),
+            channel: Some(ChannelInfo {
+                index: index as u32,
+                frequency_hz: freq,
+                sample_rate: channel_rate,
+            }),
+        }
+    }
 }
 
 /// Spawn the configured output sinks on the current tokio runtime.
@@ -942,10 +1020,12 @@ pub fn run_session(mut source: Box<dyn IqSource>, cfg: SessionConfig) -> anyhow:
         }
         decoders.push((freq, dec));
     }
+    let n_channels = decoders.len();
+    decoders = collapse_shared_acars(decoders, sample_rate, capture_center, cfg.mode);
     tracing::info!(
         "{} session: {} channel(s) from a {:.0} S/s capture centered at {:.3} MHz",
         cfg.mode,
-        decoders.len(),
+        n_channels,
         sample_rate,
         capture_center as f64 / 1e6
     );
@@ -1048,7 +1128,25 @@ pub(crate) fn decode_loop(
     let mut spectrum_fft: Option<std::sync::Arc<dyn rustfft::Fft<f32>>> = None;
     let mut chunk_count: u64 = 0;
     let mut buf = vec![Complex::new(0.0f32, 0.0f32); READ_CHUNK];
-    let mut stats: Vec<(u64, u64, u64)> = decoders.iter().map(|(f, _)| (*f, 0, 0)).collect();
+    // Per-index stats for single-channel decoders. Shared multi-channel
+    // decoders (one index spanning many channels) are excluded here and
+    // tracked per-frequency in `shared_stats` instead.
+    let mut stats: Vec<(u64, u64, u64)> = decoders
+        .iter()
+        .filter(|(_, d)| !matches!(d, ModeChannel::AcarsShared { .. }))
+        .map(|(f, _)| (*f, 0, 0))
+        .collect();
+    // Per-frequency stats for shared multi-channel decoders, seeded with every
+    // channel so even zero-frame channels appear in the summary.
+    let mut shared_stats: std::collections::BTreeMap<u64, (u64, u64)> =
+        std::collections::BTreeMap::new();
+    for (_, d) in &decoders {
+        if let ModeChannel::AcarsShared { freqs, .. } = d {
+            for &f in freqs {
+                shared_stats.insert(f, (0, 0));
+            }
+        }
+    }
     let mut consecutive_errors: u32 = 0;
     let mut dedup = DedupFilter::new();
     let mut ais_gate = AisGate::default();
@@ -1106,6 +1204,45 @@ pub(crate) fn decode_loop(
             }
         }
         for (i, (freq, dec)) in decoders.iter_mut().enumerate() {
+            // Shared multi-channel decoders (ACARS) emit per-channel results
+            // already tagged with the right freq/provenance; drive them
+            // separately so the single-channel path below stays unchanged.
+            //
+            // TODO(perf): this special-case exists because the shared front
+            // end spans many channels but the loop's stats/provenance are
+            // per-decoder-index. When the shared front end is generalized to
+            // vdl2/ais/aero/stdc, fold this into the main path (a decoder
+            // yielding per-channel (freq, msgs, …) results) rather than
+            // branching on the ACARS variant here.
+            if let ModeChannel::AcarsShared { .. } = dec {
+                let base = SharedProvenance {
+                    station: station.clone(),
+                    app: AppInfo::xng(),
+                    sdr: sdr.clone(),
+                };
+                for (_ci, freq, level, msgs, seen, ok) in dec.process_shared(&buf[..n], &base) {
+                    let entry = shared_stats.entry(freq).or_insert((0, 0));
+                    entry.0 += seen;
+                    entry.1 += ok;
+                    if let Some((state, _, _)) = &live {
+                        let fec: u64 =
+                            msgs.iter().map(|m| m.decode.fec_corrected.unwrap_or(0) as u64).sum();
+                        state.record_fec(freq, fec);
+                    }
+                    for msg in msgs {
+                        publish_msg(
+                            msg, freq, &mut dedup, reasm.as_deref_mut(), &label_filter,
+                            &ais_filter, &mut ais_gate, &live, &bus,
+                        );
+                    }
+                    if let Some((state, _, _)) = &live {
+                        let (s, o) = *entry;
+                        state.record_channel(freq, s, o, level);
+                    }
+                }
+                continue;
+            }
+
             let prov = Provenance {
                 station: station.clone(),
                 app: AppInfo::xng(),
@@ -1123,52 +1260,75 @@ pub(crate) fn decode_loop(
                 let fec: u64 = msgs.iter().map(|m| m.decode.fec_corrected.unwrap_or(0) as u64).sum();
                 state.record_fec(*freq, fec);
             }
-            for mut msg in msgs {
-                if dedup.is_duplicate(&msg) {
-                    continue;
-                }
-                if let Some((r, files)) = reasm.as_deref_mut() {
-                    apply_reassembly(&mut msg, r, files);
-                }
-                // Label Iridium ring alerts with the broadcasting satellite
-                // (no-op unless a TLE satellite map was loaded at startup).
-                crate::satmap::enrich(&mut msg);
-                // Attribute space-based APRS (145.825 / ISS digipeat) to the
-                // satellite(s) overhead (no-op unless init_aprs ran).
-                crate::satmap::enrich_aprs(&mut msg);
-                if !label_filter.allows(&msg) {
-                    continue;
-                }
-                // AIS output shaping (AIS-5h): type/MMSI filter, then rate
-                // downsample + content dedup keyed on the message time.
-                if !ais_filter.allows(&msg)
-                    || !ais_gate.pass(
-                        &msg,
-                        &ais_filter,
-                        msg.timestamp.timestamp_millis() as f64 / 1e3,
-                    )
-                {
-                    continue;
-                }
-                if let (Some((state, _, _)), xng_types::MessageBody::Acars(a)) =
-                    (&live, &msg.body)
-                {
-                    // ACARS-5.2 per-label tally — CRC-valid frames only. A
-                    // bad-CRC frame carries a garbled 2-byte label (raw 7-bit
-                    // bytes); tallying it would spawn an unbounded set of junk
-                    // `label="…"` series and blow up Prometheus cardinality.
-                    if msg.decode.crc_ok {
-                        state.record_acars_label(*freq, &a.label);
-                    }
-                }
-                bus.publish(msg);
+            for msg in msgs {
+                publish_msg(
+                    msg, *freq, &mut dedup, reasm.as_deref_mut(), &label_filter,
+                    &ais_filter, &mut ais_gate, &live, &bus,
+                );
             }
             if let Some((state, _, _)) = &live {
                 state.record_channel(stats[i].0, stats[i].1, stats[i].2, dec_level_after(dec));
             }
         }
     }
+    // Fold any shared per-channel stats into the returned summary.
+    for (freq, (seen, ok)) in shared_stats {
+        stats.push((freq, seen, ok));
+    }
     Ok(stats)
+}
+
+/// Apply the full publish pipeline to one decoded message: cross-channel
+/// dedup, multi-block reassembly, satellite enrichment, label/AIS filtering,
+/// the per-label live tally, then publish to the bus. Shared by the
+/// single-channel and shared-ACARS paths in `decode_loop`.
+#[allow(clippy::too_many_arguments)]
+// The publish pipeline genuinely needs all of this session state; threading
+// it as args keeps decode_loop's borrow checker happy without a context
+// struct (a future cleanup when the loop is generalized — see the perf TODO).
+fn publish_msg(
+    mut msg: Message,
+    freq: u64,
+    dedup: &mut DedupFilter,
+    reasm: Option<&mut (xng_acars::reasm::Reassembler, xng_acars::miam::FileReassembler)>,
+    label_filter: &LabelFilter,
+    ais_filter: &AisFilter,
+    ais_gate: &mut AisGate,
+    live: &Option<(Arc<LiveState>, u64, f64)>,
+    bus: &MessageBus,
+) {
+    if dedup.is_duplicate(&msg) {
+        return;
+    }
+    if let Some((r, files)) = reasm {
+        apply_reassembly(&mut msg, r, files);
+    }
+    // Label Iridium ring alerts with the broadcasting satellite
+    // (no-op unless a TLE satellite map was loaded at startup).
+    crate::satmap::enrich(&mut msg);
+    // Attribute space-based APRS (145.825 / ISS digipeat) to the
+    // satellite(s) overhead (no-op unless init_aprs ran).
+    crate::satmap::enrich_aprs(&mut msg);
+    if !label_filter.allows(&msg) {
+        return;
+    }
+    // AIS output shaping (AIS-5h): type/MMSI filter, then rate
+    // downsample + content dedup keyed on the message time.
+    if !ais_filter.allows(&msg)
+        || !ais_gate.pass(&msg, ais_filter, msg.timestamp.timestamp_millis() as f64 / 1e3)
+    {
+        return;
+    }
+    if let (Some((state, _, _)), xng_types::MessageBody::Acars(a)) = (live, &msg.body) {
+        // ACARS-5.2 per-label tally — CRC-valid frames only. A bad-CRC frame
+        // carries a garbled 2-byte label (raw 7-bit bytes); tallying it would
+        // spawn an unbounded set of junk `label="…"` series and blow up
+        // Prometheus cardinality.
+        if msg.decode.crc_ok {
+            state.record_acars_label(freq, &a.label);
+        }
+    }
+    bus.publish(msg);
 }
 
 /// Run several decode sessions (different modes/SDRs) in one process,
@@ -1209,10 +1369,12 @@ pub fn run_station(sessions: Vec<(Box<dyn IqSource>, SessionConfig)>) -> anyhow:
             }
             decoders.push((freq, dec));
         }
+        let n_channels = decoders.len();
+        decoders = collapse_shared_acars(decoders, sample_rate, capture_center, cfg.mode);
         tracing::info!(
             "station session: {} with {} channel(s) at {:.0} S/s centered {:.3} MHz",
             cfg.mode,
-            decoders.len(),
+            n_channels,
             sample_rate,
             capture_center as f64 / 1e6
         );
@@ -1473,7 +1635,47 @@ pub(crate) fn build_decoders(
         }
         decoders.push((freq, dec));
     }
-    Ok(decoders)
+    Ok(collapse_shared_acars(decoders, sample_rate, capture_center, cfg.mode))
+}
+
+/// When an ACARS session has more than one channel, replace the N independent
+/// per-channel `Acars` decoders with a single `AcarsShared` decoder that uses
+/// one shared downconverter front end (the CPU optimization). A single ACARS
+/// channel, or any other mode, is returned unchanged.
+///
+/// On failure to build the shared decoder (e.g. a capture too narrow to span
+/// every channel), the original per-channel decoders are kept — the shared
+/// front end is a pure optimization, never a correctness requirement.
+fn collapse_shared_acars(
+    decoders: Vec<(u64, ModeChannel)>,
+    sample_rate: f64,
+    capture_center: u64,
+    mode: Mode,
+) -> Vec<(u64, ModeChannel)> {
+    if mode != Mode::AcarsPoa || decoders.len() < 2 {
+        return decoders;
+    }
+    // Every entry is a single-channel ACARS decoder at this point.
+    if !decoders.iter().all(|(_, d)| matches!(d, ModeChannel::Acars(_))) {
+        return decoders;
+    }
+    let freqs: Vec<u64> = decoders.iter().map(|(f, _)| *f).collect();
+    let offsets: Vec<f64> = freqs.iter().map(|&f| f as f64 - capture_center as f64).collect();
+    match AcarsMultiChannelDecoder::new(sample_rate, &offsets) {
+        Ok(dec) => {
+            tracing::info!(
+                "ACARS: {} channels share one downconverter front end",
+                freqs.len()
+            );
+            // The shared entry is keyed on the first channel's freq; its own
+            // per-channel freqs live in the variant (the loop reads those).
+            vec![(freqs[0], ModeChannel::AcarsShared { dec, freqs })]
+        }
+        Err(e) => {
+            tracing::warn!("shared ACARS front end unavailable ({e}); using per-channel DDCs");
+            decoders
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -779,10 +779,11 @@ impl ModeChannel {
     }
 
     /// Decode a capture chunk for a SHARED multi-channel decoder, producing one
-    /// result per channel that actually decoded a frame. Each result is tagged
-    /// with its own channel index, frequency, level, and provenance — the
-    /// per-channel work the decode loop does for single-channel decoders, done
-    /// here because one shared decoder spans many channels.
+    /// result per channel — the per-channel work the decode loop does for
+    /// single-channel decoders, done here because one shared decoder spans many
+    /// channels. EVERY channel is returned each chunk (quiet ones with no
+    /// messages and zero counts) so the caller refreshes live level/count
+    /// metrics for all of them, matching the single-channel path.
     ///
     /// Returns `(channel_index, freq, level, msgs, seen, ok)` per channel.
     /// Only `Self::AcarsShared` produces output; other variants return empty.
@@ -794,9 +795,13 @@ impl ModeChannel {
         let Self::AcarsShared { dec, freqs } = self else {
             return Vec::new();
         };
-        let mut out = Vec::new();
-        for (i, frames) in dec.process(iq) {
-            let freq = freqs[i];
+        // dec.process returns only channels that decoded a frame; collect those
+        // by index so every channel can still be reported below.
+        let mut decoded: std::collections::HashMap<usize, Vec<xng_mode_acars::frame::AcarsFrame>> =
+            dec.process(iq).into_iter().collect();
+        let mut out = Vec::with_capacity(freqs.len());
+        for (i, &freq) in freqs.iter().enumerate() {
+            let frames = decoded.remove(&i).unwrap_or_default();
             let (level, noise) = (dec.level_dbfs(i), dec.noise_dbfs(i));
             let prov = base_prov.for_channel(i, freq, xng_mode_acars::CHANNEL_RATE);
             let seen = frames.len() as u64;


### PR DESCRIPTION
## What this does

ACARS decodes many narrowband channels from one wideband capture, but each
channel ran its **own** digital downconverter — N independent full-rate
anti-alias decimations over the same stream. That front end (not the bit
demod, which is ~17× cheaper) dominated CPU and scaled linearly with channel
count. On an underpowered 16-channel box this was ~25% CPU and produced SDR
**overrun errors** (the decoder couldn't keep up with the ring buffer, so real
samples — and real frames — were being dropped).

This PR collapses the per-channel front ends into **one shared downconverter**
for all ACARS channels, with two interchangeable implementations behind the
same interface:

- **`xng_dsp::ChannelizedDdc`** (default) — a polyphase channelizer: one shared
  FFT pass produces every channel, so cost is independent of channel count
  **and** of how far apart the channels sit.
- **`xng_dsp::SharedDdc`** (fallback) — one shared full-rate decimation feeds
  cheap per-channel finishes. Its win shrinks as channels spread across the
  band (the coarse stage can only decimate as far as the widest channel
  allows), so the channelizer is preferred; `SharedDdc` is the fallback when
  the channelizer can't be built for a rate/offset set, and the clean revert
  target for the channelizer commit.

Both produce byte-identical decodes to the old per-channel path (a `cargo test`
asserts it); the choice is purely CPU.

## Results

Live RF, 16 channels, underpowered box: **~25% → ~8% CPU**, and the **SDR
overrun errors are gone** (the front end now keeps up).

Synthetic bench (`bench/cpu.sh`, 32-core x86 dev box), front end only:

| front end | 8 ch, tight cluster | 16 ch, wide span |
|---|---|---|
| per-channel DDC (old) | 3.7× | 1.9× |
| shared decimation (`SharedDdc`) | 7.7× | 2.5× |
| polyphase channelizer (`ChannelizedDdc`, default) | 27× | 18× |

## Commits

1. `bench(acars):` add a multi-channel ACARS CPU benchmark row (`bench/cpu.sh`).
2. `perf(dsp):` add `SharedDdc` (the fallback front end).
3. `perf(acars):` drive multi-channel ACARS through one shared front end
   (`AcarsMultiChannelDecoder` + runtime wiring; defaults to `SharedDdc` at
   this commit).
4. `perf(dsp):` add `ChannelizedDdc` and make it the default; reverting **just
   this commit** falls back to the proven `SharedDdc` path (verified: ACARS
   tests stay green after the revert).

All workspace tests pass (1225, 0 failures); each commit builds + tests green
on its own.

## Where this PR falls short

**The channelizer FFT is now the dominant cost, and is the gap to the reference
decoder.** On the same hardware, acarsdec sits at ~0.6% where this lands ~8%.
The live per-channel-count breakdown shows why:

| channels | CPU (this box) |
|---|---|
| 1 | 3.8% |
| 4 | 3.2% |
| 8 | 4.3% |
| 16 | 6.1% |

There is a large **fixed floor (~3.1%)** that is the channelizer itself, and the
marginal per-channel cost is small (~0.2%/ch). The channelizer computes **all M
bins** (e.g. M=48 for the US ACARS plan) but only **uses ~16** — that wasted-bin
FFT is the bulk of the floor. acarsdec wins by doing cheap short per-channel
mix+decimate on **only** the requested channels, with no wasted-bin FFT. Closing
this is **out of scope here** (see follow-up B) — this PR is the structural win
(per-channel front end → shared front end) that unblocks it.

**Two known limitations carried as TODOs:**

- **`src/runtime.rs` `TODO(perf)` (×2):** the decode loop assumes one
  `(freq, ModeChannel)` per channel and tags every message from a
  `ModeChannel` with one `Provenance`. The shared ACARS decoder spans many
  channels, so it is **special-cased** in `decode_loop` via `process_shared`.
  This is deliberately contained; the loop should be generalized to natively
  drive multi-output decoders when other modes adopt the shared front end.
- **Marginal-frame parity not yet validated on real RF.** The CPU + overrun win
  is validated live; the channelizer's behavior on *weak/edge* frames vs the
  old per-channel DDC is not. For the exact 16-channel plan tested, M=48 lands
  the worst channel ~0.25 bin (12.5 kHz) off its bin center (the channels don't
  all sit on the 50 kHz grid relative to the capture center), which is in the
  bin's rolloff. A smarter capture center (more channels on bin centers) and/or
  per-channel residual handling would help. Tracked in follow-up A.

## Follow-up work (after this PR gets a green light)

Once this is approved, **two follow-up PRs**:

**Follow-up A — roll the shared front end out to the other narrowband modes.**
`SharedDdc` and `ChannelizedDdc` are general-purpose `xng-dsp` components. The
modes that use the same per-channel offset DDC today and would benefit
(narrowband, many channels clustered in one wideband capture):

| mode | channel rate | passband | typical use |
|---|---|---|---|
| VDL2 | 50 kHz | 8.5 kHz | ~4–7 channels @ 2.4 MS/s |
| AIS | 48 kHz | 8 kHz | 2 channels (161.975 / 162.025) |
| Aero (L-band) | 24 kHz | 2.5 kHz | multiple P/R/T channels |
| STD-C | 12 kHz | 2 kHz | 2–3 NCS carriers |

This PR also resolves the `TODO(perf)` in `src/runtime.rs` as part of that work:
generalize the decode loop so any mode can opt into a shared multi-output front
end, instead of the ACARS-only special case.

(Wideband / whole-capture modes — ADS-B, UAT, Iridium — and HF modes whose plans
span many MHz — HFDL, DSC, NAVTEX — do **not** benefit and are out of scope.)

**Follow-up B — close the channelizer FFT gap toward acarsdec.** Options to
explore: prune the channelizer to only the requested bins (sparse output / a
Goertzel-style or partial-FFT path), pick `M` and the capture center so every
requested channel lands on a bin center (kills scalloping *and* shrinks the
grid), or a hybrid that falls back to cheap per-channel mix+decimate when only a
few channels are requested. This is the path from ~8% toward acarsdec's ~0.6%.

A design/reference doc for follow-up agents is in `docs/notes/ACARS-SHARED-FRONTEND.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * ACARS can now decode multiple channels from one wideband capture, with a shared front end used automatically when possible.
  * Added support for both channelizer-based and shared-decimation decoding paths, with matching output across both modes.

* **Bug Fixes**
  * Improved multi-channel ACARS handling in runtime sessions, including correct per-channel results and statistics.
  * Benchmarking now includes an ACARS multi-channel mode for easier performance comparison.

* **Documentation**
  * Updated ACARS and benchmark notes to describe the new shared multi-channel decoding behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->